### PR TITLE
テキスト幅の余裕を2pxから10pxに増やして意図しない折り返しを修正

### DIFF
--- a/src/calcYogaLayout/measureText.ts
+++ b/src/calcYogaLayout/measureText.ts
@@ -54,8 +54,8 @@ export function measureText(
   const widthPx = lines.length ? Math.max(...lines.map((l) => l.widthPx)) : 0;
   const heightPx = lines.length * lineHeightPx;
 
-  // 端数切り上げ＋余裕分 2px を足す
-  return { widthPx: widthPx + 2, heightPx };
+  // 端数切り上げ＋余裕分 10px を足す
+  return { widthPx: widthPx + 10, heightPx };
 }
 
 function applyFontStyle(opts: MeasureOptions) {


### PR DESCRIPTION
Canvas環境での測定とPowerPointでの実際のレンダリングの差異により、
計算されたテキスト幅よりも実際に必要な幅が大きくなることがある。
特に日本語フォントでこの差が顕著に現れるため、余裕を10pxに増やすことで
意図しない折り返しやズレを防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)