### PR TITLE
ページ2にplacehold.coの画像を追加

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -340,6 +340,12 @@ const page2: POMNode = {
             text: "プロジェクトの規模や要件に応じて最適なツールを選択し、チーム全体で統一した開発環境を構築することが重要です。",
             fontPx: 16,
           },
+          {
+            type: "image",
+            src: "https://placehold.co/100x100/3B82F6/FFFFFF?text=Tools",
+            w: 100,
+            h: 100,
+          },
         ],
       },
     },


### PR DESCRIPTION
開発環境とツールページの「ツール選定のコツ」セクションに、
100x100pxのプレースホルダー画像を追加。
画像ノードの動作確認とサンプルの充実化を目的とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)