### PR TITLE
複数行テキストのレイアウトズレを修正

### DIFF
--- a/src/renderPptx/renderPptx.ts
+++ b/src/renderPptx/renderPptx.ts
@@ -88,6 +88,7 @@ export function renderPptx(pages: PositionedNode[], slidePx: SlidePx) {
             align: "left" as const,
             valign: "top" as const,
             margin: 0,
+            lineSpacingMultiple: 1.3,
           };
 
           slide.addText(node.text ?? "", opts);
@@ -198,6 +199,7 @@ export function renderPptx(pages: PositionedNode[], slidePx: SlidePx) {
               color: node.fontColor,
               align: node.alignText ?? "center",
               valign: "middle" as const,
+              lineSpacingMultiple: 1.3,
             });
           } else {
             // テキストがない場合：addShapeを使用


### PR DESCRIPTION
## Summary
- `renderPptx.ts` の `addText()` に `lineSpacingMultiple: 1.3` を追加
- 計測時（`measureText.ts`: lineHeight = 1.3）と描画時の行間設定を一致させることで、複数行テキストの高さズレを解消

## 修正箇所
- テキストノード描画（91行目）
- シェイプノード内テキスト描画（202行目）

## Test plan
- [ ] 複数行テキストを含むスライドを生成し、テキストが重ならないことを確認
- [ ] 単一行テキストのレイアウトに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)