### PR TITLE
改行文字を含むテキストの高さ計算を修正

### DIFF
--- a/src/calcYogaLayout/measureText.ts
+++ b/src/calcYogaLayout/measureText.ts
@@ -23,30 +23,41 @@ export function measureText(
 } {
   applyFontStyle(opts);
 
-  const words = splitForWrap(text);
+  // まず改行で段落に分割
+  const paragraphs = text.split("\n");
   const lines: { widthPx: number }[] = [];
 
-  let current = "";
-  let currentWidth = 0;
-
-  for (const word of words) {
-    const candidate = current ? current + word : word;
-    const w = ctx.measureText(candidate).width;
-
-    if (w <= maxWidthPx || !current) {
-      // まだ詰められる
-      current = candidate;
-      currentWidth = w;
-    } else {
-      // 折り返す
-      lines.push({ widthPx: currentWidth });
-      current = word;
-      currentWidth = ctx.measureText(word).width;
+  for (const paragraph of paragraphs) {
+    // 空の段落（連続した改行）も1行としてカウント
+    if (paragraph === "") {
+      lines.push({ widthPx: 0 });
+      continue;
     }
-  }
 
-  if (current) {
-    lines.push({ widthPx: currentWidth });
+    const words = splitForWrap(paragraph);
+
+    let current = "";
+    let currentWidth = 0;
+
+    for (const word of words) {
+      const candidate = current ? current + word : word;
+      const w = ctx.measureText(candidate).width;
+
+      if (w <= maxWidthPx || !current) {
+        // まだ詰められる
+        current = candidate;
+        currentWidth = w;
+      } else {
+        // 折り返す
+        lines.push({ widthPx: currentWidth });
+        current = word;
+        currentWidth = ctx.measureText(word).width;
+      }
+    }
+
+    if (current) {
+      lines.push({ widthPx: currentWidth });
+    }
   }
 
   const lineHeightRatio = opts.lineHeight ?? 1.3;


### PR DESCRIPTION
## Summary
- `measureText.ts` で改行文字（`\n`）を含むテキストが1行として扱われていた問題を修正
- まず `\n` で段落に分割してから、各段落を既存の折り返しロジックで処理するように変更

## 修正内容
- `measureText` 関数で `text.split("\n")` を追加
- 各段落ごとに折り返し処理を行い、行数を正しくカウント
- 空の段落（連続した改行）も1行としてカウント

## 修正前の問題
```
"• プレート：地殻と上部マントル\n• プレート境界：多くの地震"
```
このようなテキストが1行として扱われ、高さが不足していた。

## Test plan
- [ ] 改行を含むテキスト（`\n`）を含むスライドを生成し、高さが正しく計算されることを確認
- [ ] 既存の改行なしテキストのレイアウトに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)