### PR TITLE
fix: boldテキストのレイアウト計測を正確にする

### DIFF
--- a/src/calcYogaLayout/calcYogaLayout.ts
+++ b/src/calcYogaLayout/calcYogaLayout.ts
@@ -254,7 +254,7 @@ async function applyStyleToYogaNode(node: POMNode, yn: YogaNode) {
         const text = node.text;
         const fontSizePx = node.fontPx ?? 24;
         const fontFamily = "Noto Sans JP";
-        const fontWeight = "normal";
+        const fontWeight = node.bold ? "bold" : "normal";
         const lineHeight = 1.3;
 
         yn.setMeasureFunc((width, widthMode) => {
@@ -319,7 +319,7 @@ async function applyStyleToYogaNode(node: POMNode, yn: YogaNode) {
           const text = node.text;
           const fontSizePx = node.fontPx ?? 24;
           const fontFamily = "Noto Sans JP";
-          const fontWeight = "normal";
+          const fontWeight = node.bold ? "bold" : "normal";
           const lineHeight = 1.3;
 
           yn.setMeasureFunc((width, widthMode) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,6 +323,7 @@ export const shapeNodeSchema = basePOMNodeSchema.extend({
   fontPx: z.number().optional(),
   fontColor: z.string().optional(),
   alignText: z.enum(["left", "center", "right"]).optional(),
+  bold: z.boolean().optional(),
 });
 
 export const chartTypeSchema = z.enum(["bar", "line", "pie"]);


### PR DESCRIPTION
## Summary
- TextNodeとShapeNodeでboldプロパティに応じてfontWeightを設定するように修正
- ShapeNodeにboldプロパティを追加

## Changes
- `calcYogaLayout.ts`: TextNodeとShapeNodeの両方で`node.bold`に応じて`fontWeight`を`"bold"`または`"normal"`に設定
- `types.ts`: ShapeNodeスキーマに`bold: z.boolean().optional()`を追加

## Test plan
- [x] lint通過
- [x] fmt通過
- [x] typecheck通過
- [x] test通過

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)