### PR TITLE
fix: ShapeNodeのfontColorプロパティをcolorに統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ await pptx.writeFile({ fileName: "presentation.pptx" });
     color?: string;
   };
   fontPx?: number;
-  fontColor?: string;
+  color?: string;
   alignText?: "left" | "center" | "right";
 
   // 共通プロパティ

--- a/src/inputSchema.ts
+++ b/src/inputSchema.ts
@@ -84,7 +84,7 @@ export const inputShapeNodeSchema = inputBaseNodeSchema.extend({
   line: borderStyleSchema.optional(),
   shadow: shadowStyleSchema.optional(),
   fontPx: z.number().optional(),
-  fontColor: z.string().optional(),
+  color: z.string().optional(),
   alignText: z.enum(["left", "center", "right"]).optional(),
 });
 

--- a/src/renderPptx/renderPptx.ts
+++ b/src/renderPptx/renderPptx.ts
@@ -181,7 +181,7 @@ export function renderPptx(pages: PositionedNode[], slidePx: SlidePx) {
               shape: node.shapeType,
               fontSize: pxToPt(node.fontPx ?? 24),
               fontFace: "Noto Sans JP",
-              color: node.fontColor,
+              color: node.color,
               align: node.alignText ?? "center",
               valign: "middle" as const,
               lineSpacingMultiple: 1.3,

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,7 +321,7 @@ export const shapeNodeSchema = basePOMNodeSchema.extend({
   line: borderStyleSchema.optional(),
   shadow: shadowStyleSchema.optional(),
   fontPx: z.number().optional(),
-  fontColor: z.string().optional(),
+  color: z.string().optional(),
   alignText: z.enum(["left", "center", "right"]).optional(),
   bold: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary

- ShapeNode の `fontColor` プロパティを `color` に変更
- TextNode/TableCell と同じプロパティ名に統一し、API の一貫性を向上

## 変更ファイル

- `src/types.ts`: ShapeNode スキーマの `fontColor` → `color`
- `src/inputSchema.ts`: 入力スキーマの `fontColor` → `color`
- `src/renderPptx/renderPptx.ts`: 参照箇所を修正
- `README.md`: ドキュメントを更新

## Test plan

- [x] `npm run lint` 成功
- [x] `npm run fmt:check` 成功
- [x] `npm run typecheck` 成功
- [x] `npm run test:run` 成功

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)