### PR TITLE
feat(font): デフォルトフォントを游ゴシックに変更

### DIFF
--- a/src/calcYogaLayout/calcYogaLayout.ts
+++ b/src/calcYogaLayout/calcYogaLayout.ts
@@ -296,7 +296,7 @@ async function applyStyleToYogaNode(node: POMNode, yn: YogaNode) {
       {
         const text = node.text;
         const fontSizePx = node.fontPx ?? 24;
-        const fontFamily = "Noto Sans JP";
+        const fontFamily = "游ゴシック";
         const fontWeight = node.bold ? "bold" : "normal";
         const lineHeight = 1.3;
 
@@ -361,7 +361,7 @@ async function applyStyleToYogaNode(node: POMNode, yn: YogaNode) {
           // テキストがある場合、テキストサイズを測定
           const text = node.text;
           const fontSizePx = node.fontPx ?? 24;
-          const fontFamily = "Noto Sans JP";
+          const fontFamily = "游ゴシック";
           const fontWeight = node.bold ? "bold" : "normal";
           const lineHeight = 1.3;
 

--- a/src/renderPptx/renderPptx.ts
+++ b/src/renderPptx/renderPptx.ts
@@ -182,7 +182,7 @@ export function renderPptx(pages: PositionedNode[], slidePx: SlidePx) {
               ...shapeOptions,
               shape: node.shapeType,
               fontSize: pxToPt(node.fontPx ?? 24),
-              fontFace: "Noto Sans JP",
+              fontFace: "游ゴシック",
               color: node.color,
               align: node.alignText ?? "center",
               valign: "middle" as const,

--- a/src/renderPptx/textOptions.ts
+++ b/src/renderPptx/textOptions.ts
@@ -37,7 +37,7 @@ export function createBulletOptions(
 
 export function createTextOptions(node: TextNode) {
   const fontSizePx = node.fontPx ?? 24;
-  const fontFamily = node.fontFamily ?? "Noto Sans JP";
+  const fontFamily = node.fontFamily ?? "游ゴシック";
   const lineSpacingMultiple = node.lineSpacingMultiple ?? 1.3;
 
   const baseOptions = {


### PR DESCRIPTION
## Summary
- デフォルトフォントを「Noto Sans JP」から「游ゴシック」に変更
- 日本のビジネス文書で標準的に使用されるフォントに統一

## 変更箇所
- `src/calcYogaLayout/calcYogaLayout.ts`: テキスト測定時のフォント（2箇所）
- `src/renderPptx/textOptions.ts`: TextNode 描画時のデフォルトフォント
- `src/renderPptx/renderPptx.ts`: ShapeNode 内テキストのフォント

## Test plan
- [x] typecheck 通過
- [x] lint 通過
- [x] test 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)