### PR TITLE
feat: リモート画像の埋め込みをサポート

### DIFF
--- a/src/calcYogaLayout/measureImage.ts
+++ b/src/calcYogaLayout/measureImage.ts
@@ -7,6 +7,20 @@ import * as fs from "fs";
 const imageSizeCache = new Map<string, { widthPx: number; heightPx: number }>();
 
 /**
+ * 画像データのキャッシュ（Base64形式、リモート画像用）
+ */
+const imageDataCache = new Map<string, string>();
+
+/**
+ * キャッシュされた画像データ（Base64）を取得する
+ * @param src 画像のパス
+ * @returns Base64形式の画像データ、またはキャッシュがない場合はundefined
+ */
+export function getImageData(src: string): string | undefined {
+  return imageDataCache.get(src);
+}
+
+/**
  * 画像サイズを事前取得してキャッシュする（非同期）
  * HTTPS URLの画像を処理する際に使用
  * @param src 画像のパス（ローカルパス、base64データ、またはHTTPS URL）
@@ -38,6 +52,11 @@ export async function prefetchImageSize(src: string): Promise<{
       }
       const arrayBuffer = await response.arrayBuffer();
       buffer = new Uint8Array(arrayBuffer);
+
+      // 画像データをBase64形式でキャッシュ（pptxgenjs用）
+      const contentType = response.headers.get("content-type") || "image/png";
+      const base64 = Buffer.from(arrayBuffer).toString("base64");
+      imageDataCache.set(src, `${contentType};base64,${base64}`);
     }
     // ローカルファイルパスの場合
     else {

--- a/src/renderPptx/renderPptx.ts
+++ b/src/renderPptx/renderPptx.ts
@@ -81,13 +81,20 @@ export function renderPptx(pages: PositionedNode[], slidePx: SlidePx) {
         }
 
         case "image": {
-          slide.addImage({
-            path: node.src,
+          const imageOptions = {
             x: pxToIn(node.x),
             y: pxToIn(node.y),
             w: pxToIn(node.w),
             h: pxToIn(node.h),
-          });
+          };
+
+          if (node.imageData) {
+            // Base64 データがある場合は data プロパティを使用（リモート画像）
+            slide.addImage({ ...imageOptions, data: node.imageData });
+          } else {
+            // ローカルパスの場合は path プロパティを使用
+            slide.addImage({ ...imageOptions, path: node.src });
+          }
           break;
         }
 

--- a/src/toPositioned/toPositioned.ts
+++ b/src/toPositioned/toPositioned.ts
@@ -1,4 +1,5 @@
 import type { POMNode, PositionedNode } from "../types";
+import { getImageData } from "../calcYogaLayout/measureImage";
 
 /**
  * POMNode ツリーを絶対座標付きの PositionedNode ツリーに変換する
@@ -31,12 +32,14 @@ export function toPositioned(
       };
     }
     case "image": {
+      const imageData = getImageData(pom.src);
       return {
         ...pom,
         x: absoluteX,
         y: absoluteY,
         w: layout.width,
         h: layout.height,
+        imageData,
       };
     }
     case "table": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,7 +473,7 @@ type PositionedBase = z.infer<typeof positionedBaseSchema>;
 
 export type PositionedNode =
   | (TextNode & PositionedBase)
-  | (ImageNode & PositionedBase)
+  | (ImageNode & PositionedBase & { imageData?: string })
   | (TableNode & PositionedBase)
   | (BoxNode & PositionedBase & { children: PositionedNode })
   | (VStackNode & PositionedBase & { children: PositionedNode[] })
@@ -484,7 +484,9 @@ export type PositionedNode =
 export const positionedNodeSchema: z.ZodType<PositionedNode> = z.lazy(() =>
   z.union([
     textNodeSchema.merge(positionedBaseSchema),
-    imageNodeSchema.merge(positionedBaseSchema),
+    imageNodeSchema.merge(positionedBaseSchema).extend({
+      imageData: z.string().optional(),
+    }),
     tableNodeSchema.merge(positionedBaseSchema),
     boxNodeSchemaBase.merge(positionedBaseSchema).extend({
       children: z.lazy(() => positionedNodeSchema),


### PR DESCRIPTION
## Summary

- リモートURL（HTTP/HTTPS）の画像がPPTXに正しく埋め込まれない問題を修正
- 画像をfetch時にBase64形式でキャッシュして保持し、pptxgenjsにはdataプロパティで渡すように変更
- ローカルファイルは従来通りpathプロパティを使用

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] `npm run lint` が通ること
- [ ] `npm run test:run` が通ること
- [ ] リモート画像URLを含むPOMNodeでPPTXを生成し、画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)