### PR TITLE
fix: docker composeコマンド実行前に常にビルドを実行

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "test:run": "vitest run",
     "vrt": "tsx vrt/runVrt.ts",
     "vrt:update": "tsx vrt/runVrt.ts --update",
-    "vrt:docker": "docker compose run --rm vrt",
-    "vrt:docker:update": "docker compose run --rm vrt-update",
+    "vrt:docker": "docker compose build vrt && docker compose run --rm vrt",
+    "vrt:docker:update": "docker compose build vrt-update && docker compose run --rm vrt-update",
     "preview": "tsx preview/lib/previewPptx.ts",
-    "preview:docker": "docker compose run --rm preview"
+    "preview:docker": "docker compose build preview && docker compose run --rm preview"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",


### PR DESCRIPTION
## Summary
- `vrt:docker`, `vrt:docker:update`, `preview:docker` の各スクリプトで `docker compose run` の前に `docker compose build` を実行するように変更

## 問題
ソースコード変更後に docker compose で VRT や preview を実行すると、古いイメージが使われて変更が反映されない問題があった。

## 解決策
各 npm script で `docker compose build` を先に実行することで、常に最新のソースコードでコンテナが実行されるようにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)