### PR TITLE
refactor: measureText.ts の重複コード排除

### DIFF
--- a/.changeset/deduplicate-measure-text.md
+++ b/.changeset/deduplicate-measure-text.md
@@ -1,0 +1,9 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+refactor: measureText.ts の重複コード排除
+
+- measureTextCanvas と measureTextFallback の折り返しロジックを wrapText 関数に抽出
+- 結果計算ロジックを calculateResult 関数に抽出
+- 約50行の削減


### PR DESCRIPTION
close #149

## Summary
- measureTextCanvas と measureTextFallback の折り返しロジックを wrapText 関数に抽出
- 結果計算ロジックを calculateResult 関数に抽出
- 約50行の削減（291行→245行）

## Test plan
- [x] `npm run typecheck` を実行
- [x] `npm run lint` を実行
- [x] `npm run fmt:check` を実行
- [x] `npm run test:run` を実行
- [x] `npm run vrt:docker` を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)