### PR TITLE
perf: VRT の GHA キャッシュを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build Docker image with cache
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: vrt/Dockerfile
-          tags: pom-vrt:latest
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
       - name: Run VRT in Docker
         run: docker compose run --rm vrt
       - name: Upload diff on failure


### PR DESCRIPTION
## Summary

- GHA の Docker キャッシュを削除し、シンプルな構成に戻す

### 変更の背景

キャッシュのインポート/エクスポート自体に時間がかかるため、キャッシュなしの方が効率的。

| 状況 | Docker build | Run VRT | VRT 合計 |
|-----|--------------|---------|----------|
| キャッシュなし（旧構成） | - | 110秒 | 114秒 |
| キャッシュミス（新構成） | 128秒 | 20秒 | 164秒 |
| キャッシュヒット（新構成） | 42秒 | 21秒 | 75秒 |

- キャッシュミスのペナルティ（+50秒）がキャッシュヒットのメリット（-39秒）を上回る
- PR で `package.json` や `Dockerfile` が変わるとキャッシュミスになる
- GHA キャッシュは7日で期限切れになるため、頻度が低いとミスしやすい

## Test plan

- [x] `npm run lint && npm run fmt:check` が通ることを確認
- [ ] CI で VRT が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)