### PR TITLE
fix: 複合型ノードに setMeasureFunc を追加

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -36,6 +36,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
     },
   },
   ...tseslint.configs.recommendedTypeChecked,

--- a/src/calcYogaLayout/calcYogaLayout.ts
+++ b/src/calcYogaLayout/calcYogaLayout.ts
@@ -4,6 +4,13 @@ import { loadYoga } from "yoga-layout/load";
 import { measureText } from "./measureText";
 import { measureImage, prefetchImageSize } from "./measureImage";
 import { calcTableIntrinsicSize } from "../table/utils";
+import {
+  measureProcessArrow,
+  measureTimeline,
+  measureMatrix,
+  measureTree,
+  measureFlow,
+} from "./measureCompositeNodes";
 
 /**
  * POMNode ツリーを Yoga でレイアウト計算する
@@ -323,12 +330,49 @@ async function applyStyleToYogaNode(node: POMNode, yn: YogaNode) {
       }
       break;
 
-    case "timeline":
-    case "matrix":
-    case "tree":
-    case "flow":
     case "processArrow":
-      // 明示的にサイズが指定されていることを期待
+      {
+        yn.setMeasureFunc(() => {
+          const { width, height } = measureProcessArrow(node);
+          return { width, height };
+        });
+      }
+      break;
+
+    case "timeline":
+      {
+        yn.setMeasureFunc(() => {
+          const { width, height } = measureTimeline(node);
+          return { width, height };
+        });
+      }
+      break;
+
+    case "matrix":
+      {
+        yn.setMeasureFunc(() => {
+          const { width, height } = measureMatrix(node);
+          return { width, height };
+        });
+      }
+      break;
+
+    case "tree":
+      {
+        yn.setMeasureFunc(() => {
+          const { width, height } = measureTree(node);
+          return { width, height };
+        });
+      }
+      break;
+
+    case "flow":
+      {
+        yn.setMeasureFunc(() => {
+          const { width, height } = measureFlow(node);
+          return { width, height };
+        });
+      }
       break;
 
     case "line":

--- a/src/calcYogaLayout/measureCompositeNodes.ts
+++ b/src/calcYogaLayout/measureCompositeNodes.ts
@@ -1,0 +1,187 @@
+import type {
+  ProcessArrowNode,
+  TimelineNode,
+  MatrixNode,
+  TreeNode,
+  FlowNode,
+  TreeDataItem,
+} from "../types";
+
+/**
+ * ProcessArrow ノードの intrinsic size を計算する
+ */
+export function measureProcessArrow(node: ProcessArrowNode): {
+  width: number;
+  height: number;
+} {
+  const stepCount = node.steps.length;
+  if (stepCount === 0) {
+    return { width: 0, height: 0 };
+  }
+
+  const itemWidth = node.itemWidth ?? 150;
+  const itemHeight = node.itemHeight ?? 60;
+  const gap = node.gap ?? -15;
+  const direction = node.direction ?? "horizontal";
+
+  if (direction === "horizontal") {
+    return {
+      width: stepCount * itemWidth + (stepCount - 1) * gap,
+      height: itemHeight,
+    };
+  } else {
+    return {
+      width: itemWidth,
+      height: stepCount * itemHeight + (stepCount - 1) * gap,
+    };
+  }
+}
+
+/**
+ * Timeline ノードの intrinsic size を計算する
+ *
+ * Timeline の描画には以下の固定値が使用される：
+ * - nodeRadius: 12px (円のサイズ)
+ * - 日付ラベル領域: 上部 40px
+ * - タイトルラベル領域: 下部 24px
+ * - 説明ラベル領域: 下部 32px
+ */
+export function measureTimeline(node: TimelineNode): {
+  width: number;
+  height: number;
+} {
+  const itemCount = node.items.length;
+  if (itemCount === 0) {
+    return { width: 0, height: 0 };
+  }
+
+  const nodeRadius = 12;
+  const direction = node.direction ?? "horizontal";
+
+  if (direction === "horizontal") {
+    // 各アイテムの幅: 120px (ラベル幅)
+    // 最小幅: nodeRadius * 2 + (itemCount - 1) * 間隔
+    const minItemSpacing = 120; // 各アイテムの最小間隔
+    const minWidth = nodeRadius * 2 + (itemCount - 1) * minItemSpacing;
+
+    // 高さ: 上部ラベル(40) + nodeRadius*2 + 下部ラベル(24+32) + マージン
+    const height = 40 + nodeRadius * 2 + 8 + 24 + 32;
+
+    return {
+      width: minWidth,
+      height: height,
+    };
+  } else {
+    // 垂直方向
+    // 各アイテムの高さ: 約 60px
+    const minItemSpacing = 60;
+    const minHeight = nodeRadius * 2 + (itemCount - 1) * minItemSpacing;
+
+    // 幅: lineX(40) + nodeRadius + ラベル幅
+    const width = 40 + nodeRadius * 2 + 16 + 100;
+
+    return {
+      width: width,
+      height: minHeight,
+    };
+  }
+}
+
+/**
+ * Matrix ノードの intrinsic size を計算する
+ *
+ * Matrix の描画には以下の固定値が使用される：
+ * - padding: 60px (軸ラベル用の余白)
+ * - itemSize: 24px (アイテムの円のサイズ)
+ */
+export function measureMatrix(_: MatrixNode): {
+  width: number;
+  height: number;
+} {
+  const padding = 60;
+  const minAreaSize = 100; // 最小の内部描画領域サイズ
+
+  return {
+    width: padding * 2 + minAreaSize,
+    height: padding * 2 + minAreaSize,
+  };
+}
+
+/**
+ * Tree ノードの intrinsic size を計算する
+ *
+ * ツリー構造を再帰的に走査し、必要なサイズを計算する
+ */
+export function measureTree(node: TreeNode): {
+  width: number;
+  height: number;
+} {
+  const layout = node.layout ?? "vertical";
+  const nodeWidth = node.nodeWidth ?? 120;
+  const nodeHeight = node.nodeHeight ?? 40;
+  const levelGap = node.levelGap ?? 60;
+  const siblingGap = node.siblingGap ?? 20;
+
+  function calculateSubtreeSize(item: TreeDataItem): {
+    width: number;
+    height: number;
+  } {
+    if (!item.children || item.children.length === 0) {
+      return { width: nodeWidth, height: nodeHeight };
+    }
+
+    const childSizes = item.children.map(calculateSubtreeSize);
+
+    if (layout === "vertical") {
+      const childrenWidth =
+        childSizes.reduce((sum, s) => sum + s.width, 0) +
+        siblingGap * (childSizes.length - 1);
+      const childrenHeight = Math.max(...childSizes.map((s) => s.height));
+      return {
+        width: Math.max(nodeWidth, childrenWidth),
+        height: nodeHeight + levelGap + childrenHeight,
+      };
+    } else {
+      const childrenHeight =
+        childSizes.reduce((sum, s) => sum + s.height, 0) +
+        siblingGap * (childSizes.length - 1);
+      const childrenWidth = Math.max(...childSizes.map((s) => s.width));
+      return {
+        width: nodeWidth + levelGap + childrenWidth,
+        height: Math.max(nodeHeight, childrenHeight),
+      };
+    }
+  }
+
+  return calculateSubtreeSize(node.data);
+}
+
+/**
+ * Flow ノードの intrinsic size を計算する
+ */
+export function measureFlow(node: FlowNode): {
+  width: number;
+  height: number;
+} {
+  const nodeCount = node.nodes.length;
+  if (nodeCount === 0) {
+    return { width: 0, height: 0 };
+  }
+
+  const nodeWidth = node.nodeWidth ?? 120;
+  const nodeHeight = node.nodeHeight ?? 60;
+  const nodeGap = node.nodeGap ?? 80;
+  const direction = node.direction ?? "horizontal";
+
+  if (direction === "horizontal") {
+    return {
+      width: nodeCount * nodeWidth + (nodeCount - 1) * nodeGap,
+      height: nodeHeight,
+    };
+  } else {
+    return {
+      width: nodeWidth,
+      height: nodeCount * nodeHeight + (nodeCount - 1) * nodeGap,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- 複合型ノード（ProcessArrow, Timeline, Matrix, Tree, Flow）が Yoga レイアウトに内部サイズを報告するようになりました
- これにより、他のノード（Text, Image など）と組み合わせた際のレイアウト計算が正確になります
- 各ノードの intrinsic size を計算する共通ユーティリティを追加しました

## 変更内容

- `src/calcYogaLayout/measureCompositeNodes.ts`: 各複合型ノードのサイズ計算関数を新規作成
- `src/calcYogaLayout/calcYogaLayout.ts`: 各複合型ノードに setMeasureFunc を設定
- `eslint.config.mts`: argsIgnorePattern を追加（_で始まる未使用引数を許可）

## Test plan

- [x] typecheck 成功
- [x] lint 成功
- [x] fmt:check 成功
- [x] test:run 成功（14 tests passed）
- [x] vrt:docker 成功（No visual differences found）

🤖 Generated with [Claude Code](https://claude.com/claude-code)