### PR TITLE
chore: zod を 4.3.6 にアップデート

### DIFF
--- a/.changeset/update-zod.md
+++ b/.changeset/update-zod.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+chore: zod を 4.1.12 から 4.3.6 にアップデート

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@hirokisakabe/pom",
-  "version": "0.2.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirokisakabe/pom",
-      "version": "0.2.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "image-size": "2.0.2",
         "opentype.js": "^1.3.4",
         "pptxgenjs": "4.0.1",
         "yoga-layout": "3.2.1",
-        "zod": "4.1.12"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",
@@ -4942,9 +4942,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     "opentype.js": "^1.3.4",
     "pptxgenjs": "4.0.1",
     "yoga-layout": "3.2.1",
-    "zod": "4.1.12"
+    "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
## Summary

- zod を 4.1.12 から 4.3.6 にアップデート

## Test plan

- [x] lint、fmt:check、typecheck、test:run がすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)