### PR TITLE
docs: ブラウザ環境サポートの記述を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@
 
 ## Requirements
 
-- Node.js 18 or higher (for Node.js environments)
-- Modern browser with ES2020+ support (for browser environments)
-
-> [!NOTE]
-> pom works in both Node.js and browser environments. Text measurement uses opentype.js with bundled Noto Sans JP fonts, ensuring consistent layout across all environments.
+- Node.js 18 or higher
 
 ## Installation
 

--- a/docs/serverless.md
+++ b/docs/serverless.md
@@ -1,6 +1,6 @@
 # Serverless Environments
 
-pom uses `opentype.js` with bundled Noto Sans JP fonts to measure text width and determine line break positions. This approach works consistently in both Node.js and browser environments, including serverless platforms like Vercel or AWS Lambda.
+pom uses `opentype.js` with bundled Noto Sans JP fonts to measure text width and determine line break positions. This approach works consistently across Node.js environments, including serverless platforms like Vercel or AWS Lambda.
 
 ## textMeasurement Option
 


### PR DESCRIPTION
## Summary

- README.md からブラウザ環境サポートの記述（Requirements のブラウザ要件と NOTE）を削除
- docs/serverless.md からブラウザ環境への言及を削除

実際のコードは `createRequire`（Node.js `module` ビルトイン）、`fs.readFileSync`、`Buffer` 等の Node.js 専用 API を使用しており、ブラウザでは import 時点でエラーになるため、ドキュメントの記述を実態に合わせました。

## Test plan

- [ ] ドキュメント変更のみのため、ビルド・テストへの影響なし
- [ ] README.md のブラウザ関連記述が削除されていること
- [ ] docs/serverless.md のブラウザ関連記述が削除されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)