### PR TITLE
docs: awesome-readme ベストプラクティスに基づく README 改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
 - [Available Nodes](#available-nodes)
 - [Node Examples](#node-examples)
 - [Documentation](#documentation)
-- [Requirements](#requirements)
 - [License](#license)
 
 ## Features
@@ -54,6 +53,8 @@
 - **Accurate Text Measurement** — Text width measured with opentype.js and bundled Noto Sans JP fonts for consistent layout.
 
 ## Quick Start
+
+> Requires Node.js 18+
 
 ```bash
 npm install @hirokisakabe/pom
@@ -195,10 +196,6 @@ For detailed node documentation, see [Nodes Reference](./docs/nodes.md).
 | [Serverless Environments](./docs/serverless.md)  | Text measurement options for serverless |
 | [LLM Integration](./docs/llm-integration.md)     | Compact XML reference for LLM prompts   |
 | [Playground](https://pom-playground.vercel.app/) | Try pom XML in the browser              |
-
-## Requirements
-
-- Node.js 18 or higher
 
 ## License
 


### PR DESCRIPTION
## 概要

[awesome-readme](https://github.com/matiassingers/awesome-readme) の優れた例（gofiber/fiber, ai/size-limit, zenml-io/zenml 等）を参考に、README を改善。

### 変更内容

- センター配置ヘッダーとバッジ（npm version, CI status, license）を追加
- ヒーロー画像として chart / flow / tree / timeline の出力例を 2x2 グリッドで表示
- Table of Contents を追加
- Features セクションを拡充（AI Friendly を先頭に配置、Cross-platform を追加、各項目に説明を追加）
- Available Nodes テーブルに Line / Layer を追加し、ノード名を PascalCase（実際の XML タグ名）に統一
- Node Examples セクションを新設（Chart, Flow, Tree, Table, Timeline, ProcessArrow の XML コード例と出力画像）
- Requirements セクションを下部に移動（Quick Start を先に見せる構造に変更）
- package-lock.json のバージョンを package.json (v2.0.0) と整合

## テスト計画

- [x] `npm run fmt:check` パス
- [x] `npm run lint` パス
- [x] `npm run test:run` パス（112 tests）
- [ ] GitHub 上で README の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)