### PR TITLE
fix: package-lock.json のバージョンを package.json と同期

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirokisakabe/pom",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirokisakabe/pom",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.3.7",


### PR DESCRIPTION
## Summary

- `package-lock.json` のバージョンが `1.4.0` のまま残っており、`package.json`（`2.0.0`）と不一致だった
- `npm install` 実行時に `package-lock.json` に差分が発生する問題を修正
- `npm install` を実行してバージョンを同期

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run fmt:check` 通過
- [x] `npm run typecheck` 通過
- [x] `npm ci` 後に `npm install` しても `package-lock.json` に差分が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)