### PR TITLE
fix: previewPptx の pptxToPng 呼び出しシグネチャを修正

### DIFF
--- a/preview/lib/previewPptx.ts
+++ b/preview/lib/previewPptx.ts
@@ -34,10 +34,9 @@ async function main() {
 
   // 3. PPTXをPNGに変換
   console.log("2. Converting PPTX to PNG...");
-  const targetPng = path.join(OUTPUT_DIR, "sample.png");
-  await pptxToPng(targetPptx, targetPng);
+  await pptxToPng(targetPptx, OUTPUT_DIR, ["sample"]);
 
-  console.log(`\nPreview saved: ${targetPng}`);
+  console.log(`\nPreview saved: ${path.join(OUTPUT_DIR, "sample.png")}`);
   console.log("\nClaude Code can now read this PNG file to check the layout.");
 }
 


### PR DESCRIPTION
## Summary

- `preview/lib/previewPptx.ts` で `pptxToPng` の呼び出しシグネチャが実際の関数定義と合っていなかったのを修正
  - 修正前: `pptxToPng(pptxPath, pngFilePath)` — 2引数でPNGファイルパスを渡していた
  - 修正後: `pptxToPng(pptxPath, outputDir, pageNames)` — 正しい3引数に合わせた

## Test plan

- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm run fmt:check` 成功
- [x] `npm run test:run` 成功（127 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)