### PR TITLE
fix: src/ 外のスクリプトを typecheck 対象に含める

### DIFF
--- a/docs/lib/generateNodeImages.ts
+++ b/docs/lib/generateNodeImages.ts
@@ -23,7 +23,7 @@ async function generateNodeImage(nodeType: NodeType): Promise<void> {
   const pptxBuffer = await pptx.write({ outputType: "nodebuffer" });
 
   // PPTXファイルを保存
-  fs.writeFileSync(tempPptxPath, Buffer.from(pptxBuffer));
+  fs.writeFileSync(tempPptxPath, Buffer.from(pptxBuffer as Uint8Array));
 
   // PPTX → PNG変換
   await pptxToPng(tempPptxPath, IMAGES_DIR, [nodeType]);

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { buildPptx } from "./src";
+import { buildPptx } from "./src/index.js";
 
 const xml = `
 <VStack w="1280" h="720" padding='{"top":24,"bottom":24,"left":48,"right":48}' gap="24" backgroundColor="F8FAFC">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirokisakabe/pom",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirokisakabe/pom",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.3.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fmt:check": "prettier --check .",
     "knip": "knip",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",

--- a/preview/lib/previewPptx.ts
+++ b/preview/lib/previewPptx.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { pptxToPng } from "../../vrt/lib/pptxToPng";
+import { pptxToPng } from "../../vrt/lib/pptxToPng.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PREVIEW_DIR = path.dirname(__dirname);

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": [
+    "src/**/*",
+    "preview/**/*",
+    "vrt/**/*",
+    "docs/lib/**/*",
+    "main.ts"
+  ],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/vrt/lib/comparePng.ts
+++ b/vrt/lib/comparePng.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { PNG } from "pngjs";
 import pixelmatch from "pixelmatch";
-import { THRESHOLD } from "./config";
+import { THRESHOLD } from "./config.js";
 
 export function comparePng(
   actualPath: string,

--- a/vrt/lib/generatePptx.ts
+++ b/vrt/lib/generatePptx.ts
@@ -1,4 +1,4 @@
-import { buildPptx } from "../../src";
+import { buildPptx } from "../../src/index.js";
 import {
   palette,
   page1TextXml,
@@ -26,7 +26,7 @@ import {
   page22CompositeScaleToFitXml,
   page23TableColspanRowspanXml,
   page24PyramidXml,
-} from "./slides";
+} from "./slides/index.js";
 
 export async function generatePptx(outputPath: string): Promise<void> {
   const allPagesXml = [

--- a/vrt/lib/slides/backgroundImage.ts
+++ b/vrt/lib/slides/backgroundImage.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 20: Background Image Test

--- a/vrt/lib/slides/chart.ts
+++ b/vrt/lib/slides/chart.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 6: Chart Test

--- a/vrt/lib/slides/common.ts
+++ b/vrt/lib/slides/common.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 8: Common Properties Test

--- a/vrt/lib/slides/compositeScaleToFit.ts
+++ b/vrt/lib/slides/compositeScaleToFit.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 22: Composite Node Scale to Fit Test

--- a/vrt/lib/slides/flow.ts
+++ b/vrt/lib/slides/flow.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 13: Flow Node Test

--- a/vrt/lib/slides/image.ts
+++ b/vrt/lib/slides/image.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 3: Image Test

--- a/vrt/lib/slides/index.ts
+++ b/vrt/lib/slides/index.ts
@@ -1,21 +1,25 @@
-export { palette } from "./palette";
-export { page1TextXml, page2ListXml } from "./text";
-export { page3ImageXml, page3bImageSizingXml } from "./image";
-export { page4TableXml } from "./table";
-export { page5ShapeXml } from "./shape";
-export { page6ChartXml, page10ChartAdditionalXml } from "./chart";
-export { page7LayoutXml, page16LayerXml, page17HStackTableXml } from "./layout";
-export { page8CommonXml } from "./common";
-export { page9TimelineXml } from "./timeline";
-export { page11MatrixXml } from "./matrix";
-export { page12TreeXml } from "./tree";
-export { page13FlowXml } from "./flow";
-export { page14ProcessArrowXml } from "./processArrow";
-export { page15LineXml } from "./line";
-export { page18OpacityXml } from "./opacity";
-export { page19ShadowXml } from "./shadow";
-export { page20BackgroundImageXml } from "./backgroundImage";
-export { page21XmlChildElementsXml } from "./xmlChildElements";
-export { page22CompositeScaleToFitXml } from "./compositeScaleToFit";
-export { page23TableColspanRowspanXml } from "./tableColspanRowspan";
-export { page24PyramidXml } from "./pyramid";
+export { palette } from "./palette.js";
+export { page1TextXml, page2ListXml } from "./text.js";
+export { page3ImageXml, page3bImageSizingXml } from "./image.js";
+export { page4TableXml } from "./table.js";
+export { page5ShapeXml } from "./shape.js";
+export { page6ChartXml, page10ChartAdditionalXml } from "./chart.js";
+export {
+  page7LayoutXml,
+  page16LayerXml,
+  page17HStackTableXml,
+} from "./layout.js";
+export { page8CommonXml } from "./common.js";
+export { page9TimelineXml } from "./timeline.js";
+export { page11MatrixXml } from "./matrix.js";
+export { page12TreeXml } from "./tree.js";
+export { page13FlowXml } from "./flow.js";
+export { page14ProcessArrowXml } from "./processArrow.js";
+export { page15LineXml } from "./line.js";
+export { page18OpacityXml } from "./opacity.js";
+export { page19ShadowXml } from "./shadow.js";
+export { page20BackgroundImageXml } from "./backgroundImage.js";
+export { page21XmlChildElementsXml } from "./xmlChildElements.js";
+export { page22CompositeScaleToFitXml } from "./compositeScaleToFit.js";
+export { page23TableColspanRowspanXml } from "./tableColspanRowspan.js";
+export { page24PyramidXml } from "./pyramid.js";

--- a/vrt/lib/slides/layout.ts
+++ b/vrt/lib/slides/layout.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 7: Layout Test (VStack / HStack / Box)

--- a/vrt/lib/slides/line.ts
+++ b/vrt/lib/slides/line.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 15: Line Node Test

--- a/vrt/lib/slides/matrix.ts
+++ b/vrt/lib/slides/matrix.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 11: Matrix Test

--- a/vrt/lib/slides/opacity.ts
+++ b/vrt/lib/slides/opacity.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 18: Opacity Test

--- a/vrt/lib/slides/processArrow.ts
+++ b/vrt/lib/slides/processArrow.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 14: ProcessArrow Node Test

--- a/vrt/lib/slides/pyramid.ts
+++ b/vrt/lib/slides/pyramid.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 24: Pyramid Node Test

--- a/vrt/lib/slides/shadow.ts
+++ b/vrt/lib/slides/shadow.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 19: Shadow Test

--- a/vrt/lib/slides/shape.ts
+++ b/vrt/lib/slides/shape.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 5: Shape Test

--- a/vrt/lib/slides/table.ts
+++ b/vrt/lib/slides/table.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 4: Table Test

--- a/vrt/lib/slides/tableColspanRowspan.ts
+++ b/vrt/lib/slides/tableColspanRowspan.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 23: Table Colspan/Rowspan Test

--- a/vrt/lib/slides/text.ts
+++ b/vrt/lib/slides/text.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 1: Text Node Test

--- a/vrt/lib/slides/timeline.ts
+++ b/vrt/lib/slides/timeline.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 9: Timeline Test

--- a/vrt/lib/slides/tree.ts
+++ b/vrt/lib/slides/tree.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 12: Tree Node Test

--- a/vrt/lib/slides/xmlChildElements.ts
+++ b/vrt/lib/slides/xmlChildElements.ts
@@ -1,4 +1,4 @@
-import { palette } from "./palette";
+import { palette } from "./palette.js";
 
 // ============================================================
 // Page 21: XML Child Element Notation Test

--- a/vrt/runVrt.ts
+++ b/vrt/runVrt.ts
@@ -7,10 +7,10 @@ import {
   ACTUAL_DIR,
   DIFF_DIR,
   PAGE_NAMES,
-} from "./lib/config";
-import { generatePptx } from "./lib/generatePptx";
-import { pptxToPng } from "./lib/pptxToPng";
-import { comparePng } from "./lib/comparePng";
+} from "./lib/config.js";
+import { generatePptx } from "./lib/generatePptx.js";
+import { pptxToPng } from "./lib/pptxToPng.js";
+import { comparePng } from "./lib/comparePng.js";
 
 async function main() {
   const updateBaseline = process.argv.includes("--update");


### PR DESCRIPTION
close #264

## Summary

- typecheck 用の `tsconfig.check.json` を追加し、`preview/`、`vrt/`、`docs/lib/`、`main.ts` を typecheck 対象に含めるようにした
- `npm run typecheck` のコマンドを `tsconfig.check.json` を使用するよう変更
- `NodeNext` moduleResolution で必要な `.js` 拡張子を全ての相対 import パスに追加
- `docs/lib/generateNodeImages.ts` の `Buffer.from()` 型エラーを修正

## 背景

`tsconfig.json` の `include` が `src/**/*` のみだったため、`preview/`、`vrt/`、`docs/lib/` のスクリプトが `npm run typecheck` の対象外になっていた。#263 で `preview/lib/previewPptx.ts` のシグネチャ不一致が typecheck で検出できなかった問題を受け、ビルド用の `tsconfig.json` はそのまま維持しつつ、typecheck 用に `tsconfig.check.json` を追加した。

## Test plan

- [x] `npm run typecheck` が正常に完了することを確認
- [x] `npm run build`（元の `tsconfig.json`）が正常に動作することを確認
- [x] `npm run lint` が通ることを確認
- [x] `npm run fmt:check` が通ることを確認
- [x] `npm run test:run` で全テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)