### PR TITLE
fix: Icon の color 属性で # なし hex カラーを受け付けるように変更

### DIFF
--- a/.changeset/chatty-monkeys-eat.md
+++ b/.changeset/chatty-monkeys-eat.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+Icon の color 属性で `#` なし hex カラーを受け付けるように変更（`#` 付きに自動正規化）

--- a/docs/llm-integration.md
+++ b/docs/llm-integration.md
@@ -143,14 +143,14 @@ Ul の全属性に加えて:
 プリセットアイコンを表示する（Lucide アイコンライブラリ）。
 
 ```xml
-<Icon name="cpu" size="32" color="#1D4ED8" />
+<Icon name="cpu" size="32" color="1D4ED8" />
 ```
 
-| 属性    | 型 / 値                             |
-| ------- | ----------------------------------- |
-| `name`  | アイコン名（必須）                  |
-| `size`  | number（デフォルト: 24、px 単位）   |
-| `color` | hex カラー（デフォルト: `#000000`） |
+| 属性    | 型 / 値                                         |
+| ------- | ----------------------------------------------- |
+| `name`  | アイコン名（必須）                              |
+| `size`  | number（デフォルト: 24、px 単位）               |
+| `color` | hex カラー（`#` 省略可、デフォルト: `#000000`） |
 
 利用可能なアイコン: `cpu`, `database`, `cloud`, `server`, `code`, `terminal`, `wifi`, `globe`, `user`, `users`, `contact`, `briefcase`, `building`, `bar-chart`, `line-chart`, `pie-chart`, `trending-up`, `mail`, `message-square`, `phone`, `video`, `search`, `settings`, `filter`, `download`, `upload`, `share`, `check`, `alert-triangle`, `info`, `shield`, `lock`, `unlock`, `file`, `folder`, `image`, `calendar`, `clock`, `bookmark`, `arrow-right`, `arrow-left`, `arrow-up`, `arrow-down`, `external-link`, `star`, `heart`, `zap`, `target`, `lightbulb`
 

--- a/src/parseXml/parseXml.test.ts
+++ b/src/parseXml/parseXml.test.ts
@@ -170,6 +170,11 @@ describe("parseXml", () => {
       expect(() => parseXml('<Icon name="cpu" size="-1" />')).toThrow();
     });
 
+    it("Icon ノードで # なし hex color を受け付け、# 付きに正規化する", () => {
+      const result = parseXml('<Icon name="cpu" color="1D4ED8" />');
+      expect(result).toEqual([{ type: "icon", name: "cpu", color: "#1D4ED8" }]);
+    });
+
     it("Icon ノードで不正な color はエラーになる", () => {
       expect(() =>
         parseXml('<Icon name="cpu" color="not-a-color" />'),

--- a/src/parseXml/parseXml.ts
+++ b/src/parseXml/parseXml.ts
@@ -1189,6 +1189,15 @@ function convertPomNode(
     validateLeafNode(nodeType, result, errors);
   }
 
+  // Normalize icon color: add # prefix if missing
+  if (
+    nodeType === "icon" &&
+    typeof result.color === "string" &&
+    !result.color.startsWith("#")
+  ) {
+    result.color = `#${result.color}`;
+  }
+
   return result;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -402,7 +402,7 @@ export const iconNameSchema = z.enum(
 
 export const iconColorSchema = z
   .string()
-  .regex(/^#[0-9a-fA-F]{3,8}$/)
+  .regex(/^#?[0-9a-fA-F]{3,8}$/)
   .optional();
 
 const iconNodeSchema = basePOMNodeSchema.extend({


### PR DESCRIPTION
close #292

## 概要

Icon ノードの `color` 属性が `#` 付き hex のみ受け付けていたため、他ノード（Text, Shape, Line 等）の `#` なし hex と一貫性がなかった問題を修正。

## 変更内容

- `iconColorSchema` の regex を `/^#?[0-9a-fA-F]{3,8}$/` に変更し、`#` を任意に
- `parseXml` 内で `#` なし hex を `#` 付きに自動正規化（後方互換性を維持）
- `docs/llm-integration.md` の Icon サンプルコードを `#` なし形式に更新
- テストケース追加（`#` なし hex → `#` 付きに正規化されることを検証）

## テスト計画

- [x] `npm run test:run` — 全 149 テスト通過
- [x] `npm run typecheck` — 型チェック通過
- [x] `npm run lint` — ESLint 通過
- [x] `npm run fmt:check` — Prettier フォーマットチェック通過
- [x] Codex レビュー — critical/warning 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)