### PR TITLE
fix: changeset version 時に package-lock.json を同期

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npx changeset publish
-          version: npx changeset version
+          version: npx changeset version && npm install --package-lock-only
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirokisakabe/pom",
-  "version": "4.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirokisakabe/pom",
-      "version": "4.1.1",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",


### PR DESCRIPTION
## Summary

- `changeset version` 実行時に `package-lock.json` のバージョンが更新されず、`npm install` 時に差分が発生する問題を修正
- release ワークフローの `version` コマンドに `npm install --package-lock-only` を追加し、自動同期されるようにした
- 現在の `package-lock.json` のバージョン不一致（4.1.1 → 5.2.0）も解消

## Test plan

- [x] `npm run lint` パス
- [x] `npm run fmt:check` パス
- [x] `npm run typecheck` パス
- [x] `npm run test:run` 全 182 テストパス
- [x] `npm install --package-lock-only` 実行後に追加差分が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)