### PR TITLE
fix: changeset がない場合の Release ワークフロー失敗を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npx changeset publish
-          version: npx changeset version && npm install --package-lock-only
+          version: |
+            npx changeset version
+            if ! git diff --quiet -- package.json; then
+              npm install --package-lock-only
+            fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
close #325

## Summary
- changeset がない場合（docs 変更のみ等）に `changesets/action` が `No commits between main and changeset-release/main` エラーで失敗する問題を修正
- `changeset version` 後に `package.json` に変更があった場合のみ `npm install --package-lock-only` を実行するようガード条件を追加
- `A && B || C` パターンによるエラー握りつぶしを防ぐため `if` ブロックに分離

## Test plan
- [ ] changeset ありの PR マージ時に Release PR が正常に作成されることを確認
- [ ] changeset なしの PR マージ時にワークフローがエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)