### PR TITLE
fix: changeset がない場合に Release ワークフローが失敗する問題を根本修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,17 @@ jobs:
       - run: npm run build
       - run: npm run test:run
 
+      - name: Check for changesets
+        id: changesets-check
+        run: |
+          if find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' -print -quit 2>/dev/null | grep -q .; then
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release PR or Publish
+        if: steps.changesets-check.outputs.has_changesets == 'true'
         uses: changesets/action@v1
         with:
           publish: npx changeset publish
@@ -39,4 +49,10 @@ jobs:
             fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Publish (after Release PR merge)
+        if: steps.changesets-check.outputs.has_changesets == 'false'
+        run: npx changeset publish
+        env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
close #327

## Summary

- changeset の有無を事前チェックするステップを追加
- changeset がある場合のみ `changesets/action` を実行（Release PR 作成/更新）
- changeset がない場合は `npx changeset publish` を直接実行し、Release PR マージ後の npm publish が正常に動作するようにする

## 背景

changeset を含まない PR を main にマージした際、既存の Release PR がない状態だと `changesets/action` が以下のエラーで失敗していた:

```
error: pathspec 'changeset-release/main' did not match any file(s) known to git
HttpError: Validation Failed: No commits between main and changeset-release/main
```

PR #326 の修正は `version` スクリプト内のガードのみで、この根本原因には対処できていなかった。

## 修正内容

`changesets/action` の前に `find` コマンドで `.changeset/*.md`（README.md 除く）の存在を確認し:

- **changeset あり**: `changesets/action` で Release PR 作成/更新 + publish
- **changeset なし**: `npx changeset publish` を直接実行（Release PR マージ後の publish 対応）

## Test plan

- [ ] changeset を含まない PR を main にマージした際、Release ワークフローが成功すること
- [ ] changeset を含む PR を main にマージした際、Release PR が正常に作成されること
- [ ] Release PR をマージした際、npm publish が正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)