### PR TITLE
fix: Release ワークフローの version スクリプト修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,18 +38,31 @@ jobs:
           fi
 
       - name: Create Release PR or Publish
+        id: changesets
         if: steps.changesets-check.outputs.has_changesets == 'true'
         uses: changesets/action@v1
         with:
           publish: npx changeset publish
-          version: |
-            npx changeset version
-            if ! git diff --quiet -- package.json; then
-              npm install --package-lock-only
-            fi
+          version: npx changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Sync package-lock.json on Release PR branch
+        if: steps.changesets.outputs.pullRequestNumber
+        run: |
+          git fetch origin changeset-release/main
+          git checkout changeset-release/main
+          npm install --package-lock-only
+          if ! git diff --quiet -- package-lock.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add package-lock.json
+            git commit -m "chore: sync package-lock.json"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish (after Release PR merge)
         if: steps.changesets-check.outputs.has_changesets == 'false'


### PR DESCRIPTION
close #327

## 概要

`changesets/action@v1` の `version` パラメータに複数行スクリプトを渡すと、1行に結合されて実行されるため `changeset version` が失敗していた問題を修正。

### 変更内容

- `version` パラメータを `npx changeset version` のみに簡素化
- `package-lock.json` の同期は、changesets/action の後の別ステップで実施するように分離
  - Release PR ブランチ (`changeset-release/main`) にチェックアウトして `npm install --package-lock-only` を実行
  - 差分がある場合のみコミット＆プッシュ

### 方針

Issue #327 の方針2「`version` を `npx changeset version` のみにし、`package-lock.json` の同期は別ステップで行う」を採用。

## テストプラン

- [ ] changeset ありの PR を main にマージし、Release ワークフローが正常に Release PR を作成することを確認
- [ ] Release PR の package-lock.json が正しく同期されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)