### PR TITLE
fix: package-lock.json 同期の git push 修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add package-lock.json
             git commit -m "chore: sync package-lock.json"
-            git push
+            git push origin changeset-release/main
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

PR #329 の修正で追加した package-lock.json 同期ステップで、`git push` が upstream 未設定のため失敗していた問題を修正。

### 変更内容

- `git push` → `git push origin changeset-release/main` に変更し、明示的にリモートとブランチを指定

### 失敗ログ

```
fatal: The current branch changeset-release/main has no upstream branch.
```

## テストプラン

- [ ] Release ワークフローで package-lock.json 同期ステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)