### PR TITLE
docs: README の Playground URL を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 </p>
 
 <p align="center">
-  <a href="https://pom-playground.vercel.app/"><b>Try it online — Playground</b></a>
+  <a href="https://pom.pptx.app/playground"><b>Try it online — Playground</b></a>
 </p>
 
 <p align="center">
-  <a href="https://pom-playground.vercel.app/">
+  <a href="https://pom.pptx.app/playground">
     <img src="./docs/images/playground.png" alt="Playground" width="800">
   </a>
 </p>
@@ -215,13 +215,13 @@ const pptx = await buildPptx(xml, { w: 1280, h: 720 }, { autoFit: false });
 
 ## Documentation
 
-| Document                                         | Description                             |
-| ------------------------------------------------ | --------------------------------------- |
-| [Nodes Reference](./docs/nodes.md)               | Complete reference for all node types   |
-| [Master Slide](./docs/master-slide.md)           | Headers, footers, and page numbers      |
-| [Serverless Environments](./docs/serverless.md)  | Text measurement options for serverless |
-| [LLM Integration](./docs/llm-integration.md)     | Compact XML reference for LLM prompts   |
-| [Playground](https://pom-playground.vercel.app/) | Try pom XML in the browser              |
+| Document                                        | Description                             |
+| ----------------------------------------------- | --------------------------------------- |
+| [Nodes Reference](./docs/nodes.md)              | Complete reference for all node types   |
+| [Master Slide](./docs/master-slide.md)          | Headers, footers, and page numbers      |
+| [Serverless Environments](./docs/serverless.md) | Text measurement options for serverless |
+| [LLM Integration](./docs/llm-integration.md)    | Compact XML reference for LLM prompts   |
+| [Playground](https://pom.pptx.app/playground)   | Try pom XML in the browser              |
 
 ## License
 


### PR DESCRIPTION
close #333

## 概要

README.md の Playground URL を旧ドメイン (`pom-playground.vercel.app`) から統合先 (`pom.pptx.app/playground`) に更新。

## 変更内容

- README.md の3箇所の Playground URL を `https://pom.pptx.app/playground` に変更（17行目、21行目、224行目）

## テスト

- [x] `npm run fmt:check` パス
- [x] `npm run lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)