### PR TITLE
docs: README から存在しない CI バッジを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@hirokisakabe/pom"><img src="https://img.shields.io/npm/v/@hirokisakabe/pom.svg" alt="npm version"></a>
-  <a href="https://github.com/hirokisakabe/pom/actions/workflows/ci.yml"><img src="https://github.com/hirokisakabe/pom/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@hirokisakabe/pom.svg" alt="License"></a>
 </p>
 


### PR DESCRIPTION
close #344

## 概要
- README の CI バッジが存在しない `ci.yml` を参照していたため、バッジを削除

## Test plan
- [ ] README のバッジ表示が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)