### PR TITLE
docs: setup OGP, metadata, and SEO configuration

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,12 +1,26 @@
+import type { Metadata } from "next";
 import { Head } from "nextra/components";
+import { siteDescription, siteName, siteUrl } from "./siteConfig";
 
-export const metadata = {
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: {
-    default: "pom",
-    template: "%s - pom",
+    default: siteName,
+    template: `%s - ${siteName}`,
   },
-  description:
-    "A library for declaratively describing PowerPoint presentations in TypeScript",
+  description: siteDescription,
+  openGraph: {
+    type: "website",
+    siteName,
+    description: siteDescription,
+  },
+  twitter: {
+    card: "summary",
+    description: siteDescription,
+  },
+  alternates: {
+    canonical: "./",
+  },
 };
 
 export default function RootLayout({

--- a/website/app/playground/layout.tsx
+++ b/website/app/playground/layout.tsx
@@ -13,6 +13,8 @@ const geistMono = Geist_Mono({
 
 export const metadata = {
   title: "Playground",
+  description:
+    "Try pom in your browser — write XML and generate PowerPoint slides instantly",
 };
 
 export default function PlaygroundLayout({

--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "./siteConfig";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/website/app/siteConfig.ts
+++ b/website/app/siteConfig.ts
@@ -1,0 +1,4 @@
+export const siteUrl = "https://pom.pptx.app";
+export const siteName = "pom";
+export const siteDescription =
+  "A library for declaratively describing PowerPoint presentations in TypeScript";

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "./siteConfig";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: siteUrl },
+    { url: `${siteUrl}/nodes` },
+    { url: `${siteUrl}/master-slide` },
+    { url: `${siteUrl}/serverless` },
+    { url: `${siteUrl}/llm-integration` },
+    { url: `${siteUrl}/playground` },
+  ];
+}


### PR DESCRIPTION
close #342

## 概要

website に OGP・メタデータ・SEO の基本設定を整備。

## 変更内容

- **`app/siteConfig.ts`** (新規): サイト URL・名前・説明を共通定義に集約
- **`app/layout.tsx`**: OpenGraph / Twitter Card / canonical URL / metadataBase を追加
- **`app/robots.ts`** (新規): robots.txt を生成
- **`app/sitemap.ts`** (新規): sitemap.xml を生成（全ページ分）
- **`app/playground/layout.tsx`**: description メタデータを追加

## テスト計画

- [ ] `npm run lint` / `npm run typecheck` / `npm run fmt:check` がルートで通ること（website 側の既存エラーは変更対象外）
- [ ] デプロイ後、各ページの `<head>` に OGP / Twitter Card タグが出力されること
- [ ] `/robots.txt` が正しく配信されること
- [ ] `/sitemap.xml` が全ページ URL を含むこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)