### PR TITLE
test: playground のサンプル XML が PPTX に変換できることを検証

### DIFF
--- a/website/playground/server/convertXmlToPptx.test.ts
+++ b/website/playground/server/convertXmlToPptx.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { SAMPLE_TEMPLATES } from "../client/lib/sampleTemplates";
+import { convertXmlToPptx } from "./convertXmlToPptx";
+
+// PPTX (ZIP) マジックバイト: PK\x03\x04
+const ZIP_SIGNATURE = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+
+describe("convertXmlToPptx", () => {
+  it("サンプルテンプレートが1件以上存在する", () => {
+    expect(SAMPLE_TEMPLATES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(SAMPLE_TEMPLATES)("サンプル「$name」($id)", ({ xml }) => {
+    it("有効な PPTX (ZIP) バイナリに変換できる", async () => {
+      const result = await convertXmlToPptx(xml);
+      expect(result).toBeInstanceOf(ArrayBuffer);
+      expect(result.byteLength).toBeGreaterThan(0);
+
+      const header = new Uint8Array(result).slice(0, 4);
+      expect(header).toEqual(ZIP_SIGNATURE);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- playground のサンプルテンプレート（決算サマリー、プロダクト紹介、料金プラン、チャート集）の XML が実際に `convertXmlToPptx` で PPTX に変換できることを検証するインテグレーションテストを追加
- テンプレートが1件以上存在することの確認、および出力が有効な ZIP（PPTX）バイナリであることを ZIP シグネチャで検証

## Test plan
- [x] `npm run test:run` で全テストがパスすることを確認
- [x] `npm run lint` / `npm run fmt:check` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)