### PR TITLE
ci: リリース後に website の pom バージョンを自動更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,19 @@ jobs:
         run: npx changeset publish
         env:
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Update pom version in website
+        if: steps.changesets-check.outputs.has_changesets == 'false'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          cd website
+          npm install @hirokisakabe/pom@$VERSION
+          if ! git diff --quiet -- package.json package-lock.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add package.json package-lock.json
+            git commit -m "chore: update @hirokisakabe/pom to v$VERSION [skip ci]"
+            git push origin HEAD:main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
close #339

## 概要

- リリース（npm publish）後に `website/package.json` の `@hirokisakabe/pom` バージョンを自動更新するステップを `release.yml` に追加

## 変更内容

- publish ステップの後に「Update pom version in website」ステップを追加
- `npm install @hirokisakabe/pom@$VERSION` で website の依存を更新し、差分がある場合のみ commit & push
- `[skip ci]` で workflow の再トリガーを防止
- `git push origin HEAD:main` で push 先を明示

## テスト計画

- [ ] Release PR マージ後に publish → website バージョン更新が実行されることを確認
- [ ] バージョンが既に最新の場合、commit/push がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)