### PR TITLE
fix: プレイグラウンド初期表示時にプレビューを生成する

### DIFF
--- a/website/playground/client/components/AppLayout.test.tsx
+++ b/website/playground/client/components/AppLayout.test.tsx
@@ -104,6 +104,19 @@ describe("AppLayout", () => {
   });
 
   describe("プレビュー生成フロー", () => {
+    it("初期表示時にデバウンス後にプレビューを生成する", async () => {
+      render(<AppLayout />);
+
+      // デバウンス前は呼ばれていない
+      expect(mockPreviewPost).not.toHaveBeenCalled();
+
+      // デバウンス後
+      await vi.advanceTimersByTimeAsync(600);
+      await waitFor(() => {
+        expect(mockPreviewPost).toHaveBeenCalledTimes(1);
+      });
+    });
+
     it("XML 変更後、デバウンス待ち後に API を呼び出す", async () => {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       render(<AppLayout />);
@@ -111,9 +124,6 @@ describe("AppLayout", () => {
       const editor = screen.getByTestId("xml-editor");
       await user.clear(editor);
       await user.type(editor, "<Text>hello</Text>");
-
-      // デバウンス前は呼ばれていない（初期レンダーでは呼ばれない）
-      expect(mockPreviewPost).not.toHaveBeenCalled();
 
       // デバウンス後
       await vi.advanceTimersByTimeAsync(600);

--- a/website/playground/client/components/AppLayout.tsx
+++ b/website/playground/client/components/AppLayout.tsx
@@ -51,7 +51,6 @@ export function AppLayout() {
   const editorViewRef = useRef<EditorView | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const isInitialRenderRef = useRef(true);
 
   async function handleDownload() {
     setIsDownloading(true);
@@ -106,11 +105,6 @@ export function AppLayout() {
   }
 
   useEffect(() => {
-    if (isInitialRenderRef.current) {
-      isInitialRenderRef.current = false;
-      return;
-    }
-
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
     }


### PR DESCRIPTION
close #368

## 概要

- プレイグラウンドの初期表示時に `isInitialRenderRef` によるスキップ処理を削除し、デフォルトテンプレートのプレビューが自動生成されるようにした
- 初期表示時のプレビュー生成を検証するテストを追加

## 変更ファイル

- `website/playground/client/components/AppLayout.tsx` - 初回レンダリングスキップの削除
- `website/playground/client/components/AppLayout.test.tsx` - 初期プレビュー生成テストの追加、旧仕様コメントの修正

## テスト計画

- [x] ESLint パス
- [x] Prettier フォーマットチェックパス
- [x] TypeScript 型チェックパス
- [x] AppLayout テスト全15件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)