### PR TITLE
feat: website に Vercel Analytics を導入

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from "@vercel/analytics/next";
 import type { Metadata } from "next";
 import { Head } from "nextra/components";
 import { siteDescription, siteName, siteUrl } from "./siteConfig";
@@ -31,7 +32,10 @@ export default function RootLayout({
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
       <Head />
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
         "@codemirror/view": "^6.39.15",
         "@hirokisakabe/pom": "^5.2.0",
         "@hono/zod-validator": "^0.7.6",
+        "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "codemirror": "^6.0.2",
@@ -5828,6 +5829,48 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "@codemirror/view": "^6.39.15",
     "@hirokisakabe/pom": "^5.2.0",
     "@hono/zod-validator": "^0.7.6",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.2",


### PR DESCRIPTION
## Summary
- website の Next.js アプリに `@vercel/analytics` を導入
- ルートレイアウト (`website/app/layout.tsx`) に `<Analytics />` コンポーネントを追加
- Vercel にデプロイされた際に、ページビューなどのアクセス解析が自動的に収集されるようになる

## Test plan
- [x] ESLint 通過
- [x] TypeScript 型チェック通過
- [x] 既存テスト全通過 (65 tests)
- [ ] Vercel デプロイ後に Analytics ダッシュボードでデータ収集を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)