### PR TITLE
fix: Release ワークフローから website バージョン更新を削除し Dependabot に委譲

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@hirokisakabe/pom"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,3 @@ jobs:
         run: npx changeset publish
         env:
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Update pom version in website
-        if: steps.changesets-check.outputs.has_changesets == 'false'
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          cd website
-          npm install @hirokisakabe/pom@$VERSION
-          if ! git diff --quiet -- package.json package-lock.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add package.json package-lock.json
-            git commit -m "chore: update @hirokisakabe/pom to v$VERSION [skip ci]"
-            git push origin HEAD:main
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
close #376

## Summary

- `release.yml` から「Update pom version in website」ステップを削除
- `.github/dependabot.yml` を新規作成し、`@hirokisakabe/pom` の更新を Dependabot に委譲

## 背景

npm publish 直後（約1秒後）に `npm install @hirokisakabe/pom@<version>` を実行しており、レジストリ伝播が間に合わず `ETARGET` エラーで失敗するケースがあった。

## 変更内容

### `release.yml`
- publish 後に website の依存バージョンを直接更新・push するステップを削除

### `.github/dependabot.yml`（新規）
- `@hirokisakabe/pom` のみを対象に、daily スケジュールで `/website` ディレクトリの依存更新 PR を自動作成する設定

## 期待される効果

- レジストリ伝播遅延による CI 失敗が解消される
- リリースワークフローがシンプルになる
- website の依存更新が PR ベースになり、変更の追跡・レビューが可能になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)