### PR TITLE
feat: website pom バージョン更新を分離ワークフローに移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,3 @@ jobs:
         run: npx changeset publish
         env:
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Update pom version in website
-        if: steps.changesets-check.outputs.has_changesets == 'false'
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          cd website
-          npm install @hirokisakabe/pom@$VERSION
-          if ! git diff --quiet -- package.json package-lock.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add package.json package-lock.json
-            git commit -m "chore: update @hirokisakabe/pom to v$VERSION [skip ci]"
-            git push origin HEAD:main
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-website-pom.yml
+++ b/.github/workflows/update-website-pom.yml
@@ -1,0 +1,56 @@
+name: Update website pom version
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Get published version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for npm registry propagation
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          for i in $(seq 1 30); do
+            if npm view @hirokisakabe/pom@$VERSION version 2>/dev/null; then
+              echo "Version $VERSION is available on npm registry"
+              exit 0
+            fi
+            echo "Attempt $i: version $VERSION not yet available, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Version $VERSION not available after 5 minutes"
+          exit 1
+
+      - name: Update pom version in website
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          cd website
+          npm install @hirokisakabe/pom@$VERSION
+          if ! git diff --quiet -- package.json package-lock.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add package.json package-lock.json
+            git commit -m "chore: update @hirokisakabe/pom to v$VERSION [skip ci]"
+            git push origin HEAD:main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
close #376

## 概要

- `release.yml` から「Update pom version in website」ステップを削除
- 新規ワークフロー `update-website-pom.yml` を作成し、`workflow_run` トリガーで Release 完了後に起動
- npm レジストリ伝播待ち（最大5分、10秒間隔リトライ）を追加
- `concurrency` 設定で並列実行を抑止
- `ref: github.event.workflow_run.head_sha` で Release 実行コミットに固定

## テスト計画

- [ ] `release.yml` から website 更新ステップが削除されていることを確認
- [ ] `update-website-pom.yml` が `workflow_run` トリガーで正しく定義されていることを確認
- [ ] Release ワークフロー成功時のみ実行される条件 (`conclusion == 'success'`) を確認
- [ ] npm レジストリ伝播待ちのリトライロジックを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)