### PR TITLE
ci: actionlint による GitHub Actions workflow 構文検証 CI を追加

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1
+      - uses: rhysd/actionlint@v1.7.11


### PR DESCRIPTION
close #380

## 概要
- actionlint を使った GitHub Actions workflow の構文検証 CI を追加
- `.github/workflows/**` の変更時に `reviewdog/action-actionlint` で構文チェックを実行する

## テスト計画
- [ ] `.github/workflows/` 配下のファイル変更時に CI が起動することを確認
- [ ] actionlint が正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)