### PR TITLE
fix: website/ に変更がない PR の Vercel デプロイをスキップ

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./"
+}


### PR DESCRIPTION
close #384

## Summary

- `website/vercel.json` に `ignoreCommand` を追加し、website/ 配下に変更がない PR ではプレビューデプロイをスキップするようにした
- Hobby プランのデプロイ回数上限（100回/日）による rate limit エラーを回避する

## Test plan

- [ ] website/ 配下に変更がある PR でデプロイが実行されることを確認
- [ ] website/ 配下に変更がない PR でデプロイがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)