### PR TITLE
fix: docs-site CI ビルドの Next.js workspace root 警告を解消

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -1,3 +1,5 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import nextra from "nextra";
 
 const withNextra = nextra({});
@@ -7,5 +9,6 @@ export default withNextra({
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: dirname(fileURLToPath(import.meta.url)),
   serverExternalPackages: ["@resvg/resvg-js", "@hirokisakabe/pom"],
 });


### PR DESCRIPTION
close #388

## Summary

- `website/next.config.mjs` に `outputFileTracingRoot` を設定し、複数 lockfile による Next.js の workspace root 推測警告を解消

## 変更内容

ルートディレクトリと `website/` の両方に `package-lock.json` が存在するため、`next build` 時に以下の警告が出ていた：

```
⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
```

`outputFileTracingRoot` に `website/` ディレクトリ自身を明示的に設定することで警告を抑制する。

## Test plan

- [x] `website/` で `next build` を実行し、workspace root 警告が出ないことを確認済み
- [ ] CI の docs-site ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)