### PR TITLE
fix: Vercel の ignoreCommand がマージコミットで意図しないビルドスキップを起こす問題を修正

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,3 +1,0 @@
-{
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./"
-}


### PR DESCRIPTION
close #400

## Summary

- `website/vercel.json` の `ignoreCommand` を削除
- Vercel UI の Ignored Build Step ディレクトリフィルタで代替済み

## 背景

`ignoreCommand` の `git diff --quiet HEAD^ HEAD -- ./` は、マージコミット時に `HEAD^` が第1親（main 側の直前コミット）を指すため、`website/` の変更が正しく検出されずビルドがスキップされるケースがあった。

## Test plan

- [ ] Vercel の Ignored Build Step が UI で正しく設定されていることを確認
- [ ] `website/` を変更する PR のマージ後、Vercel ビルドが正常にトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)