### PR TITLE
fix: Vercel の ignoreCommand がマージコミットで意図しないビルドスキップを起こす問題を修正

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then base=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$base\" HEAD^2 -- ./; else git diff --quiet HEAD^ HEAD -- ./; fi"
+}


### PR DESCRIPTION
close #400

## Summary

- `website/vercel.json` の `ignoreCommand` をマージコミット対応に改善
- マージコミット時は `merge-base(HEAD^1, HEAD^2)` と `HEAD^2` を比較し、PR ブランチが `website/` を変更したかを正確に判定
- 非マージコミット時は従来通り `HEAD^` vs `HEAD` を比較

## 背景

旧コマンド `git diff --quiet HEAD^ HEAD -- ./` は、マージコミット時に `HEAD^`（第1親 = main 側）と比較するため、`website/` の変更が正しく検出されずビルドがスキップされるケースがあった。

## 補足

Vercel UI の Ignored Build Step 設定が有効な場合はそちらが優先されるため、UI 側の設定を削除する必要があります。

## Test plan

- [ ] Vercel UI の Ignored Build Step 設定を削除する
- [ ] `website/` を変更する PR のマージ後、Vercel ビルドが正常にトリガーされることを確認
- [ ] `website/` を変更しない PR のマージ後、Vercel ビルドがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)