### PR TITLE
feat: CI にベンチマークを統合する

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -1,0 +1,104 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # --- PR: ベースライン復元 ---
+      - name: Restore baseline from cache
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: bench-results.json
+          key: bench-baseline-main-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            bench-baseline-main-
+
+      - name: Prepare baseline
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -f bench-results.json ]; then
+            mv bench-results.json bench-baseline.json
+            echo "BASELINE_EXISTS=true" >> "$GITHUB_ENV"
+          else
+            echo "BASELINE_EXISTS=false" >> "$GITHUB_ENV"
+          fi
+
+      # --- ベンチマーク実行 ---
+      - name: Run benchmarks (with comparison)
+        if: env.BASELINE_EXISTS == 'true'
+        run: npx vitest bench --compare bench-baseline.json --outputJson bench-results.json
+
+      - name: Run benchmarks
+        if: env.BASELINE_EXISTS != 'true'
+        run: npx vitest bench --outputJson bench-results.json
+
+      # --- main: キャッシュ保存 ---
+      - name: Save baseline to cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: bench-results.json
+          key: bench-baseline-main-${{ github.sha }}
+
+      # --- PR: コメント投稿 ---
+      - name: Generate benchmark comment
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "$BASELINE_EXISTS" = "true" ]; then
+            npx tsx scripts/format-bench-comment.ts bench-results.json bench-baseline.json > bench-comment.md
+          else
+            npx tsx scripts/format-bench-comment.ts bench-results.json > bench-comment.md
+          fi
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('bench-comment.md', 'utf-8');
+            const marker = '<!-- benchmark-comment -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            const fullBody = marker + '\n' + body;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }

--- a/bench/buildPptx.bench.ts
+++ b/bench/buildPptx.bench.ts
@@ -1,0 +1,196 @@
+import { bench, describe } from "vitest";
+
+import { buildPptx } from "../src/buildPptx.ts";
+import { createBuildContext } from "../src/buildContext.ts";
+import { calcYogaLayout } from "../src/calcYogaLayout/calcYogaLayout.ts";
+import { measureText } from "../src/calcYogaLayout/measureText.ts";
+import { parseXml } from "../src/parseXml/parseXml.ts";
+import { freeYogaTree } from "../src/shared/freeYogaTree.ts";
+
+// ---------------------------------------------------------------------------
+// Test XML fixtures
+// ---------------------------------------------------------------------------
+
+const simpleXml = `
+<VStack w="100%" h="max" padding="48" gap="20" alignItems="stretch">
+  <Text fontSize="28" bold="true">Simple Slide</Text>
+  <Text fontSize="16">Hello World</Text>
+</VStack>
+`;
+
+const complexXml = `
+<VStack w="100%" h="max" padding="48" gap="16" alignItems="stretch">
+  <Text fontSize="28" bold="true">Complex Slide</Text>
+  <HStack gap="16" alignItems="stretch">
+    <VStack gap="8">
+      <Text fontSize="14" bold="true">Section A</Text>
+      <Ul fontSize="12">
+        <Li>Item 1 with some longer text content</Li>
+        <Li>Item 2 with even more detailed description</Li>
+        <Li>Item 3</Li>
+      </Ul>
+    </VStack>
+    <VStack gap="8">
+      <Text fontSize="14" bold="true">Section B</Text>
+      <Table defaultRowHeight="32">
+        <TableColumn width="100" />
+        <TableColumn width="100" />
+        <TableColumn width="100" />
+        <TableRow>
+          <TableCell fontSize="11" bold="true">Header 1</TableCell>
+          <TableCell fontSize="11" bold="true">Header 2</TableCell>
+          <TableCell fontSize="11" bold="true">Header 3</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell fontSize="11">Cell A1</TableCell>
+          <TableCell fontSize="11">Cell A2</TableCell>
+          <TableCell fontSize="11">Cell A3</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell fontSize="11">Cell B1</TableCell>
+          <TableCell fontSize="11">Cell B2</TableCell>
+          <TableCell fontSize="11">Cell B3</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell fontSize="11">Cell C1</TableCell>
+          <TableCell fontSize="11">Cell C2</TableCell>
+          <TableCell fontSize="11">Cell C3</TableCell>
+        </TableRow>
+      </Table>
+    </VStack>
+  </HStack>
+  <HStack gap="12">
+    <Shape shapeType="rect" w="120" h="60" fill.color="4472C4" />
+    <Shape shapeType="ellipse" w="120" h="60" fill.color="ED7D31" />
+    <Shape shapeType="roundRect" w="120" h="60" fill.color="70AD47" />
+  </HStack>
+</VStack>
+`;
+
+const multiSlideXml = Array.from(
+  { length: 10 },
+  (_, i) => `
+<VStack w="100%" h="max" padding="48" gap="16" alignItems="stretch">
+  <Text fontSize="24" bold="true">Slide ${i + 1}</Text>
+  <HStack gap="16" alignItems="stretch">
+    <VStack gap="8">
+      <Text fontSize="14">Content block A for slide ${i + 1}</Text>
+      <Text fontSize="12">Additional details and description text here</Text>
+    </VStack>
+    <VStack gap="8">
+      <Text fontSize="14">Content block B for slide ${i + 1}</Text>
+      <Shape shapeType="rect" w="200" h="100" fill.color="4472C4" />
+    </VStack>
+  </HStack>
+</VStack>
+`,
+).join("\n");
+
+const slideSize = { w: 1280, h: 720 };
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+describe("buildPptx E2E", () => {
+  bench("simple slide (text only)", async () => {
+    await buildPptx(simpleXml, slideSize);
+  });
+
+  bench(
+    "complex slide (text + table + shapes)",
+    async () => {
+      await buildPptx(complexXml, slideSize);
+    },
+    { time: 5000 },
+  );
+
+  bench(
+    "10 slides",
+    async () => {
+      await buildPptx(multiSlideXml, slideSize);
+    },
+    { time: 5000 },
+  );
+});
+
+describe("parseXml", () => {
+  bench("parse simple XML", () => {
+    parseXml(simpleXml);
+  });
+
+  bench(
+    "parse complex XML",
+    () => {
+      parseXml(complexXml);
+    },
+    { time: 5000 },
+  );
+
+  bench(
+    "parse 10 slides XML",
+    () => {
+      parseXml(multiSlideXml);
+    },
+    { time: 5000 },
+  );
+});
+
+describe("calcYogaLayout", () => {
+  bench("layout simple slide", async () => {
+    const nodes = parseXml(simpleXml);
+    const ctx = createBuildContext("opentype");
+    for (const node of nodes) {
+      try {
+        await calcYogaLayout(node, slideSize, ctx);
+      } finally {
+        freeYogaTree(node);
+      }
+    }
+  });
+
+  bench(
+    "layout complex slide",
+    async () => {
+      const nodes = parseXml(complexXml);
+      const ctx = createBuildContext("opentype");
+      for (const node of nodes) {
+        try {
+          await calcYogaLayout(node, slideSize, ctx);
+        } finally {
+          freeYogaTree(node);
+        }
+      }
+    },
+    { time: 5000 },
+  );
+});
+
+describe("measureText (opentype)", () => {
+  bench("short text", () => {
+    measureText(
+      "Hello World",
+      500,
+      { fontFamily: "Noto Sans JP", fontSizePx: 16 },
+      "opentype",
+    );
+  });
+
+  bench("long text with wrapping", () => {
+    measureText(
+      "This is a longer piece of text that should require line wrapping when measured against a narrow container width",
+      300,
+      { fontFamily: "Noto Sans JP", fontSizePx: 14 },
+      "opentype",
+    );
+  });
+
+  bench("CJK text", () => {
+    measureText(
+      "これはテスト用の日本語テキストです。レイアウト計算のベンチマークに使用します。",
+      400,
+      { fontFamily: "Noto Sans JP", fontSizePx: 14 },
+      "opentype",
+    );
+  });
+});

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -12,6 +12,7 @@ export default defineConfig([
       "main.ts",
       "vrt/**",
       "preview/**",
+      "bench/**",
       "scripts/docs-images/**",
       "scripts/**",
       "docs/**",

--- a/scripts/format-bench-comment.ts
+++ b/scripts/format-bench-comment.ts
@@ -1,0 +1,158 @@
+/**
+ * vitest bench --outputJson の結果をPRコメント用マークダウンに整形する。
+ *
+ * Usage:
+ *   npx tsx scripts/format-bench-comment.ts <current.json> [baseline.json]
+ *
+ * - baseline.json が指定された場合: 比較テーブルを生成
+ * - baseline.json がない場合: 現在の結果のみ表示
+ */
+import { readFileSync } from "node:fs";
+
+interface VitestBenchmark {
+  name: string;
+  hz: number;
+  rme: number;
+  sampleCount: number;
+}
+
+interface VitestGroup {
+  fullName: string;
+  benchmarks: VitestBenchmark[];
+}
+
+interface VitestFile {
+  filepath: string;
+  groups: VitestGroup[];
+}
+
+interface VitestBenchOutput {
+  files: VitestFile[];
+}
+
+interface FlatBenchmark {
+  suite: string;
+  name: string;
+  hz: number;
+  rme: number;
+  sampleCount: number;
+}
+
+function extractSuiteName(fullName: string): string {
+  const parts = fullName.split(" > ");
+  return parts.length > 1 ? parts.slice(1).join(" > ") : fullName;
+}
+
+function parseBenchOutput(path: string): FlatBenchmark[] {
+  const raw = JSON.parse(readFileSync(path, "utf-8")) as VitestBenchOutput;
+  const results: FlatBenchmark[] = [];
+  for (const file of raw.files) {
+    for (const group of file.groups) {
+      const suite = extractSuiteName(group.fullName);
+      for (const bench of group.benchmarks) {
+        // hz が null のエントリ（実行失敗）はスキップ
+        if (bench.hz == null) continue;
+        results.push({
+          suite,
+          name: bench.name,
+          hz: bench.hz,
+          rme: bench.rme,
+          sampleCount: bench.sampleCount,
+        });
+      }
+    }
+  }
+  return results;
+}
+
+function formatHz(hz: number): string {
+  return hz.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
+function changeStatus(pct: number): string {
+  if (pct <= -20) return ":rotating_light:";
+  if (pct <= -10) return ":warning:";
+  if (pct >= 10) return ":rocket:";
+  return "";
+}
+
+function generateComparisonTable(
+  current: FlatBenchmark[],
+  baseline: FlatBenchmark[],
+): string {
+  const baselineMap = new Map<string, FlatBenchmark>();
+  for (const b of baseline) {
+    baselineMap.set(`${b.suite} > ${b.name}`, b);
+  }
+
+  const lines: string[] = [
+    "## Benchmark Results",
+    "",
+    "| Suite | Benchmark | ops/sec (current) | ops/sec (baseline) | Change | |",
+    "|---|---|---:|---:|---:|---|",
+  ];
+
+  for (const c of current) {
+    const key = `${c.suite} > ${c.name}`;
+    const b = baselineMap.get(key);
+    if (b) {
+      const pct = ((c.hz - b.hz) / b.hz) * 100;
+      const sign = pct >= 0 ? "+" : "";
+      const status = changeStatus(pct);
+      lines.push(
+        `| ${c.suite} | ${c.name} | ${formatHz(c.hz)} | ${formatHz(b.hz)} | ${sign}${pct.toFixed(1)}% | ${status} |`,
+      );
+    } else {
+      lines.push(`| ${c.suite} | ${c.name} | ${formatHz(c.hz)} | - | new | |`);
+    }
+  }
+
+  lines.push(
+    "",
+    "> **Note**: Benchmark results can vary between CI runs due to shared infrastructure. Changes within ±10% are generally noise.",
+  );
+
+  return lines.join("\n");
+}
+
+function generateCurrentOnlyTable(current: FlatBenchmark[]): string {
+  const lines: string[] = [
+    "## Benchmark Results",
+    "",
+    "> :information_source: No baseline data available. Comparison will be available after the first merge to main.",
+    "",
+    "| Suite | Benchmark | ops/sec | ±RME | Samples |",
+    "|---|---|---:|---|---:|",
+  ];
+
+  for (const c of current) {
+    lines.push(
+      `| ${c.suite} | ${c.name} | ${formatHz(c.hz)} | ±${c.rme.toFixed(2)}% | ${c.sampleCount} |`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function main() {
+  const currentPath = process.argv[2];
+  const baselinePath = process.argv[3];
+
+  if (!currentPath) {
+    console.error(
+      "Usage: npx tsx scripts/format-bench-comment.ts <current.json> [baseline.json]",
+    );
+    process.exit(1);
+  }
+
+  const current = parseBenchOutput(currentPath);
+
+  if (baselinePath) {
+    const baseline = parseBenchOutput(baselinePath);
+    console.log(generateComparisonTable(current, baseline));
+  } else {
+    console.log(generateCurrentOnlyTable(current));
+  }
+}
+
+main();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       reporter: ["text", "html", "json", "json-summary"],
     },
+    benchmark: {
+      include: ["bench/**/*.bench.ts"],
+    },
   },
 });


### PR DESCRIPTION
close #373

## Summary

- `bench/buildPptx.bench.ts` にベンチマークファイルを作成（`vitest bench` を使用）
  - `buildPptx` E2E（XML → PPTX 生成）
  - `calcYogaLayout`（レイアウト計算単体）
  - `parseXml`（パース単体）
  - テキスト計測（opentype.js）
- `vitest.config.ts` にベンチマーク設定を追加
- `.github/workflows/ci-benchmark.yml` にベンチマーク用 GitHub Actions ワークフローを追加
  - main push 時: ベンチマーク結果（`bench-results.json`）をキャッシュに保存
  - PR 時: `--compare` でベースラインと比較し、結果を PR にコメント投稿
- `scripts/format-bench-comment.ts` にベンチマーク結果の整形スクリプトを作成

## Test plan

- [x] `npx vitest bench --run` で全ベンチマーク（11項目）が正常に完了することを確認
- [x] `--outputJson` で JSON 出力が正常に生成されることを確認
- [x] `scripts/format-bench-comment.ts` でマークダウンテーブルが正常に生成されることを確認
- [x] `npm run lint` / `npm run fmt:check` / `npm run typecheck` / `npm run knip` が全てパス
- [x] `npm run test:run` で既存テスト（217件）が全てパス
- [ ] CI ワークフローが PR 上で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)