### PR TITLE
fix: ignoreCommand で docs/ の変更も検出対象に追加

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then base=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$base\" HEAD^2 -- ./; else git diff --quiet HEAD^ HEAD -- ./; fi"
+  "ignoreCommand": "if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then base=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$base\" HEAD^2 -- ./ ../docs/; else git diff --quiet HEAD^ HEAD -- ./ ../docs/; fi"
 }


### PR DESCRIPTION
close #406

## Summary

- Vercel の `ignoreCommand` の pathspec に `../docs/` を追加し、`docs/` ディレクトリの変更でもビルドがトリガーされるように修正
- 通常コミット・マージコミット両方の `git diff` パスに対応

## Background

`docs/` はリポジトリルートにあり、`website/content` からシンボリックリンクで参照されている（Single Source of Truth）。しかし `ignoreCommand` が `-- ./` のみをチェックしていたため、`docs/` の変更が Vercel ビルドをトリガーせず、ドキュメント更新がデプロイされない問題があった（#403 で発覚）。

## Test plan

- [ ] `docs/` のみを変更した PR で Vercel ビルドがスキップされないことを確認
- [ ] `website/` の変更でも従来通りビルドがトリガーされることを確認
- [ ] `src/` のみの変更ではビルドがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)