### PR TITLE
refactor: toPositioned を Yoga ランタイムから分離

### DIFF
--- a/.changeset/dull-glasses-warn.md
+++ b/.changeset/dull-glasses-warn.md
@@ -1,0 +1,4 @@
+---
+---
+
+refactor: toPositioned を Yoga ランタイムから分離し、軽量な LayoutResultMap を使用するように変更

--- a/src/buildPptx.ts
+++ b/src/buildPptx.ts
@@ -3,6 +3,7 @@ import { createBuildContext } from "./buildContext.ts";
 import { calcYogaLayout } from "./calcYogaLayout/calcYogaLayout.ts";
 import type { TextMeasurementMode } from "./calcYogaLayout/measureText.ts";
 import type { YogaNodeMap } from "./calcYogaLayout/types.ts";
+import { extractLayoutResults } from "./calcYogaLayout/types.ts";
 import { parseXml } from "./parseXml/parseXml.ts";
 import { renderPptx } from "./renderPptx/renderPptx.ts";
 import { freeYogaTree } from "./shared/freeYogaTree.ts";
@@ -33,7 +34,8 @@ export async function buildPptx(
       } else {
         map = await calcYogaLayout(node, slideSize, ctx);
       }
-      const positioned = toPositioned(node, ctx, map);
+      const layoutMap = extractLayoutResults(map);
+      const positioned = toPositioned(node, ctx, layoutMap);
       positionedPages.push(positioned);
     } finally {
       if (map) freeYogaTree(map);

--- a/src/calcYogaLayout/types.ts
+++ b/src/calcYogaLayout/types.ts
@@ -3,3 +3,29 @@ import type { POMNode } from "../types.ts";
 
 /** POMNode と対応する YogaNode のマッピング。レイアウト計算フェーズでのみ存在する */
 export type YogaNodeMap = Map<POMNode, YogaNode>;
+
+/** Yoga 計算結果の軽量表現。Yoga ランタイムへの依存なし */
+export interface LayoutResult {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** POMNode と計算済みレイアウト結果のマッピング */
+export type LayoutResultMap = Map<POMNode, LayoutResult>;
+
+/** YogaNodeMap から計算済みレイアウト結果を抽出する */
+export function extractLayoutResults(yogaMap: YogaNodeMap): LayoutResultMap {
+  const layoutMap: LayoutResultMap = new Map();
+  for (const [pomNode, yogaNode] of yogaMap) {
+    const computed = yogaNode.getComputedLayout();
+    layoutMap.set(pomNode, {
+      left: computed.left,
+      top: computed.top,
+      width: computed.width,
+      height: computed.height,
+    });
+  }
+  return layoutMap;
+}

--- a/src/registry/definitions/layer.ts
+++ b/src/registry/definitions/layer.ts
@@ -48,11 +48,10 @@ export const layerNodeDef: NodeDefinition = {
         }
 
         // その他のノードは通常の処理
-        const childYogaNode = map.get(child);
-        if (!childYogaNode) {
-          throw new Error("YogaNode not found in map for layer child");
+        const childLayout = map.get(child);
+        if (!childLayout) {
+          throw new Error("Layout result not found in map for layer child");
         }
-        const childLayout = childYogaNode.getComputedLayout();
         const adjustedParentX = absoluteX + childX - childLayout.left;
         const adjustedParentY = absoluteY + childY - childLayout.top;
 

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -3,7 +3,7 @@ import type { Node as YogaNode } from "yoga-layout";
 import type { RenderContext } from "../renderPptx/types.ts";
 import type { loadYoga } from "yoga-layout/load";
 import type { BuildContext } from "../buildContext.ts";
-import type { YogaNodeMap } from "../calcYogaLayout/types.ts";
+import type { LayoutResultMap } from "../calcYogaLayout/types.ts";
 
 export type Yoga = Awaited<ReturnType<typeof loadYoga>>;
 
@@ -36,7 +36,7 @@ export interface NodeDefinition {
     absoluteY: number,
     layout: { width: number; height: number },
     ctx: BuildContext,
-    map: YogaNodeMap,
+    map: LayoutResultMap,
   ) => PositionedNode;
 
   /** PositionedNode をスライドにレンダリングする（リーフノード用） */

--- a/src/toPositioned/toPositioned.ts
+++ b/src/toPositioned/toPositioned.ts
@@ -1,13 +1,13 @@
 import type { POMNode, PositionedNode } from "../types.ts";
 import type { BuildContext } from "../buildContext.ts";
-import type { YogaNodeMap } from "../calcYogaLayout/types.ts";
+import type { LayoutResultMap } from "../calcYogaLayout/types.ts";
 import { getNodeDef } from "../registry/index.ts";
 
 /**
  * POMNode ツリーを絶対座標付きの PositionedNode ツリーに変換する
  * @param pom 入力 POMNode
  * @param ctx BuildContext
- * @param map YogaNodeMap（POMNode → YogaNode のマッピング）
+ * @param map LayoutResultMap（POMNode → 計算済みレイアウト結果のマッピング）
  * @param parentX 親ノードの絶対X座標
  * @param parentY 親ノードの絶対Y座標
  * @returns PositionedNode ツリー
@@ -15,16 +15,14 @@ import { getNodeDef } from "../registry/index.ts";
 export function toPositioned(
   pom: POMNode,
   ctx: BuildContext,
-  map: YogaNodeMap,
+  map: LayoutResultMap,
   parentX = 0,
   parentY = 0,
 ): PositionedNode {
-  const yogaNode = map.get(pom);
-  if (!yogaNode) {
-    throw new Error("YogaNode not found in map for POMNode");
+  const layout = map.get(pom);
+  if (!layout) {
+    throw new Error("Layout result not found in map for POMNode");
   }
-
-  const layout = yogaNode.getComputedLayout();
   const absoluteX = parentX + layout.left;
   const absoluteY = parentY + layout.top;
 


### PR DESCRIPTION
close #393

## Summary

- `LayoutResult` / `LayoutResultMap` 型を導入し、`toPositioned` が `YogaNode` を直接参照せず計算済みレイアウト結果のみを消費するように変更
- `extractLayoutResults` 関数で `YogaNodeMap` から軽量なレイアウト結果を抽出
- Yoga 依存をレイアウト計算フェーズ (`calcYogaLayout` / `autoFit`) に閉じ込め、後段パイプラインの疎結合化を実現

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/calcYogaLayout/types.ts` | `LayoutResult`, `LayoutResultMap` 型と `extractLayoutResults` 関数を追加 |
| `src/registry/types.ts` | `NodeDefinition.toPositioned` の `map` パラメータを `LayoutResultMap` に変更 |
| `src/toPositioned/toPositioned.ts` | `YogaNodeMap` → `LayoutResultMap` に移行 |
| `src/registry/definitions/layer.ts` | `yogaNode.getComputedLayout()` の直接呼び出しを `LayoutResultMap` に置換 |
| `src/buildPptx.ts` | `extractLayoutResults` で変換してから `toPositioned` に渡すように変更 |

## Test plan

- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm run fmt:check` 成功
- [x] `npm run knip` 成功
- [x] `npm run test:run` 成功 (10 files / 217 tests passed)
- [x] Codex レビュー: critical 0 / warning 0 / info 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)