### PR TITLE
docs: ドキュメントサイトの記述ミスを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - **AI Friendly** — Simple XML structure designed for LLM code generation. Include [llm.txt](./website/public/llm.txt) in your system prompt for XML reference. Also available at `https://pom.pptx.app/llm.txt`.
 - **Declarative** — Describe slides as XML. No imperative API calls needed.
 - **Flexible Layout** — Flexbox-style layout with VStack / HStack / Box, powered by yoga-layout.
-- **Rich Nodes** — 15 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
+- **Rich Nodes** — 19 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
 - **Schema-validated** — XML input is validated with Zod schemas at runtime with clear error messages.
 - **PowerPoint Native** — Full access to native PowerPoint shape features (roundRect, ellipse, arrows, etc.).
 - **Pixel Units** — Intuitive pixel-based sizing (internally converted to inches at 96 DPI).
@@ -89,6 +89,7 @@ await pptx.writeFile({ fileName: "presentation.pptx" });
 | Box          | Container for single child with padding        |
 | VStack       | Vertical stack layout                          |
 | HStack       | Horizontal stack layout                        |
+| Icon         | Lucide icons                                   |
 
 For detailed node documentation, see [Nodes](./docs/nodes.md).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,7 +11,7 @@
 - **AI Friendly** — Simple XML structure suited for LLM code generation
 - **Declarative** — Describe slides in XML. No imperative API calls needed
 - **Flexible Layout** — Flexbox-style layout powered by yoga-layout (VStack / HStack / Box)
-- **Rich Nodes** — 15 built-in node types: charts, flowcharts, tables, timelines, and more
+- **Rich Nodes** — 19 built-in node types: charts, flowcharts, tables, timelines, and more
 - **Schema-validated** — Runtime validation with Zod schemas
 - **PowerPoint Native** — Full use of native PowerPoint shape features
 - **Pixel Units** — Intuitive pixel-based sizing (internally converted to inches at 96 DPI)

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -803,7 +803,9 @@ A node for displaying preset icons from the Lucide icon library. Icons are rende
 | `variant` | `circle-filled`, `circle-outlined`, `square-filled`, `square-outlined`      |
 | `bgColor` | hex color for the background shape (default: `#E0E0E0` when variant is set) |
 
-**Available Icons (47):**
+All [Lucide icons](https://lucide.dev/icons/) are available. Below are common examples:
+
+**Common Icons (49):**
 
 | Category      | Icons                                                                          |
 | ------------- | ------------------------------------------------------------------------------ |


### PR DESCRIPTION
close #421

## Summary

- ノード数の記載を「15」から「19」に修正（README.md, docs/index.mdx）
- README.md の Available Nodes テーブルに Icon ノードを追加
- アイコン数を「47」から「49」に修正し、全 Lucide アイコンが利用可能であることを明記（docs/nodes.md）

## Test plan

- [ ] README.md のノード数が「19」になっていること
- [ ] docs/index.mdx のノード数が「19」になっていること
- [ ] README.md の Available Nodes テーブルに Icon が含まれていること
- [ ] docs/nodes.md のアイコン数が「49」になっていること
- [ ] docs/nodes.md に全 Lucide アイコンが利用可能であることが記載されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)