### PR TITLE
fix: website の buildPptx 呼び出しを新しい API に追従

### DIFF
--- a/website/playground/server/convertXmlToPptx.ts
+++ b/website/playground/server/convertXmlToPptx.ts
@@ -4,7 +4,7 @@ const SLIDE_WIDTH = 1280;
 const SLIDE_HEIGHT = 720;
 
 export async function convertXmlToPptx(xml: string): Promise<ArrayBuffer> {
-  const pptx = await buildPptx(xml, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT });
+  const { pptx } = await buildPptx(xml, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT });
   const buffer = await pptx.write({
     outputType: "uint8array",
   });

--- a/website/playground/server/convertXmlToPreview.ts
+++ b/website/playground/server/convertXmlToPreview.ts
@@ -7,7 +7,7 @@ const SLIDE_HEIGHT = 720;
 export async function convertXmlToPreview(
   xml: string,
 ): Promise<{ svgs: string[] }> {
-  const pptx = await buildPptx(xml, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT });
+  const { pptx } = await buildPptx(xml, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT });
   const buffer = await pptx.write({
     outputType: "uint8array",
   });


### PR DESCRIPTION
## Summary
- `buildPptx` の戻り値が `BuildPptxResult` (`{ pptx, diagnostics }`) に変更されたことに伴い、website 側の呼び出し箇所を分割代入に修正
- 対象ファイル: `convertXmlToPptx.ts`, `convertXmlToPreview.ts`

## Test plan
- [x] `npm run build` (ルート) 成功
- [x] `npm run build` (website) 成功
- [x] `npm run lint` / `npm run fmt:check` 成功
- [x] website テスト (`convertXmlToPptx.test.ts`, `hono.test.ts`) 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)