### PR TITLE
fix: ci-build の paths フィルターを拡張して関連変更の取りこぼしを防止

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,6 +5,14 @@ on:
     branches: ["main"]
     paths:
       - "src/**"
+      - "scripts/**"
+      - "vrt/**"
+      - "preview/**"
+      - "bench/**"
+      - "docs/**/*.md"
+      - "docs/**/*.mdx"
+      - "docs/**/_meta.ts"
+      - "*.md"
       - "package.json"
       - "package-lock.json"
       - "tsconfig.json"
@@ -18,6 +26,14 @@ on:
     branches: ["main"]
     paths:
       - "src/**"
+      - "scripts/**"
+      - "vrt/**"
+      - "preview/**"
+      - "bench/**"
+      - "docs/**/*.md"
+      - "docs/**/*.mdx"
+      - "docs/**/_meta.ts"
+      - "*.md"
       - "package.json"
       - "package-lock.json"
       - "tsconfig.json"


### PR DESCRIPTION
close #397

## Summary

- `ci-build` ワークフローの `paths` フィルターを拡張し、ビルド・lint・typecheck・knip・テスト・prettier に影響するファイル変更を漏れなくトリガーするようにした

## 追加したパス

| パス | トリガー理由 |
|---|---|
| `scripts/**` | knip の entry/project、prettier、typecheck (docs-images) |
| `vrt/**` | knip の project、prettier、typecheck |
| `preview/**` | knip の project、prettier、typecheck |
| `bench/**` | prettier |
| `docs/**/*.md`, `docs/**/*.mdx`, `docs/**/_meta.ts` | prettier（画像等のアセットは除外） |
| `*.md` | prettier（ルート直下の README.md, CHANGELOG.md 等） |

## 設計判断

- `docs/**` は画像ファイル等を含むため、CI に影響するテキストファイルのみに絞った（`*.md`, `*.mdx`, `_meta.ts`）
- `website/**` は knip で ignore されており tsconfig にも含まれないため、引き続き除外
- `sample_images/**` は CI ステップに影響しないため除外

## Test plan

- [ ] `ci-build` ワークフローが正常に実行されることを確認
- [ ] 追加したパスのファイル変更で CI がトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)