### PR TITLE
fix: Text/Ul/Ol の計測フォントを描画フォントに一致させる

### DIFF
--- a/.changeset/ready-ads-enjoy.md
+++ b/.changeset/ready-ads-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+Text/Ul/Ol のレイアウト計測時に fontFamily を反映し、描画フォントとの乖離を削減

--- a/docs/text-measurement.md
+++ b/docs/text-measurement.md
@@ -22,7 +22,24 @@ const { pptx } = await buildPptx(
 | `"fallback"` | Always use fallback calculation (CJK characters = 1em, alphanumeric = 0.5em estimated) |
 | `"auto"`     | Use opentype.js (same as "opentype", default)                                          |
 
+## Font Resolution Rules
+
+pom resolves the measurement method based on the `fontFamily` specified on each node:
+
+1. **Bundled font (`Noto Sans JP`)**: Uses opentype.js for accurate glyph-level measurement. This is the default when no `fontFamily` is specified.
+2. **Non-bundled fonts** (e.g., `Arial`, `Meiryo`): Automatically falls back to heuristic estimation (CJK characters = 1em, alphanumeric = 0.5em). This ensures layout does not use mismatched font metrics.
+3. **`textMeasurement: "fallback"`**: Forces heuristic estimation regardless of font family.
+
+### Why this matters
+
+Previously, layout measurement always used Noto Sans JP metrics even when a different `fontFamily` was specified for rendering. This caused layout misalignment because the measured widths did not match the rendered widths. Now, when a non-bundled font is specified, pom uses a font-independent heuristic instead, reducing the mismatch.
+
+### Supported nodes
+
+Font resolution applies consistently to all text-bearing nodes: `Text`, `Ul`, `Ol`, and `Shape`.
+
 ## Recommended Settings
 
 - **All environments**: Default (`"auto"`) works fine - bundled fonts ensure consistent results
 - **Reduced bundle size**: Use `"fallback"` if you want to avoid loading bundled fonts (less accurate but smaller bundle)
+- **Custom fonts**: When using `fontFamily` other than `Noto Sans JP`, pom automatically uses fallback measurement to avoid metric mismatch

--- a/src/calcYogaLayout/fontLoader.test.ts
+++ b/src/calcYogaLayout/fontLoader.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isBundledFont } from "./fontLoader.ts";
+
+describe("isBundledFont", () => {
+  it("Noto Sans JP はバンドル済みフォントと判定される", () => {
+    expect(isBundledFont("Noto Sans JP")).toBe(true);
+  });
+
+  it("Arial はバンドル外フォントと判定される", () => {
+    expect(isBundledFont("Arial")).toBe(false);
+  });
+
+  it("空文字はバンドル外フォントと判定される", () => {
+    expect(isBundledFont("")).toBe(false);
+  });
+});

--- a/src/calcYogaLayout/fontLoader.ts
+++ b/src/calcYogaLayout/fontLoader.ts
@@ -60,6 +60,16 @@ function getFont(weight: "normal" | "bold"): Font {
   return font;
 }
 
+/** バンドル済みフォント名の一覧 */
+const BUNDLED_FONT_NAMES = new Set(["Noto Sans JP"]);
+
+/**
+ * 指定されたフォントがバンドル済みかどうかを判定する
+ */
+export function isBundledFont(fontFamily: string): boolean {
+  return BUNDLED_FONT_NAMES.has(fontFamily);
+}
+
 /**
  * 指定したテキストの幅を計測する
  * @param text 計測するテキスト

--- a/src/calcYogaLayout/measureText.test.ts
+++ b/src/calcYogaLayout/measureText.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { measureText } from "./measureText.ts";
+
+describe("measureText", () => {
+  describe("フォントファミリーによる計測方法の切り替え", () => {
+    const text = "Hello World";
+    const maxWidth = 500;
+
+    it("バンドル済みフォント（Noto Sans JP）では opentype 計測を使用する", () => {
+      const opentypeResult = measureText(text, maxWidth, {
+        fontFamily: "Noto Sans JP",
+        fontSizePx: 24,
+      });
+
+      const fallbackResult = measureText(
+        text,
+        maxWidth,
+        {
+          fontFamily: "Noto Sans JP",
+          fontSizePx: 24,
+        },
+        "fallback",
+      );
+
+      // opentype と fallback で結果が異なることを確認（=opentype が使われている）
+      expect(opentypeResult.widthPx).not.toBe(fallbackResult.widthPx);
+    });
+
+    it("バンドル外フォントではフォールバック計測を使用する", () => {
+      const arialResult = measureText(text, maxWidth, {
+        fontFamily: "Arial",
+        fontSizePx: 24,
+      });
+
+      const fallbackResult = measureText(
+        text,
+        maxWidth,
+        {
+          fontFamily: "Arial",
+          fontSizePx: 24,
+        },
+        "fallback",
+      );
+
+      // バンドル外フォントはフォールバックと同じ結果になる
+      expect(arialResult.widthPx).toBe(fallbackResult.widthPx);
+      expect(arialResult.heightPx).toBe(fallbackResult.heightPx);
+    });
+
+    it("mode=fallback が明示された場合はフォントに関係なくフォールバックを使用する", () => {
+      const result = measureText(
+        text,
+        maxWidth,
+        {
+          fontFamily: "Noto Sans JP",
+          fontSizePx: 24,
+        },
+        "fallback",
+      );
+
+      const fallbackDirect = measureText(
+        text,
+        maxWidth,
+        {
+          fontFamily: "Arial",
+          fontSizePx: 24,
+        },
+        "fallback",
+      );
+
+      // 同じフォールバック計算なので結果は同じ
+      expect(result.widthPx).toBe(fallbackDirect.widthPx);
+    });
+
+    it("mode=opentype が明示された場合はバンドル外フォントでも opentype 計測を使用する", () => {
+      const opentypeForced = measureText(
+        text,
+        maxWidth,
+        {
+          fontFamily: "Arial",
+          fontSizePx: 24,
+        },
+        "opentype",
+      );
+
+      const fallbackResult = measureText(
+        text,
+        maxWidth,
+        {
+          fontFamily: "Arial",
+          fontSizePx: 24,
+        },
+        "fallback",
+      );
+
+      // opentype を強制した場合はフォールバックと異なる結果になる
+      expect(opentypeForced.widthPx).not.toBe(fallbackResult.widthPx);
+    });
+  });
+});

--- a/src/calcYogaLayout/measureText.ts
+++ b/src/calcYogaLayout/measureText.ts
@@ -1,4 +1,7 @@
-import { measureTextWidth as measureTextWidthOpentype } from "./fontLoader.ts";
+import {
+  measureTextWidth as measureTextWidthOpentype,
+  isBundledFont,
+} from "./fontLoader.ts";
 
 type MeasureOptions = {
   fontFamily: string;
@@ -145,6 +148,8 @@ export function measureText(
   heightPx: number;
 } {
   // 計測方法を決定
+  // "opentype" / "fallback" が明示指定された場合はそれを優先
+  // "auto" の場合はバンドル外フォントならフォールバック計測を使用
   const shouldUseFallback = (() => {
     switch (mode) {
       case "opentype":
@@ -152,8 +157,7 @@ export function measureText(
       case "fallback":
         return true;
       case "auto":
-        // opentype.js はバンドルされたフォントを使うため常に利用可能
-        return false;
+        return !isBundledFont(opts.fontFamily);
     }
   })();
 

--- a/src/registry/definitions/list.ts
+++ b/src/registry/definitions/list.ts
@@ -15,7 +15,7 @@ function applyListYogaStyle(
   const n = node as Extract<POMNode, { type: "ul" | "ol" }>;
   const combinedText = n.items.map((item) => item.text).join("\n");
   const fontSizePx = n.fontSize ?? 24;
-  const fontFamily = "Noto Sans JP";
+  const fontFamily = n.fontFamily ?? "Noto Sans JP";
   const fontWeight = n.bold ? "bold" : "normal";
   const spacingMultiple = n.lineHeight ?? 1.3;
 

--- a/src/registry/definitions/text.ts
+++ b/src/registry/definitions/text.ts
@@ -12,7 +12,7 @@ export const textNodeDef: NodeDefinition = {
     const n = node as Extract<POMNode, { type: "text" }>;
     const text = n.text;
     const fontSizePx = n.fontSize ?? 24;
-    const fontFamily = "Noto Sans JP";
+    const fontFamily = n.fontFamily ?? "Noto Sans JP";
     const fontWeight = n.bold ? "bold" : "normal";
     const lineHeight = 1.3;
 


### PR DESCRIPTION
close #309

## Summary

- Text/Ul/Ol ノードのレイアウト計測時に `fontFamily` を反映（従来はハードコードで Noto Sans JP 固定）
- バンドル外フォント（Arial, Meiryo 等）指定時はフォールバック計測を自動適用し、計測/描画の乖離を削減
- `textMeasurement: "opentype"` / `"fallback"` の明示指定は従来通り最優先で動作
- ドキュメント（docs/text-measurement.md）にフォント解決ルールを追記
- ユニットテスト追加（fontLoader.test.ts, measureText.test.ts）

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/registry/definitions/text.ts` | `fontFamily` をノードから取得するよう修正 |
| `src/registry/definitions/list.ts` | 同上（Ul/Ol 共通） |
| `src/calcYogaLayout/measureText.ts` | `auto` モード時にバンドル外フォントでフォールバックを使用 |
| `src/calcYogaLayout/fontLoader.ts` | `isBundledFont()` 関数を追加 |
| `docs/text-measurement.md` | Font Resolution Rules セクションを追加 |
| `src/calcYogaLayout/measureText.test.ts` | フォント切り替えのテスト |
| `src/calcYogaLayout/fontLoader.test.ts` | `isBundledFont` のテスト |

## Test plan

- [x] `npm run test:run` — 228 テスト全通過
- [x] `npm run lint` — エラーなし
- [x] `npm run fmt:check` — フォーマット OK
- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run knip` — 未使用コードなし
- [ ] CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)