### PR TITLE
ci: pom-vscode パッケージの CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci-pom-vscode.yml
+++ b/.github/workflows/ci-pom-vscode.yml
@@ -1,0 +1,58 @@
+name: CI - pom-vscode
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "packages/pom-vscode/**"
+      - "packages/pom-md/**"
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - ".github/workflows/ci-pom-vscode.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/pom-vscode/**"
+      - "packages/pom-md/**"
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - ".github/workflows/ci-pom-vscode.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install and build root package
+        run: |
+          npm ci
+          npm run build
+      - name: Install and build pom-md
+        run: |
+          cd packages/pom-md
+          npm ci
+          npm run build
+      - name: Install pom-vscode dependencies
+        working-directory: packages/pom-vscode
+        run: npm ci
+      - name: Format check
+        working-directory: packages/pom-vscode
+        run: npm run fmt:check
+      - name: Lint
+        working-directory: packages/pom-vscode
+        run: npm run lint
+      - name: Type check
+        working-directory: packages/pom-vscode
+        run: npm run typecheck
+      - name: Build
+        working-directory: packages/pom-vscode
+        run: npm run build


### PR DESCRIPTION
## Summary
- pom-vscode パッケージ用の CI ワークフロー（`ci-pom-vscode.yml`）を新規追加
- fmt:check, lint, typecheck, build を実行
- pom-vscode は root パッケージと pom-md に `file:` 依存しているため、それらのビルドを事前に実行
- トリガーパスに `src/**`, `packages/pom-md/**`, `package.json` 等の上流変更も含め、依存元の変更による破壊を検知可能に

## Test plan
- [ ] CI ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)