### PR TITLE
docs: update ROADMAP.md to reflect pom-vscode monorepo location

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,14 +22,14 @@ Prioritize **authoring formats** first. Execution tooling should support those w
 
 ### Active
 
-| Repository           | Role                        | Notes                                                 |
-| -------------------- | --------------------------- | ----------------------------------------------------- |
-| **pom**              | Core library                | Stable. Layout engine + PPTX generation               |
-| **prompt2pptx**      | AI slide generation app     | Primary AI application — actively developed           |
-| **pptx-glimpse**     | PPTX → SVG/PNG renderer     | Used for preview and VRT                              |
-| **pom-vscode**       | VS Code extension           | Stays as a separate repo (VS Code-specific CI/CD)     |
-| **pom-ai**           | AI chat playground          | Lightweight playground — no further feature expansion |
-| **mcp-pptx-preview** | MCP server for PPTX preview | PPTX preview via MCP                                  |
+| Repository           | Role                        | Notes                                                               |
+| -------------------- | --------------------------- | ------------------------------------------------------------------- |
+| **pom**              | Core library                | Stable. Layout engine + PPTX generation                             |
+| **prompt2pptx**      | AI slide generation app     | Primary AI application — actively developed                         |
+| **pptx-glimpse**     | PPTX → SVG/PNG renderer     | Used for preview and VRT                                            |
+| **pom-vscode**       | VS Code extension           | Monorepo package (`packages/pom-vscode`) with dedicated CI workflow |
+| **pom-ai**           | AI chat playground          | Lightweight playground — no further feature expansion               |
+| **mcp-pptx-preview** | MCP server for PPTX preview | PPTX preview via MCP                                                |
 
 ### Archive candidates
 


### PR DESCRIPTION
close #454

## Summary
- ROADMAP.md の pom-vscode の Notes を実態に合わせて更新
  - 旧: `Stays as a separate repo (VS Code-specific CI/CD)`
  - 新: `Monorepo package (packages/pom-vscode) with dedicated CI workflow`

## Test plan
- [ ] ROADMAP.md の内容が実態と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)