### PR TITLE
refactor: preview.ts のコアロジックを VSCode API 非依存に分離

### DIFF
--- a/packages/pom-vscode/src/generatePreview.ts
+++ b/packages/pom-vscode/src/generatePreview.ts
@@ -1,0 +1,91 @@
+import { parseMd } from "@hirokisakabe/pom-md";
+import { buildPptx } from "@hirokisakabe/pom";
+import { convertPptxToSvg } from "pptx-glimpse";
+
+export const SLIDE_WIDTH = 1280;
+export const SLIDE_HEIGHT = 720;
+
+export type PreviewResult =
+  | { type: "empty" }
+  | { type: "success"; svgs: string[] }
+  | { type: "error"; message: string };
+
+/**
+ * Markdown から SVG プレビューを生成する純粋関数
+ */
+export async function generatePreviewSvg(
+  markdown: string,
+  fontDirs: string[],
+): Promise<PreviewResult> {
+  try {
+    const xml = parseMd(markdown);
+    if (!xml.trim()) {
+      return { type: "empty" };
+    }
+
+    const { pptx } = await buildPptx(
+      xml,
+      { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
+      { textMeasurement: "fallback" },
+    );
+
+    const buffer = await pptx.write({ outputType: "uint8array" });
+    if (!(buffer instanceof Uint8Array)) {
+      throw new Error("Unexpected output type from pptx.write");
+    }
+
+    const slides = await convertPptxToSvg(buffer, {
+      width: SLIDE_WIDTH,
+      fontDirs,
+    });
+    const svgs = slides.map((s: { svg: string }) => s.svg);
+
+    return { type: "success", svgs };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { type: "error", message };
+  }
+}
+
+export function buildHtml(svgs: string[]): string {
+  if (svgs.length === 0) {
+    return `<!DOCTYPE html>
+<html><body style="display:flex;align-items:center;justify-content:center;height:100vh;margin:0;font-family:sans-serif;color:#888;">
+<p>No slides to preview</p>
+</body></html>`;
+  }
+
+  const slideElements = svgs
+    .map(
+      (svg, i) => `
+    <div style="margin-bottom:24px;">
+      <div style="font-size:12px;color:#888;margin-bottom:4px;">Slide ${i + 1}</div>
+      <div style="border:1px solid #ddd;border-radius:4px;overflow:hidden;background:#fff;">
+        ${svg}
+      </div>
+    </div>`,
+    )
+    .join("");
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:16px;background:#f5f5f5;font-family:sans-serif;">
+  ${slideElements}
+</body>
+</html>`;
+}
+
+export function buildErrorHtml(message: string): string {
+  const escaped = message
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  return `<!DOCTYPE html>
+<html><body style="margin:0;padding:16px;font-family:sans-serif;">
+<div style="background:#fee;border:1px solid #fcc;border-radius:4px;padding:12px;color:#c00;">
+  <strong>Error:</strong> ${escaped}
+</div>
+</body></html>`;
+}

--- a/packages/pom-vscode/src/preview.ts
+++ b/packages/pom-vscode/src/preview.ts
@@ -1,11 +1,10 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { parseMd } from "@hirokisakabe/pom-md";
-import { buildPptx } from "@hirokisakabe/pom";
-import { convertPptxToSvg } from "pptx-glimpse";
-
-const SLIDE_WIDTH = 1280;
-const SLIDE_HEIGHT = 720;
+import {
+  generatePreviewSvg,
+  buildHtml,
+  buildErrorHtml,
+} from "./generatePreview.js";
 
 const DEBOUNCE_MS = 500;
 
@@ -77,92 +76,20 @@ export class PomPreviewPanel {
   private async render(markdown: string): Promise<void> {
     const generation = ++this.renderGeneration;
 
-    try {
-      const xml = parseMd(markdown);
-      if (!xml.trim()) {
-        if (generation === this.renderGeneration && !this.disposed) {
-          this.panel.webview.html = buildHtml([]);
-        }
-        return;
-      }
+    const result = await generatePreviewSvg(markdown, this.fontDirs);
 
-      const { pptx } = await buildPptx(
-        xml,
-        {
-          w: SLIDE_WIDTH,
-          h: SLIDE_HEIGHT,
-        },
-        {
-          textMeasurement: "fallback",
-        },
-      );
+    if (generation !== this.renderGeneration || this.disposed) return;
 
-      if (generation !== this.renderGeneration) return;
-
-      const buffer = await pptx.write({ outputType: "uint8array" });
-      if (!(buffer instanceof Uint8Array)) {
-        throw new Error("Unexpected output type from pptx.write");
-      }
-
-      if (generation !== this.renderGeneration) return;
-
-      const slides = await convertPptxToSvg(buffer, {
-        width: SLIDE_WIDTH,
-        fontDirs: this.fontDirs,
-      });
-      const svgs = slides.map((s: { svg: string }) => s.svg);
-
-      if (generation === this.renderGeneration && !this.disposed) {
-        this.panel.webview.html = buildHtml(svgs);
-      }
-    } catch (err: unknown) {
-      if (generation === this.renderGeneration && !this.disposed) {
-        const message = err instanceof Error ? err.message : String(err);
-        this.panel.webview.html = buildErrorHtml(message);
-      }
+    switch (result.type) {
+      case "empty":
+        this.panel.webview.html = buildHtml([]);
+        break;
+      case "success":
+        this.panel.webview.html = buildHtml(result.svgs);
+        break;
+      case "error":
+        this.panel.webview.html = buildErrorHtml(result.message);
+        break;
     }
   }
-}
-
-function buildHtml(svgs: string[]): string {
-  if (svgs.length === 0) {
-    return `<!DOCTYPE html>
-<html><body style="display:flex;align-items:center;justify-content:center;height:100vh;margin:0;font-family:sans-serif;color:#888;">
-<p>No slides to preview</p>
-</body></html>`;
-  }
-
-  const slideElements = svgs
-    .map(
-      (svg, i) => `
-    <div style="margin-bottom:24px;">
-      <div style="font-size:12px;color:#888;margin-bottom:4px;">Slide ${i + 1}</div>
-      <div style="border:1px solid #ddd;border-radius:4px;overflow:hidden;background:#fff;">
-        ${svg}
-      </div>
-    </div>`,
-    )
-    .join("");
-
-  return `<!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"></head>
-<body style="margin:0;padding:16px;background:#f5f5f5;font-family:sans-serif;">
-  ${slideElements}
-</body>
-</html>`;
-}
-
-function buildErrorHtml(message: string): string {
-  const escaped = message
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-
-  return `<!DOCTYPE html>
-<html><body style="margin:0;padding:16px;font-family:sans-serif;">
-<div style="background:#fee;border:1px solid #fcc;border-radius:4px;padding:12px;color:#c00;">
-  <strong>Error:</strong> ${escaped}
-</div>
-</body></html>`;
 }


### PR DESCRIPTION
close #455

## Summary

- `preview.ts` からプレビュー生成のコアロジック（`pom-md → buildPptx → pptx-glimpse → SVG`）を `generatePreview.ts` に純粋関数として抽出
- `generatePreviewSvg(markdown, fontDirs): Promise<PreviewResult>` — Markdown から SVG を生成する VSCode API 非依存の関数
- `buildHtml`, `buildErrorHtml` — HTML 組み立ても同様に分離
- `preview.ts` は VSCode API 依存部分（Webview 操作、debounce、世代管理）のみを担う薄いアダプター層に変更

## 目的

- #456（Vitest によるユニットテスト導入）の前提作業
- AI エージェントが Extension Development Host なしでテスト実行できるようにする

## Test plan

- [ ] Extension Development Host でプレビューが正常に表示されることを確認
- [ ] エディタ変更時にプレビューが更新されることを確認
- [ ] エラー時にエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)