### PR TITLE
docs: アーカイブ完了リポジトリをロードマップに反映

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,16 +31,11 @@ Prioritize **authoring formats** first. Execution tooling should support those w
 | **pom-ai**           | AI chat playground          | Lightweight playground — no further feature expansion               |
 | **mcp-pptx-preview** | MCP server for PPTX preview | PPTX preview via MCP                                                |
 
-### Archive candidates
-
-| Repository         | Reason                                              |
-| ------------------ | --------------------------------------------------- |
-| **pptx-ai-studio** | Development stopped. Superseded by prompt2pptx      |
-| **pptx-ai-editor** | Development stopped. Python-based, unrelated to pom |
-| **pptx-forge**     | Python version of pom — no longer needed            |
-| **pptx-ai**        | Nearly empty (first commit only)                    |
-
 ### Already archived
 
+- **pptx-ai-studio** — development stopped, superseded by prompt2pptx
+- **pptx-ai-editor** — development stopped, Python-based, unrelated to pom
+- **pptx-forge** — Python version of pom, no longer needed
+- **pptx-ai** — nearly empty (first commit only)
 - **pom-playground** — replaced by pom-ai
 - **pptxify** — archived


### PR DESCRIPTION
close #434

## Summary
- ROADMAP.md の「Archive candidates」セクションを削除し、4リポジトリ（pptx-ai-studio, pptx-ai-editor, pptx-forge, pptx-ai）を「Already archived」セクションへ移動
- issue #434 で実施されたアーカイブ整理をドキュメントに反映

## Test plan
- [x] Prettier フォーマットチェック通過
- [x] ROADMAP.md の内容が issue #434 の完了状態と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)