### PR TITLE
fix: knip で packages 配下の誤検出を除外

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,5 +8,5 @@
     "scripts/docs-images/**/*.ts",
     "scripts/**/*.ts"
   ],
-  "ignore": ["website/**"]
+  "ignore": ["website/**", "packages/**"]
 }


### PR DESCRIPTION
close #470

## Summary
- `knip.json` の `ignore` に `packages/**` を追加し、サブパッケージ内のファイルが root の knip スキャンで誤検出される問題を解消
- `packages/pom-vscode/src/generatePreview.test.ts` で報告されていた `@hirokisakabe/pom-md` と `pptx-glimpse` の Unlisted dependencies エラーが解消される

## Test plan
- [x] `npm run knip` が正常に通ることを確認
- [x] `npm run fmt:check` が正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)