### PR TITLE
pom-md: npm publish のリリースワークフロー整備

### DIFF
--- a/.github/workflows/release-pom-md.yml
+++ b/.github/workflows/release-pom-md.yml
@@ -1,0 +1,53 @@
+name: Release - pom-md
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/pom-md/**"
+      - "packages/pom-md/.node-version"
+      - ".github/workflows/release-pom-md.yml"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/pom-md
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: packages/pom-md/.node-version
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
+      - run: npm ci
+      - run: npm run fmt:check
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run test:run
+      - run: npm run build
+
+      - name: Check if version is already published
+        id: version-check
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.published == 'false'
+        run: npm publish --provenance --access public

--- a/packages/pom-md/LICENSE
+++ b/packages/pom-md/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 hirokisakabe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
close #449

## 概要

pom-md (`@hirokisakabe/pom-md`) の npm publish を自動化するリリースワークフローを追加する。

## 変更内容

### 1. `.github/workflows/release-pom-md.yml` の新規作成

pom コアの `release.yml` とは独立したワークフロー。

- **トリガー**: `packages/pom-md/` 配下の変更が main に push された時
- **フロー**: fmt:check → lint → typecheck → test → build → バージョンチェック → publish
- **バージョン管理**: 手動バージョニング + publish-on-version-change 方式
  - `package.json` の version を npm レジストリの公開済みバージョンと比較
  - 未公開バージョンの場合のみ `npm publish` を実行
- **npm provenance**: `--provenance` フラグで署名付き公開
- **concurrency**: 並行実行による publish 競合を防止

### 2. `packages/pom-md/LICENSE` の配置

ルートの MIT LICENSE を pom-md パッケージディレクトリにコピー。`package.json` の `files` フィールドに既に `"LICENSE"` が含まれているため、npm tarball に含まれるようになる。

## テスト計画

- [ ] ワークフロー YAML の構文が正しいことを確認
- [ ] CI が通ることを確認
- [ ] `packages/pom-md/package.json` のバージョンを更新して main に push し、npm publish が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)