### PR TITLE
feat: add release workflow for pom-vscode

### DIFF
--- a/.github/workflows/release-pom-vscode.yml
+++ b/.github/workflows/release-pom-vscode.yml
@@ -71,7 +71,7 @@ jobs:
           PKG_VERSION=$(node -p "require('./package.json').version")
           PUBLISHER=$(node -p "require('./package.json').publisher")
           EXTENSION_ID="${PUBLISHER}.${PKG_NAME}"
-          if vsce show "${EXTENSION_ID}" 2>/dev/null | grep -q "^Version:.*${PKG_VERSION}$"; then
+          if vsce show "${EXTENSION_ID}" 2>/dev/null | grep -Fq "Version: ${PKG_VERSION}"; then
             echo "published=true" >> "$GITHUB_OUTPUT"
           else
             echo "published=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
close #451

## 概要

pom-vscode の VS Code Marketplace への publish を自動化するリリースワークフロー (`release-pom-vscode.yml`) を追加。

## 変更内容

- `release-pom-vscode.yml` を新規作成
  - main ブランチへの push（`packages/pom-vscode/**` 配下の変更）でトリガー
  - ルートパッケージと pom-md のビルド（依存関係）
  - pom-vscode の fmt:check / lint / typecheck / test / build / integration test を実行
  - `vsce show` でバージョンが未公開の場合のみ `vsce publish` を実行
  - `VSCE_PAT` シークレットで認証

## 補足

- pom-md の `release-pom-md.yml` と同様のパターンで独立したワークフロー
- npm publish ではなく VS Code Marketplace への publish（`@vscode/vsce` を使用）

## テストプラン

- [ ] ワークフローの YAML 構文が正しいこと（actionlint 通過済み）
- [ ] `VSCE_PAT` シークレットをリポジトリに設定
- [ ] Marketplace の publisher 登録確認
- [ ] main マージ後にワークフローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)