### PR TITLE
chore(pom-vscode): bump version to 0.1.1

### DIFF
--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pom-vscode",
   "displayName": "pom",
   "description": "Live preview for pom-md presentations",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "hirokisakabe",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- pom-vscode のバージョンを 0.1.0 → 0.1.1 に更新
- main にマージ後、GitHub Actions (`release-pom-vscode.yml`) が自動的に VS Code Marketplace への公開と Git タグ作成を実行

## Test plan
- [ ] CI が通ることを確認
- [ ] マージ後に `release-pom-vscode.yml` ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)