### PR TITLE
fix(pom-vscode): add private: true to exclude from Changesets publish

### DIFF
--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pom-vscode",
+  "private": true,
   "displayName": "pom",
   "description": "Live preview for pom-md presentations",
   "version": "0.1.1",


### PR DESCRIPTION
close #498

## Summary

- `packages/pom-vscode/package.json` に `"private": true` を追加し、Changesets の npm publish 対象から除外
- pom-vscode は VS Code 拡張であり、npm ではなく VS Code Marketplace に publish するため、Changesets の対象にすべきではない
- pom-vscode のリリースは従来通り Git tag 駆動の専用ワークフロー（`release-pom-vscode.yml`）で行う

## Test plan

- [ ] Prettier フォーマットチェック通過を確認済み
- [ ] Changesets の Release ワークフローで pom-vscode が publish 対象から除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)