### PR TITLE
fix: pnpm-workspace.yaml にルートパッケージを追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
+  - "."
   - "packages/*"
   - "website"


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml` に `"."` を追加し、ルートパッケージ (`@hirokisakabe/pom`) を Changesets のワークスペースパッケージとして認識させる

## 背景
Release ワークフローで `changeset version` 実行時に以下のエラーが発生していた:

```
Error: Found changeset fix-image-size-bundle for package @hirokisakabe/pom which is not in the workspace
```

`pnpm-workspace.yaml` にルートが含まれていなかったため、Changesets が `@hirokisakabe/pom` を認識できなかった。

## Test plan
- [ ] CI が通ることを確認
- [ ] マージ後、Release ワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)