### PR TITLE
fix: release.yml から changeset 有無チェックを削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,8 @@ jobs:
       - run: pnpm --filter @hirokisakabe/pom-md run typecheck
       - run: pnpm --filter @hirokisakabe/pom-md run test:run
 
-      - name: Check for changesets
-        id: changesets-check
-        run: |
-          if find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' -print -quit 2>/dev/null | grep -q .; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create Release PR or Publish
         id: changesets
-        if: steps.changesets-check.outputs.has_changesets == 'true'
         uses: changesets/action@v1
         with:
           publish: pnpm exec changeset publish
@@ -66,9 +56,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish (after Release PR merge)
-        if: steps.changesets-check.outputs.has_changesets == 'false'
-        run: pnpm exec changeset publish
-        env:
-          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- `changesets-check` ステップと standalone publish ステップを削除
- 常に `changesets/action@v1` を実行する形に戻す

## 背景
pnpm workspace 導入時に `release.yml` を書き換えた際、changeset の有無を手動チェックし、changeset がない場合は `changesets/action` を経由せず素の `changeset publish` を実行する構成にしていた。

しかし `changesets/action` は内部で changeset の有無を判断し、以下を自動で行う:
- changeset あり → Release PR を作成
- changeset なし（Release PR マージ後）→ npm publish + **Git tag + GitHub Release を作成**

手動チェックにより publish 時に `changesets/action` を経由しなくなったため、v5.2.1〜v6.0.0 で Git tag / GitHub Release が作成されない問題が発生していた。

## Test plan
- [ ] CI が通ることを確認
- [ ] マージ後、Release ワークフローで Git tag と GitHub Release が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)