### PR TITLE
fix: website の pom 依存を workspace:* に変更

### DIFF
--- a/.github/workflows/ci-docs-site.yml
+++ b/.github/workflows/ci-docs-site.yml
@@ -31,6 +31,7 @@ jobs:
           node-version-file: website/.node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
       - run: pnpm --filter pom-docs run fmt:check
       - run: pnpm --filter pom-docs run lint
       - run: pnpm --filter pom-docs run typecheck

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: ^6.39.15
         version: 6.40.0
       "@hirokisakabe/pom":
-        specifier: 6.0.0
-        version: 6.0.0
+        specifier: workspace:*
+        version: link:..
       "@hono/zod-validator":
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.9)(zod@4.3.6)
@@ -1529,13 +1529,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
-
-  "@hirokisakabe/pom@6.0.0":
-    resolution:
-      {
-        integrity: sha512-R4Cj6O5J11ZQ0YCiYblqvun4r15jT1tzYeyf7Z4f8jKounpo2boi7+/DGIt9M6GSYm4j4+0kzJDKvI0ftXKH+A==,
-      }
-    engines: { node: ">=18" }
 
   "@hono/node-server@1.19.11":
     resolution:
@@ -12568,16 +12561,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
-
-  "@hirokisakabe/pom@6.0.0":
-    dependencies:
-      "@resvg/resvg-js": 2.6.2
-      fast-xml-parser: 5.5.9
-      image-size: 2.0.2
-      opentype.js: 1.3.4
-      pptxgenjs: 4.0.1
-      yoga-layout: 3.2.1
-      zod: 4.3.6
 
   "@hono/node-server@1.19.11(hono@4.12.9)":
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next --turbopack",
-    "build": "next build",
+    "build": "cd .. && pnpm run build && cd website && next build",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
@@ -16,7 +16,7 @@
     "@codemirror/lint": "^6.9.5",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.15",
-    "@hirokisakabe/pom": "6.0.0",
+    "@hirokisakabe/pom": "workspace:*",
     "@hono/zod-validator": "^0.7.6",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- website の `@hirokisakabe/pom` 依存を `"6.0.0"` から `"workspace:*"` に変更

## 背景
Release ワークフローの「Sync pnpm-lock.yaml」ステップで、`changeset version` がバンプした未 publish バージョン（例: `6.0.1`）を `pnpm install --lockfile-only` が npm レジストリから解決しようとして失敗していた。

website は `private: true` のデプロイ専用パッケージなので、`workspace:*` でローカルのワークスペースパッケージを直接参照するのが適切。

## Test plan
- [ ] CI が通ることを確認
- [ ] マージ後、Release ワークフローの Sync pnpm-lock.yaml ステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)