### PR TITLE
fix: Release ワークフローの Sync pnpm-lock.yaml で Prettier フォーマットを実行する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           git fetch origin changeset-release/main
           git checkout changeset-release/main
           pnpm install --lockfile-only
+          pnpm exec prettier --write pnpm-lock.yaml
           if ! git diff --quiet -- pnpm-lock.yaml; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
close #515

## Summary
- Release ワークフローの「Sync pnpm-lock.yaml」ステップで `pnpm install --lockfile-only` 後に `pnpm exec prettier --write pnpm-lock.yaml` を実行するよう修正
- これにより自動コミットされた `pnpm-lock.yaml` が `fmt:check` に通らず CI が失敗する問題を解消

## Test plan
- [ ] Release PR が作成された際に、自動コミットされた `pnpm-lock.yaml` が Prettier フォーマット済みであることを確認
- [ ] CI の `fmt:check` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)