### PR TITLE
fix: npm を v11.5.1+ にアップグレードし trusted publishing を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
+      - name: Upgrade npm for trusted publishing (OIDC)
+        run: npm install -g npm@^11.5.1
       - run: pnpm run build
       - run: pnpm --filter @hirokisakabe/pom-md run build
       - run: pnpm run test:run


### PR DESCRIPTION
close #518

## 概要

- Release ワークフローに `npm install -g npm@^11.5.1` ステップを追加
- pnpm publish が内部で呼び出す npm CLI を trusted publishing (OIDC) 対応バージョンにアップグレード
- GitHub Actions デフォルトの npm v10.x では OIDC publish が E404 で失敗する問題を解消

## 変更内容

`.github/workflows/release.yml` に `pnpm install` の後、ビルド前のタイミングで npm アップグレードステップを追加。`npm@latest` ではなく `npm@^11.5.1` でメジャーバージョンを固定し、将来の破壊的変更による意図しない失敗を防止。

## テスト計画

- [ ] CI が通ることを確認
- [ ] main マージ後、次回の changeset publish で npm trusted publishing が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)