### PR TITLE
docs: 主要ディレクトリに README を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+<h1 align="center">pom</h1>
+<p align="center">
+  AI-friendly PowerPoint generation with a Flexbox layout engine.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@hirokisakabe/pom"><img src="https://img.shields.io/npm/v/@hirokisakabe/pom.svg" alt="npm version"></a>
+  <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@hirokisakabe/pom.svg" alt="License"></a>
+</p>
+
+<p align="center">
+  <b>pom (PowerPoint Object Model)</b> is a TypeScript library that converts XML into editable PowerPoint files (.pptx).
+</p>
+
+<p align="center">
+  <a href="https://pom.pptx.app/playground"><b>Try it online — Playground</b></a>
+</p>
+
+<p align="center">
+  <a href="https://pom.pptx.app/playground">
+    <img src="./packages/pom/docs/images/playground.png" alt="Playground" width="800">
+  </a>
+</p>
+
+---
+
+## Features
+
+- **AI Friendly** — Simple XML structure designed for LLM code generation.
+- **Declarative** — Describe slides as XML. No imperative API calls needed.
+- **Flexible Layout** — Flexbox-style layout with VStack / HStack, powered by yoga-layout.
+- **Rich Nodes** — 18 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
+- **Schema-validated** — XML input is validated with Zod schemas at runtime with clear error messages.
+- **PowerPoint Native** — Full access to native PowerPoint shape features (roundRect, ellipse, arrows, etc.).
+
+## Quick Start
+
+> Requires Node.js 18+
+
+```bash
+npm install @hirokisakabe/pom
+```
+
+```typescript
+import { buildPptx } from "@hirokisakabe/pom";
+
+const xml = `
+<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+  <Text fontSize="48" bold="true">Presentation Title</Text>
+  <Text fontSize="24" color="666666">Subtitle</Text>
+</VStack>
+`;
+
+const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+await pptx.writeFile({ fileName: "presentation.pptx" });
+```
+
+## Packages
+
+This repository is a pnpm monorepo containing the following packages:
+
+| Package | Description | npm |
+| ------- | ----------- | --- |
+| [packages/pom](./packages/pom/) | Core library — XML to PPTX conversion | [`@hirokisakabe/pom`](https://www.npmjs.com/package/@hirokisakabe/pom) |
+| [packages/pom-md](./packages/pom-md/) | Markdown to pom XML converter | [`@hirokisakabe/pom-md`](https://www.npmjs.com/package/@hirokisakabe/pom-md) |
+| [packages/pom-vscode](./packages/pom-vscode/) | VS Code extension for live preview | [Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode) |
+| [apps/website](./apps/website/) | Documentation website ([pom.pptx.app](https://pom.pptx.app)) | — |
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- [pnpm](https://pnpm.io/) 10+
+
+### Setup
+
+```bash
+pnpm install
+```
+
+### Common Commands
+
+```bash
+# Core library
+pnpm --filter @hirokisakabe/pom run build
+pnpm --filter @hirokisakabe/pom run test:run
+pnpm --filter @hirokisakabe/pom run lint
+
+# Markdown converter
+pnpm --filter @hirokisakabe/pom-md run build
+pnpm --filter @hirokisakabe/pom-md run test:run
+
+# VS Code extension
+pnpm --filter pom-vscode run build
+
+# Documentation website
+pnpm --filter pom-docs run dev
+```
+
+## Documentation
+
+| Document | Description |
+| -------- | ----------- |
+| [API Reference](./packages/pom/docs/api-reference.md) | `buildPptx()` function and options |
+| [Nodes](./packages/pom/docs/nodes.md) | Complete reference for all node types |
+| [Master Slide](./packages/pom/docs/master-slide.md) | Headers, footers, and page numbers |
+| [Text Measurement](./packages/pom/docs/text-measurement.md) | Text measurement options and settings |
+| [llm.txt](https://pom.pptx.app/llm.txt) | Compact XML reference for LLM prompts |
+| [Playground](https://pom.pptx.app/playground) | Try pom XML in the browser |
+| [Roadmap](./ROADMAP.md) | Ecosystem direction and priorities |
+
+## License
+
+MIT

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -1,0 +1,46 @@
+<h1 align="center">pom-docs</h1>
+<p align="center">
+  Documentation website for pom — <a href="https://pom.pptx.app">pom.pptx.app</a>
+</p>
+
+---
+
+## Overview
+
+**pom-docs** is the documentation website for the [pom](../../packages/pom/) library. Built with [Next.js](https://nextjs.org/) and [Nextra](https://nextra.site/), it includes API documentation, guides, and an interactive playground.
+
+## Features
+
+- **Documentation** — API reference, node documentation, and guides powered by Nextra.
+- **Playground** — Interactive editor to try pom XML in the browser with live PPTX preview.
+- **Content Symlink** — Documentation source lives in `packages/pom/docs/` and is symlinked to `content/`.
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- [pnpm](https://pnpm.io/) 10+
+
+### Setup
+
+```bash
+# From the repository root
+pnpm install
+```
+
+### Commands
+
+```bash
+pnpm --filter pom-docs run dev          # Start dev server (Turbopack)
+pnpm --filter pom-docs run build        # Production build
+pnpm --filter pom-docs run start        # Start production server
+pnpm --filter pom-docs run lint         # ESLint
+pnpm --filter pom-docs run fmt:check    # Format check
+pnpm --filter pom-docs run typecheck    # Type checking
+pnpm --filter pom-docs run test:run     # Run tests
+```
+
+## License
+
+MIT

--- a/packages/pom-vscode/README.md
+++ b/packages/pom-vscode/README.md
@@ -1,0 +1,70 @@
+<h1 align="center">pom-vscode</h1>
+<p align="center">
+  VS Code extension for live preview of pom-md presentations.
+</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode"><img src="https://img.shields.io/visual-studio-marketplace/v/hirokisakabe.pom-vscode.svg" alt="VS Marketplace version"></a>
+  <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/github/license/hirokisakabe/pom.svg" alt="License"></a>
+</p>
+
+---
+
+## Overview
+
+**pom-vscode** is a VS Code extension that provides live preview for `.pom.md` files. It converts pom-md content to SVG via [pptx-glimpse](https://github.com/nicokoenig/pptx-glimpse) and displays it in a webview panel.
+
+Pipeline: `.pom.md → parseMd() → buildPptx() → pptx-glimpse (convertPptxToSvg) → Webview`
+
+## Features
+
+- **Live Preview** — Real-time slide preview as you edit `.pom.md` files.
+- **Editor Integration** — Preview button appears in the editor title bar for `.pom.md` files.
+- **Command Palette** — Open preview via `pom: Open Preview` command.
+
+## Getting Started
+
+> Requires VS Code 1.85+
+
+### Install from Marketplace
+
+Search for **pom** in the VS Code Extensions view, or install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode).
+
+### Usage
+
+1. Open a `.pom.md` file in VS Code
+2. Click the preview icon in the editor title bar, or run `pom: Open Preview` from the Command Palette
+
+## Development
+
+### Prerequisites
+
+- Node.js 20+
+- [pnpm](https://pnpm.io/) 10+
+
+### Setup
+
+```bash
+# From the repository root
+pnpm install
+```
+
+### Commands
+
+```bash
+pnpm --filter pom-vscode run build       # esbuild bundle
+pnpm --filter pom-vscode run watch       # esbuild watch mode
+pnpm --filter pom-vscode run lint        # ESLint
+pnpm --filter pom-vscode run fmt         # Prettier formatting
+pnpm --filter pom-vscode run fmt:check   # Format check
+pnpm --filter pom-vscode run typecheck   # Type checking
+pnpm --filter pom-vscode run test:run   # Run unit tests
+```
+
+### Testing Locally
+
+Open `packages/pom-vscode` in VS Code and press **F5** to launch the Extension Development Host.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- ルートディレクトリに README.md を追加（モノレポ全体の概要、パッケージ一覧、開発手順）
- `packages/pom-vscode/` に README.md を追加（VS Code 拡張の概要、インストール方法、開発コマンド）
- `apps/website/` に README.md を追加（ドキュメントサイトの概要、開発コマンド）
- 既存の `packages/pom/README.md` のフォーマット（中央寄せタイトル、バッジ、セクション構成）に統一

## Test plan
- [ ] 各 README のリンクが正しいことを確認
- [ ] バッジが正しく表示されることを確認
- [ ] Prettier フォーマットチェック通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)