### PR TITLE
fix: VRT の画像テスト失敗を修正

### DIFF
--- a/packages/pom/scripts/docs-images/sampleNodes.ts
+++ b/packages/pom/scripts/docs-images/sampleNodes.ts
@@ -42,8 +42,7 @@ const textSample = `
 </VStack>
 `;
 
-const sampleImageUrl =
-  "https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png";
+const sampleImageUrl = "sample_images/sample_0.png";
 
 const imageSample = `
 <VStack w="100%" h="max" padding="40" gap="24" backgroundColor="${palette.background}">

--- a/packages/pom/vrt/lib/slides/backgroundImage.ts
+++ b/packages/pom/vrt/lib/slides/backgroundImage.ts
@@ -12,15 +12,15 @@ export const page20BackgroundImageXml = `
     <Text fontSize="16" color="${palette.charcoal}" bold="true">Background Image Sizing Modes:</Text>
     <HStack gap="16">
       <!-- cover モード -->
-      <Text w="280" h="180" backgroundImage.src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" backgroundImage.sizing="cover" border.color="${palette.border}" border.width="2" fontSize="16" color="FFFFFF" bold="true">cover</Text>
+      <Text w="280" h="180" backgroundImage.src="sample_images/sample_0.png" backgroundImage.sizing="cover" border.color="${palette.border}" border.width="2" fontSize="16" color="FFFFFF" bold="true">cover</Text>
       <!-- contain モード -->
-      <Text w="280" h="180" backgroundImage.src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" backgroundImage.sizing="contain" backgroundColor="333333" border.color="${palette.border}" border.width="2" fontSize="16" color="FFFFFF" bold="true">contain (with backgroundColor)</Text>
+      <Text w="280" h="180" backgroundImage.src="sample_images/sample_0.png" backgroundImage.sizing="contain" backgroundColor="333333" border.color="${palette.border}" border.width="2" fontSize="16" color="FFFFFF" bold="true">contain (with backgroundColor)</Text>
       <!-- デフォルト（cover） -->
-      <Text w="280" h="180" backgroundImage.src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_1.png" border.color="${palette.border}" border.width="2" fontSize="16" color="FFFFFF" bold="true">default (cover)</Text>
+      <Text w="280" h="180" backgroundImage.src="sample_images/sample_1.png" border.color="${palette.border}" border.width="2" fontSize="16" color="FFFFFF" bold="true">default (cover)</Text>
     </HStack>
   </VStack>
   <!-- VStack with backgroundImage -->
-  <VStack gap="8" padding="16" backgroundImage.src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" backgroundImage.sizing="cover" border.color="${palette.border}" border.width="1">
+  <VStack gap="8" padding="16" backgroundImage.src="sample_images/sample_0.png" backgroundImage.sizing="cover" border.color="${palette.border}" border.width="1">
     <Text fontSize="16" color="FFFFFF" bold="true">VStack with backgroundImage</Text>
     <Text fontSize="14" color="FFFFFF">Background image on VStack container</Text>
   </VStack>

--- a/packages/pom/vrt/lib/slides/image.ts
+++ b/packages/pom/vrt/lib/slides/image.ts
@@ -11,15 +11,15 @@ export const page3ImageXml = `
     <Text fontSize="14" bold="true">Size variations:</Text>
     <HStack gap="24" alignItems="end">
       <VStack gap="4" alignItems="center">
-        <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" w="60" h="60" />
+        <Image src="sample_images/sample_0.png" w="60" h="60" />
         <Text fontSize="12">60x60</Text>
       </VStack>
       <VStack gap="4" alignItems="center">
-        <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_1.png" w="120" h="90" />
+        <Image src="sample_images/sample_1.png" w="120" h="90" />
         <Text fontSize="12">120x90</Text>
       </VStack>
       <VStack gap="4" alignItems="center">
-        <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" w="180" h="135" />
+        <Image src="sample_images/sample_0.png" w="180" h="135" />
         <Text fontSize="12">180x135</Text>
       </VStack>
     </HStack>
@@ -27,7 +27,7 @@ export const page3ImageXml = `
   <VStack padding="16" backgroundColor="FFFFFF" border='{"color":"${palette.border}","width":1}' gap="12">
     <Text fontSize="14" bold="true">Image with container styling:</Text>
     <HStack gap="16" alignItems="start">
-      <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" w="80" h="80" padding="12" backgroundColor="${palette.lightBlue}" border='{"color":"${palette.blue}","width":2}' />
+      <Image src="sample_images/sample_0.png" w="80" h="80" padding="12" backgroundColor="${palette.lightBlue}" border='{"color":"${palette.blue}","width":2}' />
       <VStack gap="4">
         <Text fontSize="16" bold="true">Image in styled VStack</Text>
         <Text fontSize="12">VStack with padding, backgroundColor, border</Text>
@@ -48,15 +48,15 @@ export const page3bImageSizingXml = `
     <Text fontSize="14" bold="true">Sizing modes:</Text>
     <HStack gap="24" alignItems="end">
       <VStack gap="4" alignItems="center">
-        <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" w="150" h="150" sizing='{"type":"contain"}' />
+        <Image src="sample_images/sample_0.png" w="150" h="150" sizing='{"type":"contain"}' />
         <Text fontSize="12">contain</Text>
       </VStack>
       <VStack gap="4" alignItems="center">
-        <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" w="150" h="150" sizing='{"type":"cover"}' />
+        <Image src="sample_images/sample_0.png" w="150" h="150" sizing='{"type":"cover"}' />
         <Text fontSize="12">cover</Text>
       </VStack>
       <VStack gap="4" alignItems="center">
-        <Image src="https://raw.githubusercontent.com/hirokisakabe/pom/main/sample_images/sample_0.png" w="150" h="150" sizing='{"type":"crop","w":100,"h":100,"x":10,"y":10}' />
+        <Image src="sample_images/sample_0.png" w="150" h="150" sizing='{"type":"crop","w":100,"h":100,"x":10,"y":10}' />
         <Text fontSize="12">crop (100x100)</Text>
       </VStack>
     </HStack>


### PR DESCRIPTION
## Summary

- monorepo 移行（`refactor/monorepo-directory-structure`）で `sample_images/` が `packages/pom/` 配下に移動したが、VRT・docs-images のテストスライドでは GitHub raw URL（旧パス）を参照していたため、画像フェッチが 404 になり VRT が失敗していた
- リモート URL をローカル相対パス（`sample_images/sample_0.png`）に変更して解消
- 対象ファイル: `vrt/lib/slides/image.ts`, `vrt/lib/slides/backgroundImage.ts`, `scripts/docs-images/sampleNodes.ts`

## Test plan

- [x] `pnpm run vrt:docker` で全 36 ページがパスすることを確認済み
- [x] `pnpm run lint` / `pnpm run fmt:check` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)