### PR TITLE
ci: pom 対象ワークフローの命名を統一

### DIFF
--- a/.github/workflows/ci-pom-benchmark.yml
+++ b/.github/workflows/ci-pom-benchmark.yml
@@ -1,4 +1,4 @@
-name: Benchmark
+name: CI - pom Benchmark
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - "packages/pom/scripts/format-bench-comment.ts"
       - "pnpm-lock.yaml"
       - ".node-version"
-      - ".github/workflows/ci-benchmark.yml"
+      - ".github/workflows/ci-pom-benchmark.yml"
   pull_request:
     branches: [main]
     paths:
@@ -20,7 +20,7 @@ on:
       - "packages/pom/scripts/format-bench-comment.ts"
       - "pnpm-lock.yaml"
       - ".node-version"
-      - ".github/workflows/ci-benchmark.yml"
+      - ".github/workflows/ci-pom-benchmark.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/ci-pom-docs-images-vrt.yml
+++ b/.github/workflows/ci-pom-docs-images-vrt.yml
@@ -1,38 +1,38 @@
-name: CI - VRT
+name: CI - pom Docs Images VRT
 
 on:
   push:
     branches: ["main"]
     paths:
+      - "packages/pom/docs/**"
       - "packages/pom/src/**"
-      - "packages/pom/vrt/**"
+      - "packages/pom/scripts/docs-images/**"
       - "packages/pom/package.json"
       - "pnpm-lock.yaml"
       - "packages/pom/docker-compose.yml"
-      - ".github/workflows/ci-vrt.yml"
+      - ".github/workflows/ci-pom-docs-images-vrt.yml"
   pull_request:
     branches: ["main"]
     paths:
+      - "packages/pom/docs/**"
       - "packages/pom/src/**"
-      - "packages/pom/vrt/**"
+      - "packages/pom/scripts/docs-images/**"
       - "packages/pom/package.json"
       - "pnpm-lock.yaml"
       - "packages/pom/docker-compose.yml"
-      - ".github/workflows/ci-vrt.yml"
+      - ".github/workflows/ci-pom-docs-images-vrt.yml"
 
 jobs:
-  vrt:
+  docs-images-vrt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run VRT in Docker
+      - name: Run docs images VRT in Docker
         working-directory: packages/pom
-        run: docker compose run --rm vrt
+        run: docker compose run --rm docs-images-vrt
       - name: Upload diff on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: vrt-diff
-          path: |
-            packages/pom/vrt/actual.png
-            packages/pom/vrt/diff.png
+          name: docs-images-vrt-diff
+          path: packages/pom/docs/images/output/diff/

--- a/.github/workflows/ci-pom-size-limit.yml
+++ b/.github/workflows/ci-pom-size-limit.yml
@@ -1,4 +1,4 @@
-name: CI - Size Limit
+name: CI - pom Size Limit
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - "pnpm-lock.yaml"
       - "packages/pom/.size-limit.js"
       - ".node-version"
-      - ".github/workflows/ci-size-limit.yml"
+      - ".github/workflows/ci-pom-size-limit.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -18,7 +18,7 @@ on:
       - "pnpm-lock.yaml"
       - "packages/pom/.size-limit.js"
       - ".node-version"
-      - ".github/workflows/ci-size-limit.yml"
+      - ".github/workflows/ci-pom-size-limit.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/ci-pom-vrt.yml
+++ b/.github/workflows/ci-pom-vrt.yml
@@ -1,38 +1,38 @@
-name: CI - Docs Images VRT
+name: CI - pom VRT
 
 on:
   push:
     branches: ["main"]
     paths:
-      - "packages/pom/docs/**"
       - "packages/pom/src/**"
-      - "packages/pom/scripts/docs-images/**"
+      - "packages/pom/vrt/**"
       - "packages/pom/package.json"
       - "pnpm-lock.yaml"
       - "packages/pom/docker-compose.yml"
-      - ".github/workflows/ci-docs-images-vrt.yml"
+      - ".github/workflows/ci-pom-vrt.yml"
   pull_request:
     branches: ["main"]
     paths:
-      - "packages/pom/docs/**"
       - "packages/pom/src/**"
-      - "packages/pom/scripts/docs-images/**"
+      - "packages/pom/vrt/**"
       - "packages/pom/package.json"
       - "pnpm-lock.yaml"
       - "packages/pom/docker-compose.yml"
-      - ".github/workflows/ci-docs-images-vrt.yml"
+      - ".github/workflows/ci-pom-vrt.yml"
 
 jobs:
-  docs-images-vrt:
+  vrt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run docs images VRT in Docker
+      - name: Run VRT in Docker
         working-directory: packages/pom
-        run: docker compose run --rm docs-images-vrt
+        run: docker compose run --rm vrt
       - name: Upload diff on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: docs-images-vrt-diff
-          path: packages/pom/docs/images/output/diff/
+          name: vrt-diff
+          path: |
+            packages/pom/vrt/actual.png
+            packages/pom/vrt/diff.png

--- a/.github/workflows/ci-pom.yml
+++ b/.github/workflows/ci-pom.yml
@@ -1,4 +1,4 @@
-name: CI - Build
+name: CI - pom
 
 on:
   push:
@@ -17,7 +17,7 @@ on:
       - "packages/pom/knip.json"
       - "packages/pom/vitest.config.ts"
       - ".node-version"
-      - ".github/workflows/ci-build.yml"
+      - ".github/workflows/ci-pom.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -34,7 +34,7 @@ on:
       - "packages/pom/knip.json"
       - "packages/pom/vitest.config.ts"
       - ".node-version"
-      - ".github/workflows/ci-build.yml"
+      - ".github/workflows/ci-pom.yml"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- pom パッケージ対象の CI ワークフローのファイル名に `pom` プレフィックスを追加し、`pom-md` / `pom-vscode` と命名規則を統一
- 各ワークフローの `name:` フィールドも `CI - pom xxx` 形式に統一
- ワークフロー内の `paths` トリガーで参照している自ファイル名も更新

### 変更一覧
| 変更前 | 変更後 |
|---|---|
| `ci-build.yml` | `ci-pom-build.yml` |
| `ci-benchmark.yml` | `ci-pom-benchmark.yml` |
| `ci-docs-images-vrt.yml` | `ci-pom-docs-images-vrt.yml` |
| `ci-size-limit.yml` | `ci-pom-size-limit.yml` |
| `ci-vrt.yml` | `ci-pom-vrt.yml` |

横断ワークフロー（`ci-actionlint.yml`, `ci-docs-site.yml`, `release.yml`）は変更なし。

## Test plan
- [ ] actionlint がパス済みであること
- [ ] CI が正しくトリガーされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)