### PR TITLE
fix: pom-vscode の VSIX 環境での起動失敗を修正

### DIFF
--- a/packages/pom-vscode/esbuild.mjs
+++ b/packages/pom-vscode/esbuild.mjs
@@ -7,6 +7,24 @@ const buildTest = process.argv.includes("--test");
 // CJS バンドルで import.meta.url が空になる問題を解消するプラグイン。
 // pom の dist ファイルが createRequire(import.meta.url) を使用しているため、
 // CJS 互換の __filename ベース URL に置き換える。
+// pptx-glimpse が sharp をトップレベルで import しているが、
+// pom-vscode では convertPptxToSvg のみ使用し sharp は不要。
+// sharp はネイティブバイナリを含むため VSIX にバンドルできないので、
+// 空のスタブモジュールに置き換える。
+const sharpStubPlugin = {
+  name: "sharp-stub",
+  setup(build) {
+    build.onResolve({ filter: /^sharp$/ }, () => ({
+      path: "sharp",
+      namespace: "sharp-stub",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "sharp-stub" }, () => ({
+      contents: "module.exports = {};",
+      loader: "js",
+    }));
+  },
+};
+
 const importMetaPlugin = {
   name: "import-meta-url-shim",
   setup(build) {
@@ -28,13 +46,13 @@ const buildOptions = {
   entryPoints: ["src/extension.ts"],
   bundle: true,
   outfile: "dist/extension.js",
-  external: ["vscode", "sharp"],
+  external: ["vscode"],
   loader: { ".node": "copy" },
   format: "cjs",
   platform: "node",
   target: "node18",
   sourcemap: true,
-  plugins: [importMetaPlugin],
+  plugins: [sharpStubPlugin, importMetaPlugin],
 };
 
 /** @type {import('esbuild').BuildOptions} */
@@ -42,13 +60,13 @@ const testBuildOptions = {
   entryPoints: ["src/test/extension.test.ts"],
   bundle: true,
   outfile: "dist/test/extension.test.js",
-  external: ["vscode", "mocha", "assert", "sharp"],
+  external: ["vscode", "mocha", "assert"],
   loader: { ".node": "copy" },
   format: "cjs",
   platform: "node",
   target: "node18",
   sourcemap: true,
-  plugins: [importMetaPlugin],
+  plugins: [sharpStubPlugin, importMetaPlugin],
 };
 
 /** @type {import('esbuild').BuildOptions} */

--- a/packages/pom-vscode/run-vsix-test.mjs
+++ b/packages/pom-vscode/run-vsix-test.mjs
@@ -23,6 +23,8 @@ if (!vsixFile) {
 
 // ワークスペース外の一時ディレクトリに拡張をインストール
 const extensionsDir = mkdtempSync(join(tmpdir(), "pom-vsix-ext-"));
+// macOS の Unix ソケットパス上限(103文字)を回避するため、短いパスを使用
+const userDataDir = mkdtempSync(join(tmpdir(), "pom-ud-"));
 
 try {
   const vscodeExecutablePath = await downloadAndUnzipVSCode();
@@ -43,10 +45,17 @@ try {
     vscodeExecutablePath,
     extensionDevelopmentPath: resolve("test-vsix-harness"),
     extensionTestsPath: resolve("dist/test/vsix-runner.js"),
-    launchArgs: ["--extensions-dir", extensionsDir, "."],
+    launchArgs: [
+      "--extensions-dir",
+      extensionsDir,
+      "--user-data-dir",
+      userDataDir,
+      ".",
+    ],
   });
 
   process.exit(exitCode);
 } finally {
   rmSync(extensionsDir, { recursive: true, force: true });
+  rmSync(userDataDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
close #508

## Summary
- `pptx-glimpse` が `sharp` をトップレベルで import するため、VSIX インストール環境で `Cannot find module 'sharp'` が発生し拡張機能の起動に失敗していた
- esbuild プラグイン (`sharpStubPlugin`) で `sharp` を空のスタブモジュールに置き換え、バンドル時にネイティブバイナリへの依存を除去
- `run-vsix-test.mjs` で macOS の Unix ソケットパス上限 (103文字) を回避するため、短い `user-data-dir` を使用するよう修正

## 背景
- `pom-vscode` は `convertPptxToSvg` のみ使用し、`sharp` が必要な `svgToPng` は使用しない
- `sharp` はネイティブバイナリを含むため VSIX にバンドルできない
- `pptxgenjs` 自体は commit `920b283` で `createRequire` から動的 `import()` に変更済みで、esbuild が正しくバンドルしている

## Test plan
- [x] `pnpm run build` 成功
- [x] `pnpm run lint` 成功
- [x] `pnpm run fmt:check` 成功
- [x] `pnpm run typecheck` 成功
- [x] `pnpm run test:vsix` — 3/3 テストパス
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)