### PR TITLE
chore: pom-vscode のバージョンを 0.1.2 に更新

### DIFF
--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "displayName": "pom",
   "description": "Live preview for pom-md presentations",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "hirokisakabe",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- pom-vscode の `version` を `0.1.1` → `0.1.2` に更新
- main にマージ後、`release-pom-vscode.yml` により VS Code Marketplace への公開と Git タグ作成が自動実行される

## Test plan
- [x] fmt:check / lint / typecheck 通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)