### PR TITLE
chore: pom-vscode のバージョンを 0.1.3 に更新

### DIFF
--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "displayName": "pom",
   "description": "Live preview for pom-md presentations",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "hirokisakabe",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- pom-vscode の `version` を `0.1.2` → `0.1.3` に更新（patch リリース）

## Test plan
- [ ] CI が通ることを確認
- [ ] main マージ後、`release-pom-vscode.yml` で VS Code Marketplace への publish と Git tag 作成が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)