### PR TITLE
docs: pom-vscode に LICENSE ファイルを追加

### DIFF
--- a/packages/pom-vscode/LICENSE
+++ b/packages/pom-vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 hirokisakabe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
close #550

## Summary
- `packages/pom-vscode/LICENSE` を追加（ルートの MIT LICENSE をコピー）
- VSIX パッケージに LICENSE がバンドルされ、VS Code Marketplace の License タブに表示されるようになる

## 確認事項
- [x] `.vscodeignore` で除外されていないことを確認
- [x] VSIX ビルド後に `vsce ls` で LICENSE がバンドルされていることを確認
- [x] lint / fmt チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)