### PR TITLE
feat(pom-vscode): PPTX エクスポートコマンドを追加

### DIFF
--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -26,6 +26,11 @@
         "command": "pom.openPreview",
         "title": "pom: Open Preview",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "pom.exportPptx",
+        "title": "pom: Export PPTX",
+        "icon": "$(desktop-download)"
       }
     ],
     "menus": {
@@ -33,6 +38,11 @@
         {
           "when": "resourceFilename =~ /\\.pom\\.md$/",
           "command": "pom.openPreview",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceFilename =~ /\\.pom\\.md$/",
+          "command": "pom.exportPptx",
           "group": "navigation"
         }
       ]

--- a/packages/pom-vscode/src/exportPptx.test.ts
+++ b/packages/pom-vscode/src/exportPptx.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@hirokisakabe/pom-md", () => ({
+  parseMd: vi.fn(),
+}));
+
+vi.mock("@hirokisakabe/pom", () => ({
+  buildPptx: vi.fn(),
+}));
+
+import { parseMd } from "@hirokisakabe/pom-md";
+import { buildPptx } from "@hirokisakabe/pom";
+import { generatePptxBuffer } from "./exportPptx.js";
+import { SLIDE_WIDTH, SLIDE_HEIGHT } from "./generatePreview.js";
+
+const mockParseMd = vi.mocked(parseMd);
+const mockBuildPptx = vi.mocked(buildPptx);
+
+describe("generatePptxBuffer", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("正常な Markdown から Uint8Array を返す", async () => {
+    const expected = new Uint8Array([1, 2, 3]);
+    mockParseMd.mockReturnValue("<Text>Hello</Text>");
+    mockBuildPptx.mockResolvedValue({
+      pptx: {
+        write: vi.fn().mockResolvedValue(expected),
+      },
+    } as never);
+
+    const result = await generatePptxBuffer("# Title");
+    expect(result).toBe(expected);
+  });
+
+  it("パイプライン各段階が正しい引数で呼ばれる", async () => {
+    mockParseMd.mockReturnValue("<Text>Test</Text>");
+    mockBuildPptx.mockResolvedValue({
+      pptx: {
+        write: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      },
+    } as never);
+
+    await generatePptxBuffer("# Test");
+
+    expect(mockParseMd).toHaveBeenCalledWith("# Test");
+    expect(mockBuildPptx).toHaveBeenCalledWith(
+      "<Text>Test</Text>",
+      { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
+      { textMeasurement: "fallback" },
+    );
+  });
+
+  it("parseMd が空文字列を返す場合エラーを投げる", async () => {
+    mockParseMd.mockReturnValue("");
+
+    await expect(generatePptxBuffer("")).rejects.toThrow(
+      "No slides found in the document",
+    );
+    expect(mockBuildPptx).not.toHaveBeenCalled();
+  });
+
+  it("parseMd が空白のみを返す場合エラーを投げる", async () => {
+    mockParseMd.mockReturnValue("   ");
+
+    await expect(generatePptxBuffer("   ")).rejects.toThrow(
+      "No slides found in the document",
+    );
+  });
+
+  it("pptx.write が Uint8Array 以外を返した場合エラーを投げる", async () => {
+    mockParseMd.mockReturnValue("<Text>X</Text>");
+    mockBuildPptx.mockResolvedValue({
+      pptx: {
+        write: vi.fn().mockResolvedValue("not-uint8array"),
+      },
+    } as never);
+
+    await expect(generatePptxBuffer("md")).rejects.toThrow(
+      "Unexpected output type from pptx.write",
+    );
+  });
+
+  it("buildPptx がエラーを投げた場合そのまま伝搬する", async () => {
+    mockParseMd.mockReturnValue("<InvalidTag/>");
+    mockBuildPptx.mockRejectedValue(new Error("Unknown tag"));
+
+    await expect(generatePptxBuffer("bad")).rejects.toThrow("Unknown tag");
+  });
+});

--- a/packages/pom-vscode/src/exportPptx.ts
+++ b/packages/pom-vscode/src/exportPptx.ts
@@ -1,0 +1,28 @@
+import { parseMd } from "@hirokisakabe/pom-md";
+import { buildPptx } from "@hirokisakabe/pom";
+import { SLIDE_WIDTH, SLIDE_HEIGHT } from "./generatePreview.js";
+
+/**
+ * Markdown から PPTX バッファを生成する
+ */
+export async function generatePptxBuffer(
+  markdown: string,
+): Promise<Uint8Array> {
+  const xml = parseMd(markdown);
+  if (!xml.trim()) {
+    throw new Error("No slides found in the document");
+  }
+
+  const { pptx } = await buildPptx(
+    xml,
+    { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
+    { textMeasurement: "fallback" },
+  );
+
+  const buffer = await pptx.write({ outputType: "uint8array" });
+  if (!(buffer instanceof Uint8Array)) {
+    throw new Error("Unexpected output type from pptx.write");
+  }
+
+  return buffer;
+}

--- a/packages/pom-vscode/src/extension.ts
+++ b/packages/pom-vscode/src/extension.ts
@@ -1,5 +1,7 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { PomPreviewPanel } from "./preview.js";
+import { generatePptxBuffer } from "./exportPptx.js";
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
@@ -16,6 +18,53 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       PomPreviewPanel.createOrShow(context.extensionUri, editor.document);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pom.exportPptx", async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        void vscode.window.showErrorMessage("No active editor");
+        return;
+      }
+      if (!editor.document.fileName.endsWith(".pom.md")) {
+        void vscode.window.showErrorMessage(
+          "This command is only available for .pom.md files",
+        );
+        return;
+      }
+
+      const basename = path.basename(editor.document.fileName, ".pom.md");
+      const defaultUri = vscode.Uri.file(
+        path.join(path.dirname(editor.document.fileName), `${basename}.pptx`),
+      );
+
+      const saveUri = await vscode.window.showSaveDialog({
+        defaultUri,
+        filters: { PowerPoint: ["pptx"] },
+      });
+      if (!saveUri) return;
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Exporting PPTX...",
+          cancellable: false,
+        },
+        async () => {
+          try {
+            const buffer = await generatePptxBuffer(editor.document.getText());
+            await vscode.workspace.fs.writeFile(saveUri, buffer);
+            void vscode.window.showInformationMessage(
+              `Exported to ${path.basename(saveUri.fsPath)}`,
+            );
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            void vscode.window.showErrorMessage(`Export failed: ${message}`);
+          }
+        },
+      );
     }),
   );
 


### PR DESCRIPTION
close #548

## 概要

- `pom.exportPptx` コマンドを追加し、`.pom.md` ファイルから PPTX ファイルをエクスポートできるようにした
- 保存先選択ダイアログ (`showSaveDialog`) を表示
- エクスポート中のプログレス表示 (`withProgress`)
- エディタタイトルバーにエクスポートボタンを追加

## 変更ファイル

- `packages/pom-vscode/src/exportPptx.ts` - PPTX バッファ生成ロジック（新規）
- `packages/pom-vscode/src/exportPptx.test.ts` - ユニットテスト（新規）
- `packages/pom-vscode/src/extension.ts` - `pom.exportPptx` コマンド登録
- `packages/pom-vscode/package.json` - コマンド・メニュー定義追加

## テスト計画

- [x] typecheck 通過
- [x] lint 通過
- [x] fmt:check 通過
- [x] knip 通過
- [x] test:run 通過（25テスト全パス）
- [ ] VS Code Extension Development Host で `.pom.md` ファイルを開き、コマンドパレットから `pom: Export PPTX` を実行して PPTX が生成されることを確認
- [ ] エディタタイトルバーのエクスポートボタンが `.pom.md` ファイルでのみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)