### PR TITLE
docs: pom-md README のコード例をコピペしやすい形に改善

### DIFF
--- a/packages/pom-md/README.md
+++ b/packages/pom-md/README.md
@@ -10,11 +10,9 @@ npm install @hirokisakabe/pom-md @hirokisakabe/pom
 
 ## Usage
 
-```ts
-import { parseMd } from "@hirokisakabe/pom-md";
-import { buildPptx } from "@hirokisakabe/pom";
+Create a `.pom.md` file:
 
-const markdown = `
+````markdown
 ---
 size: 16:9
 ---
@@ -28,23 +26,31 @@ size: 16:9
 
 ## Detailed Data
 
-\`\`\`pomxml
+```pomxml
 <Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
-\`\`\`
+```
 
 ---
 
 ## Process
 
-\`\`\`pomxml
+```pomxml
 <Flow>
   <Step>Plan</Step>
   <Step>Develop</Step>
   <Step>Release</Step>
 </Flow>
-\`\`\`
-`;
+```
+````
 
+Then convert it to PPTX:
+
+```ts
+import { readFileSync } from "node:fs";
+import { parseMd } from "@hirokisakabe/pom-md";
+import { buildPptx } from "@hirokisakabe/pom";
+
+const markdown = readFileSync("slides.pom.md", "utf-8");
 const xml = parseMd(markdown);
 const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
 await pptx.writeFile({ fileName: "output.pptx" });


### PR DESCRIPTION
close #555

## Summary

- Usage セクションのテンプレートリテラル内でエスケープされていたコードフェンスを、別の `````markdown` コードブロックとして併記する形に変更
- TypeScript のコード例はファイル読み込み (`readFileSync`) 形式に変更し、ユーザーが `.pom.md` ファイルの内容をそのままコピペできるように改善

## Test plan

- [ ] README の Markdown コードブロックからコピーした内容が `.pom.md` ファイルとしてそのまま使えることを確認
- [ ] GitHub 上で README のレンダリングが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)