### PR TITLE
feat(pom-vscode): プレビューのズーム/フィット制御

### DIFF
--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -33,6 +33,30 @@
         "icon": "$(desktop-download)"
       }
     ],
+    "configuration": {
+      "title": "pom",
+      "properties": {
+        "pom.preview.defaultZoom": {
+          "type": "string",
+          "enum": [
+            "fit",
+            "50",
+            "75",
+            "100",
+            "150"
+          ],
+          "enumItemLabels": [
+            "Fit to Width",
+            "50%",
+            "75%",
+            "100%",
+            "150%"
+          ],
+          "default": "fit",
+          "description": "Default zoom level for the pom preview panel."
+        }
+      }
+    },
     "menus": {
       "editor/title": [
         {

--- a/packages/pom-vscode/src/generatePreview.test.ts
+++ b/packages/pom-vscode/src/generatePreview.test.ts
@@ -22,6 +22,8 @@ import {
   buildErrorHtml,
   SLIDE_WIDTH,
   SLIDE_HEIGHT,
+  ZOOM_LEVELS,
+  type ZoomLevel,
 } from "./generatePreview.js";
 
 const mockParseMd = vi.mocked(parseMd);
@@ -159,8 +161,15 @@ describe("generatePreviewSvg", () => {
 });
 
 describe("buildHtml", () => {
+  const nonce = "test-nonce";
+  const defaultZoom: ZoomLevel = "fit";
+
   it("SVG が1つの場合、スライド番号付きの HTML を返す", () => {
-    const html = buildHtml(['<svg width="100" height="50"></svg>']);
+    const html = buildHtml(
+      ['<svg width="100" height="50"></svg>'],
+      nonce,
+      defaultZoom,
+    );
     expect(html).toContain("<!DOCTYPE html>");
     expect(html).toContain("Slide 1");
     expect(html).toContain('<svg width="100" height="50"></svg>');
@@ -173,7 +182,7 @@ describe("buildHtml", () => {
       '<svg id="s2"></svg>',
       '<svg id="s3"></svg>',
     ];
-    const html = buildHtml(svgs);
+    const html = buildHtml(svgs, nonce, defaultZoom);
     expect(html).toContain("Slide 1");
     expect(html).toContain("Slide 2");
     expect(html).toContain("Slide 3");
@@ -183,9 +192,33 @@ describe("buildHtml", () => {
   });
 
   it("空配列の場合、No slides メッセージを返す", () => {
-    const html = buildHtml([]);
+    const html = buildHtml([], nonce, defaultZoom);
     expect(html).toContain("No slides to preview");
     expect(html).not.toContain("Slide 1");
+  });
+
+  it("ズームコントロールのボタンを含む", () => {
+    const html = buildHtml(["<svg></svg>"], nonce, defaultZoom);
+    for (const { label } of ZOOM_LEVELS) {
+      expect(html).toContain(label);
+    }
+  });
+
+  it("data-zoom 属性にデフォルトズームが設定される", () => {
+    const html = buildHtml(["<svg></svg>"], nonce, "100");
+    expect(html).toContain('data-zoom="100"');
+  });
+
+  it("nonce が style と script タグに設定される", () => {
+    const html = buildHtml(["<svg></svg>"], "abc123", defaultZoom);
+    expect(html).toContain('nonce="abc123"');
+  });
+
+  it("Content-Security-Policy meta タグが出力される", () => {
+    const html = buildHtml(["<svg></svg>"], nonce, defaultZoom);
+    expect(html).toContain("Content-Security-Policy");
+    expect(html).toContain(`'nonce-${nonce}'`);
+    expect(html).toContain("default-src 'none'");
   });
 });
 

--- a/packages/pom-vscode/src/generatePreview.ts
+++ b/packages/pom-vscode/src/generatePreview.ts
@@ -58,7 +58,21 @@ export async function generatePreviewSvg(
   }
 }
 
-export function buildHtml(svgs: string[]): string {
+export type ZoomLevel = "fit" | "50" | "75" | "100" | "150";
+
+export const ZOOM_LEVELS: { value: ZoomLevel; label: string }[] = [
+  { value: "fit", label: "Fit to Width" },
+  { value: "50", label: "50%" },
+  { value: "75", label: "75%" },
+  { value: "100", label: "100%" },
+  { value: "150", label: "150%" },
+];
+
+export function buildHtml(
+  svgs: string[],
+  nonce: string,
+  defaultZoom: ZoomLevel,
+): string {
   if (svgs.length === 0) {
     return `<!DOCTYPE html>
 <html><body style="display:flex;align-items:center;justify-content:center;height:100vh;margin:0;font-family:sans-serif;color:#888;">
@@ -69,20 +83,157 @@ export function buildHtml(svgs: string[]): string {
   const slideElements = svgs
     .map(
       (svg, i) => `
-    <div style="margin-bottom:24px;">
-      <div style="font-size:12px;color:#888;margin-bottom:4px;">Slide ${i + 1}</div>
-      <div style="border:1px solid #ddd;border-radius:4px;overflow:hidden;background:#fff;">
+    <div class="slide-wrapper">
+      <div class="slide-label">Slide ${i + 1}</div>
+      <div class="slide-frame">
         ${svg}
       </div>
     </div>`,
     )
     .join("");
 
+  const zoomButtons = ZOOM_LEVELS.map(
+    ({ value, label }) =>
+      `<button class="zoom-btn" data-zoom="${value}">${label}</button>`,
+  ).join("");
+
   return `<!DOCTYPE html>
 <html>
-<head><meta charset="UTF-8"></head>
-<body style="margin:0;padding:16px;background:#f5f5f5;font-family:sans-serif;">
-  ${slideElements}
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}'; img-src data:;">
+<style nonce="${nonce}">
+  body {
+    margin: 0;
+    padding: 0;
+    background: #f5f5f5;
+    font-family: sans-serif;
+  }
+  .toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 16px;
+    background: var(--vscode-editor-background, #f5f5f5);
+    border-bottom: 1px solid var(--vscode-panel-border, #ddd);
+  }
+  .zoom-btn {
+    padding: 3px 10px;
+    font-size: 12px;
+    border: 1px solid var(--vscode-button-border, #ccc);
+    border-radius: 3px;
+    background: var(--vscode-button-secondaryBackground, #fff);
+    color: var(--vscode-button-secondaryForeground, #333);
+    cursor: pointer;
+  }
+  .zoom-btn:hover {
+    background: var(--vscode-button-secondaryHoverBackground, #e8e8e8);
+  }
+  .zoom-btn.active {
+    background: var(--vscode-button-background, #007acc);
+    color: var(--vscode-button-foreground, #fff);
+    border-color: var(--vscode-button-background, #007acc);
+  }
+  .slides-container {
+    padding: 16px;
+  }
+  .slide-wrapper {
+    margin-bottom: 24px;
+  }
+  .slide-label {
+    font-size: 12px;
+    color: #888;
+    margin-bottom: 4px;
+  }
+  .slide-frame {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    overflow: hidden;
+    background: #fff;
+    display: inline-block;
+  }
+  .slide-frame svg {
+    display: block;
+  }
+  /* Fit to Width: SVG の幅をコンテナに合わせる */
+  body[data-zoom="fit"] .slide-frame {
+    display: block;
+  }
+  body[data-zoom="fit"] .slide-frame svg {
+    width: 100%;
+    height: auto;
+  }
+  /* 固定ズーム: SVG 幅を SLIDE_WIDTH のパーセンテージに設定 */
+  body[data-zoom="50"] .slide-frame svg {
+    width: ${SLIDE_WIDTH * 0.5}px;
+    height: auto;
+  }
+  body[data-zoom="75"] .slide-frame svg {
+    width: ${SLIDE_WIDTH * 0.75}px;
+    height: auto;
+  }
+  body[data-zoom="100"] .slide-frame svg {
+    width: ${SLIDE_WIDTH}px;
+    height: auto;
+  }
+  body[data-zoom="150"] .slide-frame svg {
+    width: ${SLIDE_WIDTH * 1.5}px;
+    height: auto;
+  }
+</style>
+</head>
+<body data-zoom="${defaultZoom}">
+  <div class="toolbar">
+    ${zoomButtons}
+  </div>
+  <div class="slides-container">
+    ${slideElements}
+  </div>
+  <script nonce="${nonce}">
+    (function() {
+      const vscode = acquireVsCodeApi();
+
+      // 前回の状態を復元
+      const previousState = vscode.getState();
+      if (previousState && previousState.zoom) {
+        applyZoom(previousState.zoom);
+      }
+
+      // Extension からのメッセージを受信
+      window.addEventListener('message', function(event) {
+        const message = event.data;
+        if (message.type === 'setZoom') {
+          applyZoom(message.zoom);
+        }
+      });
+
+      // ズームボタンのクリックイベント
+      document.querySelectorAll('.zoom-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          var zoom = this.getAttribute('data-zoom');
+          applyZoom(zoom);
+          vscode.setState({ zoom: zoom });
+          vscode.postMessage({ type: 'zoomChanged', zoom: zoom });
+        });
+      });
+
+      var VALID_ZOOMS = ['fit','50','75','100','150'];
+      function applyZoom(zoom) {
+        if (VALID_ZOOMS.indexOf(zoom) === -1) zoom = 'fit';
+        document.body.setAttribute('data-zoom', zoom);
+        document.querySelectorAll('.zoom-btn').forEach(function(b) {
+          b.classList.toggle('active', b.getAttribute('data-zoom') === zoom);
+        });
+      }
+
+      // 初期状態のボタンをアクティブにする
+      var currentZoom = document.body.getAttribute('data-zoom');
+      applyZoom(currentZoom);
+    })();
+  </script>
 </body>
 </html>`;
 }

--- a/packages/pom-vscode/src/preview.ts
+++ b/packages/pom-vscode/src/preview.ts
@@ -1,12 +1,28 @@
+import * as crypto from "crypto";
 import * as path from "path";
 import * as vscode from "vscode";
 import {
   generatePreviewSvg,
   buildHtml,
   buildErrorHtml,
+  ZOOM_LEVELS,
+  type ZoomLevel,
 } from "./generatePreview.js";
 
 const DEBOUNCE_MS = 500;
+
+function getNonce(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+const VALID_ZOOM_VALUES = new Set<string>(ZOOM_LEVELS.map((z) => z.value));
+
+function getDefaultZoom(): ZoomLevel {
+  const value = vscode.workspace
+    .getConfiguration("pom.preview")
+    .get<string>("defaultZoom", "fit");
+  return VALID_ZOOM_VALUES.has(value) ? (value as ZoomLevel) : "fit";
+}
 
 export class PomPreviewPanel {
   private static instance: PomPreviewPanel | undefined;
@@ -50,7 +66,7 @@ export class PomPreviewPanel {
       "pomPreview",
       "pom Preview",
       vscode.ViewColumn.Beside,
-      { enableScripts: false },
+      { enableScripts: true },
     );
 
     PomPreviewPanel.instance = new PomPreviewPanel(
@@ -80,12 +96,15 @@ export class PomPreviewPanel {
 
     if (generation !== this.renderGeneration || this.disposed) return;
 
+    const nonce = getNonce();
+    const defaultZoom = getDefaultZoom();
+
     switch (result.type) {
       case "empty":
-        this.panel.webview.html = buildHtml([]);
+        this.panel.webview.html = buildHtml([], nonce, defaultZoom);
         break;
       case "success":
-        this.panel.webview.html = buildHtml(result.svgs);
+        this.panel.webview.html = buildHtml(result.svgs, nonce, defaultZoom);
         break;
       case "error":
         this.panel.webview.html = buildErrorHtml(result.message);


### PR DESCRIPTION
close #546

## 概要

プレビュー Webview にズーム/フィット制御機能を追加し、スライドの表示サイズをユーザーが調整できるようにする。

## 変更内容

- **ズームコントロール UI**: ツールバーに「Fit to Width / 50% / 75% / 100% / 150%」ボタンを追加
- **Fit to Width**: SVG 幅をコンテナに合わせてレスポンシブ表示
- **固定ズーム**: SVG 幅を SLIDE_WIDTH (1280px) のパーセンテージで設定
- **状態永続化**: `vscode.getState()`/`setState()` でズーム選択を保持（パネル再表示時に復元）
- **VS Code 設定**: `pom.preview.defaultZoom` でデフォルトズームレベルを設定可能
- **セキュリティ**: `enableScripts: true` に変更し、nonce ベースの CSP (Content-Security-Policy) を設定
- **バリデーション**: ズーム値の不正値チェックとフォールバック処理を追加

## テスト計画

- [x] typecheck 通過
- [x] lint 通過
- [x] fmt:check 通過
- [x] test:run 通過 (29 テスト)
- [x] knip 通過
- [x] build 成功
- [ ] VS Code Extension Development Host で手動動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)