### PR TITLE
feat(pom-vscode): Diagnostics を VS Code Problems パネルに表示

### DIFF
--- a/packages/pom-vscode/src/extension.ts
+++ b/packages/pom-vscode/src/extension.ts
@@ -11,6 +11,11 @@ function getPomExtension(fileName: string): string {
 }
 
 export function activate(context: vscode.ExtensionContext): void {
+  const diagnosticCollection =
+    vscode.languages.createDiagnosticCollection("pom");
+  context.subscriptions.push(diagnosticCollection);
+  PomPreviewPanel.setDiagnosticCollection(diagnosticCollection);
+
   context.subscriptions.push(
     vscode.commands.registerCommand("pom.openPreview", () => {
       const editor = vscode.window.activeTextEditor;

--- a/packages/pom-vscode/src/generatePreview.test.ts
+++ b/packages/pom-vscode/src/generatePreview.test.ts
@@ -41,6 +41,7 @@ describe("generatePreviewSvg", () => {
       pptx: {
         write: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
       },
+      diagnostics: [],
     } as never);
     mockConvertPptxToSvg.mockResolvedValue([
       { svg: '<svg width="1280" height="720">slide1</svg>' },
@@ -60,6 +61,7 @@ describe("generatePreviewSvg", () => {
       pptx: {
         write: vi.fn().mockResolvedValue(new Uint8Array([1])),
       },
+      diagnostics: [],
     } as never);
     mockConvertPptxToSvg.mockResolvedValue([{ svg: "<svg></svg>" }] as never);
 
@@ -87,6 +89,7 @@ describe("generatePreviewSvg", () => {
       pptx: {
         write: vi.fn().mockResolvedValue(new Uint8Array([1])),
       },
+      diagnostics: [],
     } as never);
     mockConvertPptxToSvg.mockResolvedValue([
       { svg: "<svg>s1</svg>" },
@@ -149,6 +152,7 @@ describe("generatePreviewSvg", () => {
       pptx: {
         write: vi.fn().mockResolvedValue(new Uint8Array([1])),
       },
+      diagnostics: [],
     } as never);
     mockConvertPptxToSvg.mockResolvedValue([{ svg: "<svg></svg>" }] as never);
 
@@ -183,12 +187,50 @@ describe("generatePreviewSvg", () => {
     });
   });
 
+  it("diagnostics がある場合 success の diagnostics に含まれる", async () => {
+    const diags = [
+      { code: "AUTOFIT_OVERFLOW" as const, message: "Slide 1 overflows" },
+    ];
+    mockParseMd.mockReturnValue("<Text>X</Text>");
+    mockBuildPptx.mockResolvedValue({
+      pptx: {
+        write: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      },
+      diagnostics: diags,
+    } as never);
+    mockConvertPptxToSvg.mockResolvedValue([{ svg: "<svg></svg>" }] as never);
+
+    const result = await generatePreviewSvg("md", []);
+    expect(result.type).toBe("success");
+    if (result.type === "success") {
+      expect(result.diagnostics).toEqual(diags);
+    }
+  });
+
+  it("diagnostics が空の場合 success の diagnostics も空配列になる", async () => {
+    mockParseMd.mockReturnValue("<Text>X</Text>");
+    mockBuildPptx.mockResolvedValue({
+      pptx: {
+        write: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      },
+      diagnostics: [],
+    } as never);
+    mockConvertPptxToSvg.mockResolvedValue([{ svg: "<svg></svg>" }] as never);
+
+    const result = await generatePreviewSvg("md", []);
+    expect(result.type).toBe("success");
+    if (result.type === "success") {
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
   it("pptx.write が Uint8Array 以外を返した場合 error を返す", async () => {
     mockParseMd.mockReturnValue("<Text>X</Text>");
     mockBuildPptx.mockResolvedValue({
       pptx: {
         write: vi.fn().mockResolvedValue("not-uint8array"),
       },
+      diagnostics: [],
     } as never);
 
     const result = await generatePreviewSvg("md", []);

--- a/packages/pom-vscode/src/generatePreview.ts
+++ b/packages/pom-vscode/src/generatePreview.ts
@@ -1,5 +1,5 @@
 import { parseMd } from "@hirokisakabe/pom-md";
-import { buildPptx } from "@hirokisakabe/pom";
+import { buildPptx, type Diagnostic } from "@hirokisakabe/pom";
 import { convertPptxToSvg } from "pptx-glimpse";
 
 export const SLIDE_WIDTH = 1280;
@@ -20,7 +20,7 @@ const EXTRA_FONT_MAPPING: Record<string, string> = {
 
 type PreviewResult =
   | { type: "empty" }
-  | { type: "success"; svgs: string[] }
+  | { type: "success"; svgs: string[]; diagnostics: Diagnostic[] }
   | { type: "error"; message: string };
 
 /**
@@ -37,7 +37,7 @@ export async function generatePreviewSvg(
       return { type: "empty" };
     }
 
-    const { pptx } = await buildPptx(
+    const { pptx, diagnostics } = await buildPptx(
       xml,
       { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
       { textMeasurement: "fallback" },
@@ -55,7 +55,7 @@ export async function generatePreviewSvg(
     });
     const svgs = slides.map((s: { svg: string }) => s.svg);
 
-    return { type: "success", svgs };
+    return { type: "success", svgs, diagnostics };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return { type: "error", message };

--- a/packages/pom-vscode/src/preview.ts
+++ b/packages/pom-vscode/src/preview.ts
@@ -1,6 +1,7 @@
 import * as crypto from "crypto";
 import * as path from "path";
 import * as vscode from "vscode";
+import type { Diagnostic, DiagnosticCode } from "@hirokisakabe/pom";
 import {
   generatePreviewSvg,
   buildHtml,
@@ -9,6 +10,26 @@ import {
   type ZoomLevel,
 } from "./generatePreview.js";
 import { detectFormat } from "./fileUtils.js";
+
+const SEVERITY_MAP: Record<DiagnosticCode, vscode.DiagnosticSeverity> = {
+  IMAGE_MEASURE_FAILED: vscode.DiagnosticSeverity.Error,
+  IMAGE_NOT_PREFETCHED: vscode.DiagnosticSeverity.Error,
+  AUTOFIT_OVERFLOW: vscode.DiagnosticSeverity.Warning,
+  SCALE_BELOW_THRESHOLD: vscode.DiagnosticSeverity.Warning,
+};
+
+function toVsDiagnostics(items: Diagnostic[]): vscode.Diagnostic[] {
+  const range = new vscode.Range(0, 0, 0, 0);
+  return items.map((d) => {
+    const diag = new vscode.Diagnostic(
+      range,
+      `[${d.code}] ${d.message}`,
+      SEVERITY_MAP[d.code],
+    );
+    diag.source = "pom";
+    return diag;
+  });
+}
 
 const DEBOUNCE_MS = 500;
 
@@ -27,6 +48,7 @@ function getDefaultZoom(): ZoomLevel {
 
 export class PomPreviewPanel {
   private static instance: PomPreviewPanel | undefined;
+  private static diagnosticCollection: vscode.DiagnosticCollection | undefined;
   private readonly panel: vscode.WebviewPanel;
   private readonly fontDirs: string[];
   private documentUri: vscode.Uri;
@@ -34,6 +56,12 @@ export class PomPreviewPanel {
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private renderGeneration = 0;
   private disposed = false;
+
+  static setDiagnosticCollection(
+    collection: vscode.DiagnosticCollection,
+  ): void {
+    PomPreviewPanel.diagnosticCollection = collection;
+  }
 
   private constructor(
     panel: vscode.WebviewPanel,
@@ -48,6 +76,7 @@ export class PomPreviewPanel {
     this.panel.onDidDispose(() => {
       this.disposed = true;
       if (this.debounceTimer) clearTimeout(this.debounceTimer);
+      PomPreviewPanel.diagnosticCollection?.delete(this.documentUri);
       PomPreviewPanel.instance = undefined;
     });
 
@@ -59,6 +88,10 @@ export class PomPreviewPanel {
     document: vscode.TextDocument,
   ): void {
     if (PomPreviewPanel.instance) {
+      const oldUri = PomPreviewPanel.instance.documentUri;
+      if (oldUri.toString() !== document.uri.toString()) {
+        PomPreviewPanel.diagnosticCollection?.delete(oldUri);
+      }
       PomPreviewPanel.instance.documentUri = document.uri;
       PomPreviewPanel.instance.format = detectFormat(document.fileName);
       PomPreviewPanel.instance.panel.reveal(vscode.ViewColumn.Beside);
@@ -110,12 +143,22 @@ export class PomPreviewPanel {
     switch (result.type) {
       case "empty":
         this.panel.webview.html = buildHtml([], nonce, defaultZoom);
+        PomPreviewPanel.diagnosticCollection?.delete(this.documentUri);
         break;
       case "success":
         this.panel.webview.html = buildHtml(result.svgs, nonce, defaultZoom);
+        if (result.diagnostics.length > 0) {
+          PomPreviewPanel.diagnosticCollection?.set(
+            this.documentUri,
+            toVsDiagnostics(result.diagnostics),
+          );
+        } else {
+          PomPreviewPanel.diagnosticCollection?.delete(this.documentUri);
+        }
         break;
       case "error":
         this.panel.webview.html = buildErrorHtml(result.message);
+        PomPreviewPanel.diagnosticCollection?.delete(this.documentUri);
         break;
     }
   }


### PR DESCRIPTION
close #547

## 概要

`buildPptx` が返す Diagnostics を VS Code の Problems パネルに表示する機能を追加。

## 変更内容

- `generatePreviewSvg` の `success` 結果に `diagnostics` を含めるよう拡張
- `PomPreviewPanel` に `vscode.DiagnosticCollection` を統合
  - プレビュー成功時: diagnostics を VS Code Diagnostic に変換して Problems パネルに表示
  - empty / error 時: diagnostics をクリア
  - ドキュメント切り替え時: 旧ドキュメントの diagnostics をクリア
  - パネル dispose 時: diagnostics をクリア
- Severity マッピング:
  - `IMAGE_MEASURE_FAILED` / `IMAGE_NOT_PREFETCHED` → Error
  - `AUTOFIT_OVERFLOW` / `SCALE_BELOW_THRESHOLD` → Warning
- diagnostics 関連のユニットテストを追加

## テスト計画

- [x] `pnpm --filter pom-vscode run typecheck` — 型チェック通過
- [x] `pnpm --filter pom-vscode run lint` — ESLint 通過
- [x] `pnpm --filter pom-vscode run fmt:check` — フォーマットチェック通過
- [x] `pnpm --filter pom-vscode run knip` — 未使用コード検出通過
- [x] `pnpm --filter pom-vscode run build` — ビルド成功
- [x] `vitest run src/generatePreview.test.ts` — テスト 28件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)