### PR TITLE
fix: Vercel デプロイ時に @resvg/resvg-wasm を NFT トレースに含める

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -15,6 +15,15 @@ export default withNextra({
   // バンドラ（webpack / Turbopack）の静的解析対象から外して
   // Node.js ランタイムの require に委ねる。
   serverExternalPackages: ["@resvg/resvg-wasm", "@hirokisakabe/pom"],
+  // @hirokisakabe/pom 内の WASM ロード処理は Function コンストラクタで require を
+  // 隠蔽しているため Vercel の @vercel/nft が依存を検出できず、デプロイ成果物に
+  // @resvg/resvg-wasm が含まれない。明示的にトレース対象へ追加する。
+  outputFileTracingIncludes: {
+    "/api/**": [
+      "../../packages/pom/node_modules/@resvg/resvg-wasm/**/*",
+      "../../node_modules/.pnpm/@resvg+resvg-wasm@*/node_modules/@resvg/resvg-wasm/**/*",
+    ],
+  },
   webpack: (config, { isServer }) => {
     if (isServer) {
       // workspace link の @hirokisakabe/pom は dist/ を参照するため

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -18,6 +18,9 @@ export default withNextra({
   // @hirokisakabe/pom 内の WASM ロード処理は Function コンストラクタで require を
   // 隠蔽しているため Vercel の @vercel/nft が依存を検出できず、デプロイ成果物に
   // @resvg/resvg-wasm が含まれない。明示的にトレース対象へ追加する。
+  // Turbopack が動的 require / import を Webpack 同等に解析できるようになれば
+  // 隠蔽自体が不要になり、本設定も削除できる。
+  // 上流 issue: https://github.com/vercel/next.js/issues/85238
   outputFileTracingIncludes: {
     "/api/**": [
       "../../packages/pom/node_modules/@resvg/resvg-wasm/**/*",

--- a/packages/pom/src/icons/renderIcon.ts
+++ b/packages/pom/src/icons/renderIcon.ts
@@ -9,6 +9,10 @@ import { ICON_DATA } from "./iconData.ts";
 // バンドラ（webpack / Turbopack）のスタティック解析が require / require.resolve を
 // 追跡してエラーにするのを避けるため、Function コンストラクタで Node.js の require を
 // 取得し、モジュール名は文字列結合で構築する。
+// Turbopack が動的 require / import を Webpack 同等に解析できるようになれば
+// 隠蔽自体が不要になり、apps/website 側の outputFileTracingIncludes 設定もまとめて
+// 撤去できる。
+// 上流 issue: https://github.com/vercel/next.js/issues/85238
 type ResvgWasm = typeof import("@resvg/resvg-wasm");
 const RESVG_PKG = ["@resvg", "resvg-wasm"].join("/");
 let resvgModule: ResvgWasm | undefined;


### PR DESCRIPTION
## 概要

Vercel 環境で Icon を含む XML から PPTX 生成する際に、以下のランタイムエラーで失敗していた問題を修正する。

```
Cannot find module '@resvg/resvg-wasm'
Require stack:
- /var/task/packages/pom/dist/icons/renderIcon.js
```

再現: https://pom.pptx.app/playground で Icon を含むテンプレートからダウンロードを試みると発生。

## 原因

\`@resvg/resvg-js\` → \`@resvg/resvg-wasm\` 切替時（#538 / e410c35）から潜在していた問題。
\`packages/pom/src/icons/renderIcon.ts\` は WASM ロード時に Function コンストラクタ + 文字列結合で require を完全に隠蔽している。これは Turbopack の静的解析エラー（\"Module not found: Can't resolve <dynamic>\"）回避には有効だが、Vercel デプロイ時の \`@vercel/nft\` ファイルトレースも require を検出できなくなり、\`@resvg/resvg-wasm\` パッケージがデプロイ成果物（\`/var/task/\`）に同梱されない結果となっていた。

\`serverExternalPackages\` で外部モジュール扱いにしているため、ランタイムでは Node.js の通常の \`require()\` で読み込まれるが、ファイルが存在しないため失敗していた。

## 修正

\`apps/website/next.config.mjs\` に \`outputFileTracingIncludes\` を追加し、\`/api/**\` ルートに対して \`@resvg/resvg-wasm\` を明示的にトレース対象へ含める。

- pnpm の symlink 経由（\`packages/pom/node_modules/@resvg/resvg-wasm/\`）
- 実体パス（\`node_modules/.pnpm/@resvg+resvg-wasm@*/...\`）

両方を指定し、pnpm 構造の差異に依存しない形で確実に同梱されるようにした。

## 動作確認

ローカルでプロダクションビルド後、トレースファイルに \`@resvg/resvg-wasm\` 配下のファイル（\`index_bg.wasm\` 含む）が含まれることを確認:

\`\`\`
$ cat .next/server/app/api/[[...route]]/route.js.nft.json | jq '.files[] | select(test(\"resvg\"))'
\".../packages/pom/node_modules/@resvg/resvg-wasm/index_bg.wasm\"
\".../node_modules/.pnpm/@resvg+resvg-wasm@2.6.2/.../index_bg.wasm\"
...
\`\`\`

\`pnpm run start\` で起動し、Icon を含む XML で \`/api/download\` が 200 で PPTX を返すことを確認。

最終的な検証はこの PR の Vercel プレビュー環境で実施する。

## Test plan

- [ ] Vercel プレビュー環境の playground で Icon を含むテンプレート（例: ダッシュボード系のサンプル）の \"Download\" が成功する
- [ ] エラー \`Cannot find module '@resvg/resvg-wasm'\` が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)