### PR TITLE
fix: size-limit のベースラインキャッシュ保存パスを復元側に揃える

### DIFF
--- a/.github/workflows/ci-pom-size-limit.yml
+++ b/.github/workflows/ci-pom-size-limit.yml
@@ -45,11 +45,16 @@ jobs:
         run: pnpm exec size-limit --json > size-limit-results.json
 
       # --- main: キャッシュ保存 ---
+      - name: Copy results as baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: packages/pom
+        run: cp size-limit-results.json size-limit-baseline.json
+
       - name: Save baseline to cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
-          path: packages/pom/size-limit-results.json
+          path: packages/pom/size-limit-baseline.json
           key: size-limit-main-${{ github.sha }}
 
       # --- PR: ベースライン復元 ---


### PR DESCRIPTION
close #637

## Summary

- `ci-pom-size-limit.yml` の PR 時 bundle size 差分比較が常に「No baseline found for comparison」になっていた問題を修正
- `actions/cache` の保存ステップ (`size-limit-results.json`) と復元ステップ (`size-limit-baseline.json`) でファイルパスが不一致だったため、復元が空振りしていた
- 保存前に `cp size-limit-results.json size-limit-baseline.json` を実行し、保存パスを `size-limit-baseline.json` に統一

## Test plan

- [ ] main にマージ後、main への push で baseline キャッシュが保存されることを確認
- [ ] その後の PR で `Restore baseline from cache` がヒットし、コメントに diff が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)