### PR TITLE
docs: サンプルから無効な <Slide> タグを除去

### DIFF
--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -93,16 +93,14 @@ const nodes: { name: string; image: StaticImageData }[] = [
 const codeExample = `import { buildPptx } from "@hirokisakabe/pom";
 
 const xml = \`
-<Slide>
-  <VStack w="100%" h="max" padding="48" gap="24">
-    <Text fontSize="48" bold="true">
-      Presentation Title
-    </Text>
-    <Text fontSize="24" color="666666">
-      Generated with pom
-    </Text>
-  </VStack>
-</Slide>
+<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+  <Text fontSize="48" bold="true">
+    Presentation Title
+  </Text>
+  <Text fontSize="24" color="666666">
+    Generated with pom
+  </Text>
+</VStack>
 \`;
 
 const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });

--- a/packages/pom-vscode/docs/supported-formats.md
+++ b/packages/pom-vscode/docs/supported-formats.md
@@ -28,13 +28,13 @@ Write slides directly in pom XML for full control over layout and styling.
 **Pipeline:** `.pom.xml → buildPptx() → pptx-glimpse → SVG → Webview`
 
 ```xml
-<Slide>
+<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
   <Text fontSize="28" bold="true">Hello World</Text>
   <Ul>
     <Li>First point</Li>
     <Li>Second point</Li>
   </Ul>
-</Slide>
+</VStack>
 ```
 
 See the [Nodes](/nodes) reference for the full list of available XML nodes and their attributes.


### PR DESCRIPTION
close #671

## 概要

ランディングページと pom-vscode ドキュメントのサンプル XML から、pom がサポートしていない `<Slide>` タグのラップを除去し、`<VStack>` を top-level に置く形式に揃えた。

pom では top-level 要素が直接スライドになる仕様 (`packages/pom/docs/index.mdx` のクイックスタート参照) であり、`<Slide>` は `parseXml` でエラーになる未定義タグだったため、ユーザーがサンプルをコピーして実行した際に最初の体験が損なわれていた。

## 変更点

- `apps/website/app/page.tsx`: `codeExample` の `<Slide>` ラップを除去し、`<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">` を top-level に変更
- `packages/pom-vscode/docs/supported-formats.md`: `.pom.xml` サンプルの `<Slide>` ラップを除去し、同形式の `<VStack>` でラップ

## 動作確認

- 修正後のサンプル XML を実際に `buildPptx(xml, { w: 1280, h: 720 })` に渡し、いずれも `parseXml` を通過し PPTX 生成までエラーなく完走することを確認
- `grep -rn "<Slide>"` でリポジトリ内の他の箇所に `<Slide>` 残留がないことを確認
- `apps/website` および `pom-vscode` パッケージの `lint` / `typecheck` / `fmt:check` 通過を確認

## Test plan

- [ ] CI (lint / typecheck / build / test / VRT) がグリーン
- [ ] ランディングページのサンプル表示が崩れていないこと