### PR TITLE
fix: Next 16 Turbopack 向けに docs symlink をファイル単位へ変換

### DIFF
--- a/.claude/rules/pom-md.md
+++ b/.claude/rules/pom-md.md
@@ -18,3 +18,13 @@ pnpm --filter @hirokisakabe/pom-md run test:run     # Run tests
 ```
 
 Pipeline: `Markdown → parseMd() → pom XML string → buildPptx() (core)`
+
+### Documentation Symlinks
+
+`packages/pom-md/docs/` 配下にドキュメントファイルを追加・リネーム・削除した場合、`apps/website/content/pom-md/` 側にもファイル単位の symlink を追加・更新する。Next 16 / Turbopack はディレクトリ symlink を辿れないため、ファイルごとに symlink を張る方針を採用している。
+
+```bash
+# 新規ファイルを追加した場合の例
+cd apps/website/content/pom-md
+ln -s ../../../../packages/pom-md/docs/<new-file>.md <new-file>.md
+```

--- a/.claude/rules/pom-vscode.md
+++ b/.claude/rules/pom-vscode.md
@@ -24,6 +24,16 @@ Pipeline:
 
 To test locally: open `packages/pom-vscode` in VS Code and press F5 to launch Extension Development Host.
 
+### Documentation Symlinks
+
+`packages/pom-vscode/docs/` 配下にドキュメントファイルを追加・リネーム・削除した場合、`apps/website/content/pom-vscode/` 側にもファイル単位の symlink を追加・更新する。Next 16 / Turbopack はディレクトリ symlink を辿れないため、ファイルごとに symlink を張る方針を採用している。
+
+```bash
+# 新規ファイルを追加した場合の例
+cd apps/website/content/pom-vscode
+ln -s ../../../../packages/pom-vscode/docs/<new-file>.md <new-file>.md
+```
+
 ### Release Flow
 
 pom-vscode uses Changesets for versioning (`privatePackages` config). The release is handled by the unified `release.yml` workflow.

--- a/apps/website/content/pom-md
+++ b/apps/website/content/pom-md
@@ -1,1 +1,0 @@
-../../../packages/pom-md/docs

--- a/apps/website/content/pom-md/_meta.ts
+++ b/apps/website/content/pom-md/_meta.ts
@@ -1,0 +1,1 @@
+../../../../packages/pom-md/docs/_meta.ts

--- a/apps/website/content/pom-md/index.md
+++ b/apps/website/content/pom-md/index.md
@@ -1,0 +1,1 @@
+../../../../packages/pom-md/docs/index.md

--- a/apps/website/content/pom-md/markdown-syntax.md
+++ b/apps/website/content/pom-md/markdown-syntax.md
@@ -1,0 +1,1 @@
+../../../../packages/pom-md/docs/markdown-syntax.md

--- a/apps/website/content/pom-md/pomxml-code-fence.md
+++ b/apps/website/content/pom-md/pomxml-code-fence.md
@@ -1,0 +1,1 @@
+../../../../packages/pom-md/docs/pomxml-code-fence.md

--- a/apps/website/content/pom-vscode
+++ b/apps/website/content/pom-vscode
@@ -1,1 +1,0 @@
-../../../packages/pom-vscode/docs

--- a/apps/website/content/pom-vscode/_meta.ts
+++ b/apps/website/content/pom-vscode/_meta.ts
@@ -1,0 +1,1 @@
+../../../../packages/pom-vscode/docs/_meta.ts

--- a/apps/website/content/pom-vscode/configuration.md
+++ b/apps/website/content/pom-vscode/configuration.md
@@ -1,0 +1,1 @@
+../../../../packages/pom-vscode/docs/configuration.md

--- a/apps/website/content/pom-vscode/index.md
+++ b/apps/website/content/pom-vscode/index.md
@@ -1,0 +1,1 @@
+../../../../packages/pom-vscode/docs/index.md

--- a/apps/website/content/pom-vscode/supported-formats.md
+++ b/apps/website/content/pom-vscode/supported-formats.md
@@ -1,0 +1,1 @@
+../../../../packages/pom-vscode/docs/supported-formats.md


### PR DESCRIPTION
close #674

## Summary

- Next 16 / Turbopack がディレクトリ symlink を辿れず `/pom-md`, `/pom-vscode` 配下の docs が全て 404 になっていた問題を修正
- `apps/website/content/pom-md` と `apps/website/content/pom-vscode` のディレクトリ symlink を、実ディレクトリ + ファイル単位 symlink に置き換え (既存の `content/api-reference.md` 等と同じパターンに統一)
- 新規ドキュメント追加時の symlink 作成手順を `.claude/rules/pom-md.md` と `.claude/rules/pom-vscode.md` に追記

## Test plan

- [x] `pnpm build` (apps/website) が成功し、ビルドログに `[nextra] Error while loading` が出ない
- [x] `.next/prerender-manifest.json` に `/pom-md`, `/pom-md/markdown-syntax`, `/pom-md/pomxml-code-fence`, `/pom-vscode`, `/pom-vscode/configuration`, `/pom-vscode/supported-formats` が含まれる
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm fmt:check`, `pnpm test:run` がすべて成功
- [x] サイトマップ (`app/sitemap.ts`) のエントリと prerender-manifest が一致
- [ ] 本番デプロイ後に各 URL が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)