### PR TITLE
fix: website サイドバーのパッケージ見出しを整理

### DIFF
--- a/apps/website/content/_meta.ts
+++ b/apps/website/content/_meta.ts
@@ -6,12 +6,21 @@ export default {
   "master-slide": "Slide Master",
   "text-measurement": "Text Measurement",
   "api-reference": "API Reference",
-  "-- packages": {
+  "-- tools": {
     type: "separator",
-    title: "Packages",
+    title: "Tools",
   },
-  "pom-md": "pom-md",
-  "pom-vscode": "pom-vscode",
+  "pom-md": {
+    title: "pom-md",
+    display: "children",
+  },
+  "-- pom-vscode-divider": {
+    type: "separator",
+  },
+  "pom-vscode": {
+    title: "pom-vscode",
+    display: "children",
+  },
   "-- -": {
     type: "separator",
   },

--- a/apps/website/content/_meta.ts
+++ b/apps/website/content/_meta.ts
@@ -6,15 +6,11 @@ export default {
   "master-slide": "Slide Master",
   "text-measurement": "Text Measurement",
   "api-reference": "API Reference",
-  "-- pom-md": {
+  "-- packages": {
     type: "separator",
-    title: "pom-md",
+    title: "Packages",
   },
   "pom-md": "pom-md",
-  "-- pom-vscode": {
-    type: "separator",
-    title: "pom-vscode",
-  },
   "pom-vscode": "pom-vscode",
   "-- -": {
     type: "separator",

--- a/packages/pom-md/docs/_meta.ts
+++ b/packages/pom-md/docs/_meta.ts
@@ -1,5 +1,5 @@
 export default {
-  index: "Getting Started",
+  index: "pom-md",
   "markdown-syntax": "Markdown Syntax",
   "pomxml-code-fence": "pomxml Code Fence",
 };

--- a/packages/pom-vscode/docs/_meta.ts
+++ b/packages/pom-vscode/docs/_meta.ts
@@ -1,5 +1,5 @@
 export default {
-  index: "Getting Started",
+  index: "pom-vscode",
   "supported-formats": "Supported Formats",
   configuration: "Configuration",
 };


### PR DESCRIPTION
## Summary

- サイドバーで `pom-md` / `pom-vscode` がそれぞれ separator のタイトルとフォルダ名で二重表示されていた問題を解消しました。
- `display: "children"` でフォルダ自体を非表示にし、子ページを `Tools` セクション直下にフラット展開する構成に変更（トグル動作も排除）。
- 各パッケージ docs の `index` タイトルを `Getting Started` → パッケージ名そのもの (`pom-md` / `pom-vscode`) に変更し、フラット展開時のラベル重複を回避。
- `pom-md` と `pom-vscode` の境界は薄い separator で区切り。
- URL 構造（`/pom-md/markdown-syntax` 等）は維持しています。

## Before / After

Before:

```
- API Reference
- ─── pom-md ───
  - pom-md (toggle)
    - Getting Started
    - Markdown Syntax
    - pomxml Code Fence
- ─── pom-vscode ───
  - pom-vscode (toggle)
    - Getting Started
    - Supported Formats
    - Configuration
```

After:

```
- API Reference
- ─── Tools ───
- pom-md
- Markdown Syntax
- pomxml Code Fence
- ─── (区切り線)
- pom-vscode
- Supported Formats
- Configuration
```

## Test plan

- [x] `pnpm run lint` (apps/website)
- [x] `pnpm run typecheck` (apps/website)
- [x] `pnpm run fmt:check` (apps/website)
- [x] `pnpm run dev` でサイドバー表示・ブレッドクラム・各パッケージページへのリンクをブラウザ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)