### PR TITLE
polish: プレイグラウンドのサンプルスライド全8種の見た目を整理

### DIFF
--- a/apps/website/playground/client/lib/sampleTemplates.ts
+++ b/apps/website/playground/client/lib/sampleTemplates.ts
@@ -8,13 +8,19 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
   {
     id: "financial-summary",
     name: "決算サマリー",
-    xml: `<VStack w="max" h="max" padding="24" backgroundColor="F8F9FC" gap="16">
-  <HStack w="max" gap="0" alignItems="center">
-    <Shape w="8" h="48" shapeType="rect" fill.color="0E0D6A" />
-    <VStack padding.left="16" gap="2">
-      <Text fontSize="28" color="0E0D6A" bold="true">2025年度 第3四半期 決算サマリー</Text>
-      <Text fontSize="12" color="5A5A8A">Financial Results Summary for Q3 FY2025｜2025年10月1日～12月31日</Text>
-    </VStack>
+    xml: `<VStack w="max" h="max" padding="24" backgroundColor="F8F9FC" gap="14">
+  <HStack w="max" justifyContent="spaceBetween" alignItems="center">
+    <HStack gap="0" alignItems="center">
+      <Shape w="6" h="52" shapeType="rect" fill.color="0E0D6A" />
+      <VStack padding.left="14" gap="2">
+        <Text fontSize="26" color="0E0D6A" bold="true">2025年度 第3四半期 決算サマリー</Text>
+        <Text fontSize="11" color="5A5A8A">Financial Results Summary for Q3 FY2025｜2025年10月1日～12月31日</Text>
+      </VStack>
+    </HStack>
+    <HStack gap="6" alignItems="center" padding.top="8" padding.bottom="8" padding.left="14" padding.right="14" backgroundColor="0E0D6A" borderRadius="999">
+      <Icon name="trending-up" size="13" color="FFFFFF" />
+      <Text fontSize="11" color="FFFFFF" bold="true">前年同期比 増収増益</Text>
+    </HStack>
   </HStack>
   <HStack w="max" gap="16" alignItems="start">
     <VStack gap="12">
@@ -144,36 +150,45 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
       </VStack>
     </VStack>
   </HStack>
-  <VStack w="max" padding="12" backgroundColor="0E0D6A">
-    <Text fontSize="14" color="FFFFFF" textAlign="center" bold="true">第3四半期 主要トピックス</Text>
-  </VStack>
+  <HStack w="max" gap="0" alignItems="center" padding.top="2">
+    <Shape w="4" h="20" shapeType="rect" fill.color="0E0D6A" />
+    <Text padding.left="10" fontSize="14" color="0E0D6A" bold="true">第3四半期 主要トピックス</Text>
+  </HStack>
   <HStack w="max" gap="12">
-    <VStack padding="10" backgroundColor="FFFFFF" border.color="0E0D6A" border.width="2">
-      <VStack gap="6" alignItems="center">
-        <Shape w="36" h="36" shapeType="ellipse" fill.color="E8EAF6" fontSize="12" color="0E0D6A">01</Shape>
-        <Text fontSize="11" color="0E0D6A" textAlign="center" bold="true">新規事業の収益寄与</Text>
-        <Text fontSize="9" color="3C3C3C" textAlign="center">AI・クラウド事業が前年比+42%成長、売上構成比15%に拡大。SaaS型サービスのARR（年間経常収益）が280億円を突破</Text>
+    <VStack padding="14" backgroundColor="FFFFFF" border.color="C5CAE9" border.width="1" borderRadius="10">
+      <VStack gap="8">
+        <HStack gap="8" alignItems="center">
+          <Shape w="28" h="28" shapeType="roundRect" fill.color="0E0D6A" fontSize="11" bold="true" color="FFFFFF" borderRadius="6">01</Shape>
+          <Text fontSize="11" color="0E0D6A" bold="true">新規事業の収益寄与</Text>
+        </HStack>
+        <Text fontSize="9" color="3C3C3C" lineHeight="1.5">AI・クラウド事業が前年比+42%成長、売上構成比15%に拡大。SaaS型サービスのARR（年間経常収益）が280億円を突破。</Text>
       </VStack>
     </VStack>
-    <VStack padding="10" backgroundColor="FFFFFF" border.color="0E0D6A" border.width="2">
-      <VStack gap="6" alignItems="center">
-        <Shape w="36" h="36" shapeType="ellipse" fill.color="E8EAF6" fontSize="12" color="0E0D6A">02</Shape>
-        <Text fontSize="11" color="0E0D6A" textAlign="center" bold="true">コスト最適化の進展</Text>
-        <Text fontSize="9" color="3C3C3C" textAlign="center">全社DX推進により販管費率が前年比1.2pt改善。物流拠点統合で年間45億円のコスト削減を実現</Text>
+    <VStack padding="14" backgroundColor="FFFFFF" border.color="C5CAE9" border.width="1" borderRadius="10">
+      <VStack gap="8">
+        <HStack gap="8" alignItems="center">
+          <Shape w="28" h="28" shapeType="roundRect" fill.color="0E0D6A" fontSize="11" bold="true" color="FFFFFF" borderRadius="6">02</Shape>
+          <Text fontSize="11" color="0E0D6A" bold="true">コスト最適化の進展</Text>
+        </HStack>
+        <Text fontSize="9" color="3C3C3C" lineHeight="1.5">全社DX推進により販管費率が前年比1.2pt改善。物流拠点統合で年間45億円のコスト削減を実現。</Text>
       </VStack>
     </VStack>
-    <VStack padding="10" backgroundColor="FFFFFF" border.color="0E0D6A" border.width="2">
-      <VStack gap="6" alignItems="center">
-        <Shape w="36" h="36" shapeType="ellipse" fill.color="E8EAF6" fontSize="12" color="0E0D6A">03</Shape>
-        <Text fontSize="11" color="0E0D6A" textAlign="center" bold="true">主力製品の成長加速</Text>
-        <Text fontSize="9" color="3C3C3C" textAlign="center">フラッグシップ製品「NEXUS Pro」が累計導入社数5,000社突破。大企業向けエンタープライズ版の受注が好調</Text>
+    <VStack padding="14" backgroundColor="FFFFFF" border.color="C5CAE9" border.width="1" borderRadius="10">
+      <VStack gap="8">
+        <HStack gap="8" alignItems="center">
+          <Shape w="28" h="28" shapeType="roundRect" fill.color="0E0D6A" fontSize="11" bold="true" color="FFFFFF" borderRadius="6">03</Shape>
+          <Text fontSize="11" color="0E0D6A" bold="true">主力製品の成長加速</Text>
+        </HStack>
+        <Text fontSize="9" color="3C3C3C" lineHeight="1.5">フラッグシップ製品「NEXUS Pro」が累計導入社数5,000社突破。大企業向けエンタープライズ版の受注が好調。</Text>
       </VStack>
     </VStack>
-    <VStack padding="10" backgroundColor="FFFFFF" border.color="0E0D6A" border.width="2">
-      <VStack gap="6" alignItems="center">
-        <Shape w="36" h="36" shapeType="ellipse" fill.color="E8EAF6" fontSize="12" color="0E0D6A">04</Shape>
-        <Text fontSize="11" color="0E0D6A" textAlign="center" bold="true">海外展開の加速</Text>
-        <Text fontSize="9" color="3C3C3C" textAlign="center">ASEAN地域売上が前年比+28%。シンガポール拠点を起点に東南アジア6カ国での事業展開を本格化</Text>
+    <VStack padding="14" backgroundColor="FFFFFF" border.color="C5CAE9" border.width="1" borderRadius="10">
+      <VStack gap="8">
+        <HStack gap="8" alignItems="center">
+          <Shape w="28" h="28" shapeType="roundRect" fill.color="0E0D6A" fontSize="11" bold="true" color="FFFFFF" borderRadius="6">04</Shape>
+          <Text fontSize="11" color="0E0D6A" bold="true">海外展開の加速</Text>
+        </HStack>
+        <Text fontSize="9" color="3C3C3C" lineHeight="1.5">ASEAN地域売上が前年比+28%。シンガポール拠点を起点に東南アジア6カ国での事業展開を本格化。</Text>
       </VStack>
     </VStack>
   </HStack>
@@ -186,64 +201,86 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
   {
     id: "product-landing",
     name: "プロダクト紹介",
-    xml: `<VStack w="1280" h="max" padding="48" gap="40" backgroundColor="F8FAFC" alignItems="stretch">
+    xml: `<VStack w="1280" h="max" padding="56" gap="36" backgroundColor="F8FAFC" alignItems="stretch">
 
-  <VStack gap="16" alignItems="center">
-    <Shape shapeType="roundRect" w="180" h="32" fontSize="14" bold="true"
-           fill.color="DBEAFE" color="2563EB" borderRadius="16">
-      NEW RELEASE
-    </Shape>
-    <Text fontSize="48" bold="true" color="0F172A" textAlign="center">
+  <VStack gap="18" alignItems="center">
+    <HStack gap="8" alignItems="center" padding.top="6" padding.bottom="6" padding.left="14" padding.right="14" backgroundColor="DBEAFE" borderRadius="999">
+      <Shape shapeType="ellipse" w="8" h="8" fill.color="2563EB" />
+      <Text fontSize="12" bold="true" color="1D4ED8">NEW RELEASE｜2026 SUMMER</Text>
+    </HStack>
+    <Text fontSize="50" bold="true" color="0F172A" textAlign="center" lineHeight="1.2">
       次世代の業務効率化プラットフォーム
     </Text>
-    <Text fontSize="18" color="64748B" textAlign="center" lineHeight="1.5">
-      煩雑なプロセスを自動化し、チームの生産性を最大化します。
-      導入から運用まで、専門チームが徹底サポート。
+    <Text fontSize="18" color="475569" textAlign="center" lineHeight="1.6">
+      煩雑なプロセスを自動化し、チームの生産性を最大化。
+      導入から運用まで、専門チームが徹底サポートします。
     </Text>
   </VStack>
 
-  <HStack gap="24" alignItems="stretch">
-    <VStack padding="32" backgroundColor="FFFFFF" borderRadius="16" shadow.type="outer" shadow.opacity="0.1" shadow.blur="10" shadow.angle="90" shadow.offset="4">
-      <VStack gap="16" alignItems="start">
-        <Shape shapeType="ellipse" w="48" h="48" fill.color="EEF2FF" fontSize="24" color="4F46E5">⚡</Shape>
+  <HStack gap="20" alignItems="stretch">
+    <VStack padding="28" backgroundColor="FFFFFF" borderRadius="20" border.color="E2E8F0" border.width="1" shadow.type="outer" shadow.opacity="0.08" shadow.blur="20" shadow.offset="6">
+      <VStack gap="14" alignItems="start">
+        <Icon name="zap" size="22" color="4F46E5" variant="square-filled" bgColor="EEF2FF" w="48" h="48" />
         <Text fontSize="20" bold="true" color="0F172A">圧倒的なスピード</Text>
-        <Text fontSize="14" color="475569" lineHeight="1.4">
-          独自のエンジンにより、従来のツールと比較して約5倍の処理速度を実現しました。
+        <Text fontSize="14" color="475569" lineHeight="1.6">
+          独自のエンジンにより、従来比 約5倍の処理速度を実現。大量データもストレスなく処理します。
         </Text>
+        <HStack gap="6" alignItems="center" padding.top="4">
+          <Text fontSize="22" bold="true" color="4F46E5">5×</Text>
+          <Text fontSize="11" color="64748B">処理速度向上</Text>
+        </HStack>
       </VStack>
     </VStack>
 
-    <VStack padding="32" backgroundColor="FFFFFF" borderRadius="16" shadow.type="outer" shadow.opacity="0.1" shadow.blur="10" shadow.angle="90" shadow.offset="4">
-      <VStack gap="16" alignItems="start">
-        <Shape shapeType="ellipse" w="48" h="48" fill.color="ECFDF5" fontSize="24" color="059669">🔒</Shape>
+    <VStack padding="28" backgroundColor="FFFFFF" borderRadius="20" border.color="E2E8F0" border.width="1" shadow.type="outer" shadow.opacity="0.08" shadow.blur="20" shadow.offset="6">
+      <VStack gap="14" alignItems="start">
+        <Icon name="shield-check" size="22" color="059669" variant="square-filled" bgColor="ECFDF5" w="48" h="48" />
         <Text fontSize="20" bold="true" color="0F172A">高度なセキュリティ</Text>
-        <Text fontSize="14" color="475569" lineHeight="1.4">
-          金融機関レベルの暗号化技術を標準搭載。大切なデータを安全に守ります。
+        <Text fontSize="14" color="475569" lineHeight="1.6">
+          金融機関レベルの暗号化技術を標準搭載。多要素認証・監査ログでデータを安全に守ります。
         </Text>
+        <HStack gap="6" alignItems="center" padding.top="4">
+          <Text fontSize="22" bold="true" color="059669">ISO 27001</Text>
+          <Text fontSize="11" color="64748B">認証取得</Text>
+        </HStack>
       </VStack>
     </VStack>
 
-    <VStack padding="32" backgroundColor="FFFFFF" borderRadius="16" shadow.type="outer" shadow.opacity="0.1" shadow.blur="10" shadow.angle="90" shadow.offset="4">
-      <VStack gap="16" alignItems="start">
-        <Shape shapeType="ellipse" w="48" h="48" fill.color="FFFBEB" fontSize="24" color="D97706">📱</Shape>
+    <VStack padding="28" backgroundColor="FFFFFF" borderRadius="20" border.color="E2E8F0" border.width="1" shadow.type="outer" shadow.opacity="0.08" shadow.blur="20" shadow.offset="6">
+      <VStack gap="14" alignItems="start">
+        <Icon name="smartphone" size="22" color="D97706" variant="square-filled" bgColor="FFFBEB" w="48" h="48" />
         <Text fontSize="20" bold="true" color="0F172A">マルチデバイス対応</Text>
-        <Text fontSize="14" color="475569" lineHeight="1.4">
-          PC、スマートフォン、タブレット。場所を選ばず、いつでもどこでもアクセス可能。
+        <Text fontSize="14" color="475569" lineHeight="1.6">
+          PC・スマートフォン・タブレット。場所を選ばず、シームレスに業務を継続できます。
         </Text>
+        <HStack gap="6" alignItems="center" padding.top="4">
+          <Text fontSize="22" bold="true" color="D97706">24/7</Text>
+          <Text fontSize="11" color="64748B">どこでもアクセス</Text>
+        </HStack>
       </VStack>
     </VStack>
   </HStack>
 
-  <VStack w="max" padding="40" backgroundColor="1E293B" borderRadius="16">
-    <HStack gap="40" alignItems="center" justifyContent="spaceBetween">
-      <VStack gap="8" w="60%">
-        <Text fontSize="24" bold="true" color="FFFFFF">まずは無料トライアルから</Text>
-        <Text fontSize="14" color="94A3B8">すべての機能を14日間無料でお試しいただけます。</Text>
+  <VStack w="max" padding="32" backgroundColor="0F172A" borderRadius="20">
+    <HStack gap="24" alignItems="center" justifyContent="spaceBetween">
+      <VStack gap="6" w="60%">
+        <HStack gap="8" alignItems="center">
+          <Icon name="sparkles" size="18" color="60A5FA" />
+          <Text fontSize="14" color="60A5FA" bold="true">FREE TRIAL</Text>
+        </HStack>
+        <Text fontSize="26" bold="true" color="FFFFFF">まずは無料トライアルから</Text>
+        <Text fontSize="14" color="94A3B8">クレジットカード不要・14日間すべての機能を体験できます。</Text>
       </VStack>
-      <Shape shapeType="roundRect" w="240" h="56" fontSize="18" bold="true"
-             fill.color="2563EB" color="FFFFFF" borderRadius="8">
-        無料で始める
-      </Shape>
+      <HStack gap="12" alignItems="center">
+        <Shape shapeType="roundRect" w="200" h="52" fontSize="15" bold="true"
+               fill.color="FFFFFF" color="0F172A" borderRadius="10">
+          資料ダウンロード
+        </Shape>
+        <Shape shapeType="roundRect" w="200" h="52" fontSize="15" bold="true"
+               fill.color="2563EB" color="FFFFFF" borderRadius="10">
+          無料で始める →
+        </Shape>
+      </HStack>
     </HStack>
   </VStack>
 
@@ -252,91 +289,107 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
   {
     id: "pricing-plan",
     name: "料金プラン",
-    xml: `<VStack h="max" w="max" padding="48" backgroundColor="F8FAFC" gap="40" alignItems="center">
-  <VStack gap="12" alignItems="center">
-    <Shape shapeType="roundRect" w="140" h="32" fill.color="EEF2FF" color="6366F1" fontSize="12" bold="true">PRICING</Shape>
-    <Text fontSize="40" color="1E293B" bold="true">シンプルで、迷わない料金プラン</Text>
-    <Text fontSize="16" color="64748B">すべてのプランに14日間の無料トライアルがつきます</Text>
+    xml: `<VStack h="max" w="max" padding="44" backgroundColor="F8FAFC" gap="28" alignItems="center">
+  <VStack gap="10" alignItems="center">
+    <HStack gap="6" alignItems="center" padding.top="6" padding.bottom="6" padding.left="14" padding.right="14" backgroundColor="EEF2FF" borderRadius="999">
+      <Icon name="tag" size="14" color="6366F1" />
+      <Text fontSize="12" color="6366F1" bold="true">PRICING</Text>
+    </HStack>
+    <Text fontSize="38" color="1E293B" bold="true">シンプルで、迷わない料金プラン</Text>
+    <Text fontSize="15" color="64748B">すべてのプランに 14日間の無料トライアル付き｜年間契約で 20% OFF</Text>
   </VStack>
 
-  <HStack w="100%" gap="24" alignItems="end">
-    <VStack w="30%" padding="32" backgroundColor="FFFFFF" borderRadius="32" shadow.type="outer" shadow.opacity="0.05" shadow.blur="20" shadow.offset="10">
-      <VStack gap="24">
-        <Shape shapeType="ellipse" w="56" h="56" fill.color="E0F7FA" color="0891B2" fontSize="24" bold="true">🌱</Shape>
+  <HStack w="100%" gap="20" alignItems="stretch">
+    <VStack w="30%" padding="28" backgroundColor="FFFFFF" borderRadius="24" border.color="E2E8F0" border.width="1" shadow.type="outer" shadow.opacity="0.04" shadow.blur="16" shadow.offset="6">
+      <VStack gap="18">
+        <Icon name="sprout" size="26" color="0891B2" variant="square-filled" bgColor="E0F7FA" w="56" h="56" />
         <VStack gap="4">
-          <Text fontSize="20" color="0891B2" bold="true">ライト</Text>
-          <HStack gap="4" alignItems="end">
-            <Text fontSize="36" bold="true" color="1E293B">¥0</Text>
-            <Text fontSize="14" color="94A3B8">/月</Text>
-          </HStack>
+          <Text fontSize="18" color="0891B2" bold="true">ライト</Text>
+          <Text fontSize="11" color="94A3B8">個人・スモールチーム向け</Text>
         </VStack>
-        <Ul fontSize="13" color="64748B" lineHeight="1.8">
+        <HStack gap="4" alignItems="end">
+          <Text fontSize="40" bold="true" color="1E293B">¥0</Text>
+          <Text fontSize="13" color="94A3B8">/月</Text>
+        </HStack>
+        <Shape shapeType="rect" w="max" h="1" fill.color="E2E8F0" />
+        <Ul fontSize="13" color="475569" lineHeight="1.9">
           <Li text="最大3プロジェクト" />
           <Li text="基本テンプレート利用" />
           <Li text="コミュニティサポート" />
         </Ul>
-        <Shape shapeType="roundRect" w="max" h="56" fill.color="F1F5F9" color="64748B" fontSize="15" bold="true">無料で始める</Shape>
+        <Shape shapeType="roundRect" w="max" h="48" fill.color="F1F5F9" color="475569" fontSize="14" bold="true" borderRadius="10">無料で始める</Shape>
       </VStack>
     </VStack>
 
-    <VStack w="32%" padding="40" backgroundColor="FFFFFF" borderRadius="32" border.color="6366F1" border.width="3" shadow.type="outer" shadow.opacity="0.15" shadow.blur="30" shadow.offset="15">
-      <VStack gap="24">
-        <HStack justifyContent="spaceBetween" alignItems="center">
-          <Shape shapeType="ellipse" w="64" h="64" fill.color="EEF2FF" color="6366F1" fontSize="28" bold="true">🚀</Shape>
-          <Shape shapeType="roundRect" w="100" h="28" fill.color="6366F1" color="FFFFFF" fontSize="11" bold="true">一番人気！</Shape>
+    <VStack w="34%" padding="28" backgroundColor="FFFFFF" borderRadius="24" border.color="6366F1" border.width="2" shadow.type="outer" shadow.opacity="0.18" shadow.blur="32" shadow.offset="14">
+      <VStack gap="18">
+        <HStack w="max" justifyContent="spaceBetween" alignItems="center">
+          <Icon name="rocket" size="28" color="FFFFFF" variant="square-filled" bgColor="6366F1" w="56" h="56" />
+          <Shape shapeType="roundRect" w="86" h="26" fill.color="6366F1" color="FFFFFF" fontSize="11" bold="true" borderRadius="999">★ 一番人気</Shape>
         </HStack>
         <VStack gap="4">
-          <Text fontSize="24" color="6366F1" bold="true">スタンダード</Text>
-          <HStack gap="4" alignItems="end">
-            <Text fontSize="44" bold="true" color="1E293B">¥4,980</Text>
-            <Text fontSize="14" color="94A3B8">/月</Text>
-          </HStack>
+          <Text fontSize="20" color="6366F1" bold="true">スタンダード</Text>
+          <Text fontSize="11" color="94A3B8">成長企業に選ばれる定番プラン</Text>
         </VStack>
-        <Ul fontSize="14" color="1E293B" lineHeight="1.8" bold="true">
+        <HStack gap="4" alignItems="end">
+          <Text fontSize="44" bold="true" color="1E293B">¥4,980</Text>
+          <Text fontSize="13" color="94A3B8">/月</Text>
+        </HStack>
+        <Shape shapeType="rect" w="max" h="1" fill.color="E2E8F0" />
+        <Ul fontSize="13" color="1E293B" lineHeight="1.9">
           <Li text="プロジェクト無制限" />
           <Li text="AIアシスタント機能" />
           <Li text="高度な分析レポート" />
           <Li text="24時間メールサポート" />
         </Ul>
-        <Shape shapeType="roundRect" w="max" h="60" fill.color="6366F1" shadow.type="outer" shadow.opacity="0.3" shadow.blur="10" color="FFFFFF" fontSize="16" bold="true">14日間無料で試す</Shape>
+        <Shape shapeType="roundRect" w="max" h="52" fill.color="6366F1" shadow.type="outer" shadow.opacity="0.35" shadow.blur="14" color="FFFFFF" fontSize="15" bold="true" borderRadius="12">14日間無料で試す</Shape>
       </VStack>
     </VStack>
 
-    <VStack w="30%" padding="32" backgroundColor="FFFFFF" borderRadius="32" shadow.type="outer" shadow.opacity="0.05" shadow.blur="20" shadow.offset="10">
-      <VStack gap="24">
-        <Shape shapeType="ellipse" w="56" h="56" fill.color="FFFBEB" color="D97706" fontSize="24" bold="true">💎</Shape>
+    <VStack w="30%" padding="28" backgroundColor="FFFFFF" borderRadius="24" border.color="E2E8F0" border.width="1" shadow.type="outer" shadow.opacity="0.04" shadow.blur="16" shadow.offset="6">
+      <VStack gap="18">
+        <Icon name="gem" size="26" color="D97706" variant="square-filled" bgColor="FFFBEB" w="56" h="56" />
         <VStack gap="4">
-          <Text fontSize="20" color="D97706" bold="true">ビジネス</Text>
-          <HStack gap="4" alignItems="end">
-            <Text fontSize="32" bold="true" color="1E293B">要お見積り</Text>
-          </HStack>
+          <Text fontSize="18" color="D97706" bold="true">ビジネス</Text>
+          <Text fontSize="11" color="94A3B8">大企業・複雑な要件向け</Text>
         </VStack>
-        <Ul fontSize="13" color="64748B" lineHeight="1.8">
+        <Text fontSize="28" bold="true" color="1E293B">要お見積り</Text>
+        <Shape shapeType="rect" w="max" h="1" fill.color="E2E8F0" />
+        <Ul fontSize="13" color="475569" lineHeight="1.9">
           <Li text="専任サクセスマネージャー" />
           <Li text="SSO / SAML認証" />
           <Li text="操作ログ保存（無制限）" />
           <Li text="個別トレーニング実施" />
         </Ul>
-        <Shape shapeType="roundRect" w="max" h="56" fill.color="1E293B" color="FFFFFF" fontSize="15" bold="true">お問い合わせ</Shape>
+        <Shape shapeType="roundRect" w="max" h="48" fill.color="0F172A" color="FFFFFF" fontSize="14" bold="true" borderRadius="10">お問い合わせ</Shape>
       </VStack>
     </VStack>
   </HStack>
 
-  <Text fontSize="12" color="94A3B8">※価格はすべて税抜き表示です。年間契約の場合さらに20%OFFが適用されます。</Text>
+  <Text fontSize="12" color="475569" textAlign="center" padding.top="4">✓ いつでも解約可能 ・ ✓ クレジットカード不要 ・ ✓ 日本語サポート ・ ✓ SOC 2 Type II 準拠</Text>
 </VStack>`,
   },
   {
     id: "chart-showcase",
     name: "チャート集",
-    xml: `<VStack w="max" h="max" padding="32" backgroundColor="FAFAFA" gap="20">
-  <VStack gap="4" alignItems="center">
-    <Text fontSize="28" color="212121" bold="true">データビジュアライゼーション</Text>
-    <Text fontSize="14" color="757575">各種チャートの表示サンプル</Text>
-  </VStack>
-  <HStack w="max" gap="16">
-    <VStack padding="16" backgroundColor="FFFFFF" border.color="E0E0E0" border.width="1" borderRadius="8">
+    xml: `<VStack w="max" h="max" padding="28" backgroundColor="F5F7FA" gap="16">
+  <HStack w="max" justifyContent="spaceBetween" alignItems="center">
+    <HStack gap="12" alignItems="center">
+      <Icon name="bar-chart-3" size="22" color="FFFFFF" variant="square-filled" bgColor="1565C0" w="46" h="46" />
+      <VStack gap="2">
+        <Text fontSize="24" color="0D2A4D" bold="true">データビジュアライゼーション</Text>
+        <Text fontSize="12" color="6B7B8E">Chart Showcase｜棒・折れ線・円・ドーナツ・レーダー・エリア</Text>
+      </VStack>
+    </HStack>
+    <Shape shapeType="roundRect" w="120" h="28" fill.color="E3F2FD" color="1565C0" fontSize="11" bold="true" borderRadius="999">▣ 6 chart types</Shape>
+  </HStack>
+  <HStack w="max" gap="14">
+    <VStack padding="16" backgroundColor="FFFFFF" border.color="E3E8EE" border.width="1" borderRadius="12" shadow.type="outer" shadow.opacity="0.04" shadow.blur="10" shadow.offset="2">
       <VStack gap="8">
-        <Text fontSize="14" color="212121" bold="true">棒グラフ — 月別売上推移</Text>
+        <HStack gap="8" alignItems="center">
+          <Icon name="bar-chart" size="14" color="1565C0" />
+          <Text fontSize="13" color="0D2A4D" bold="true">棒グラフ — 月別売上推移</Text>
+        </HStack>
         <Chart w="420" h="200" chartType="bar" showLegend="true" chartColors='["90CAF9","1565C0"]'>
           <ChartSeries name="2024年">
             <ChartDataPoint label="1月" value="320" />
@@ -357,9 +410,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
         </Chart>
       </VStack>
     </VStack>
-    <VStack padding="16" backgroundColor="FFFFFF" border.color="E0E0E0" border.width="1" borderRadius="8">
+    <VStack padding="16" backgroundColor="FFFFFF" border.color="E3E8EE" border.width="1" borderRadius="12" shadow.type="outer" shadow.opacity="0.04" shadow.blur="10" shadow.offset="2">
       <VStack gap="8">
-        <Text fontSize="14" color="212121" bold="true">折れ線グラフ — ユーザー数推移</Text>
+        <HStack gap="8" alignItems="center">
+          <Icon name="trending-up" size="14" color="FF6F00" />
+          <Text fontSize="13" color="0D2A4D" bold="true">折れ線グラフ — ユーザー数推移</Text>
+        </HStack>
         <Chart w="420" h="200" chartType="line" showLegend="true" chartColors='["1565C0","FF6F00"]'>
           <ChartSeries name="MAU">
             <ChartDataPoint label="1月" value="12000" />
@@ -381,11 +437,14 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
       </VStack>
     </VStack>
   </HStack>
-  <HStack w="max" gap="16">
-    <VStack padding="16" backgroundColor="FFFFFF" border.color="E0E0E0" border.width="1" borderRadius="8">
+  <HStack w="max" gap="14">
+    <VStack padding="16" backgroundColor="FFFFFF" border.color="E3E8EE" border.width="1" borderRadius="12" shadow.type="outer" shadow.opacity="0.04" shadow.blur="10" shadow.offset="2">
       <VStack gap="8">
-        <Text fontSize="14" color="212121" bold="true">円グラフ — 顧客構成</Text>
-        <Chart w="260" h="200" chartType="pie" showLegend="true" chartColors='["1565C0","26A69A","FF6F00","AB47BC","78909C"]'>
+        <HStack gap="8" alignItems="center">
+          <Icon name="pie-chart" size="14" color="1565C0" />
+          <Text fontSize="13" color="0D2A4D" bold="true">円グラフ — 顧客構成</Text>
+        </HStack>
+        <Chart w="260" h="180" chartType="pie" showLegend="true" chartColors='["1565C0","26A69A","FF6F00","AB47BC","78909C"]'>
           <ChartSeries name="業種別">
             <ChartDataPoint label="製造業" value="35" />
             <ChartDataPoint label="IT" value="25" />
@@ -396,10 +455,13 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
         </Chart>
       </VStack>
     </VStack>
-    <VStack padding="16" backgroundColor="FFFFFF" border.color="E0E0E0" border.width="1" borderRadius="8">
+    <VStack padding="16" backgroundColor="FFFFFF" border.color="E3E8EE" border.width="1" borderRadius="12" shadow.type="outer" shadow.opacity="0.04" shadow.blur="10" shadow.offset="2">
       <VStack gap="8">
-        <Text fontSize="14" color="212121" bold="true">ドーナツ — 予算配分</Text>
-        <Chart w="260" h="200" chartType="doughnut" showLegend="true" chartColors='["1565C0","2E7D32","FF6F00","AB47BC","78909C"]'>
+        <HStack gap="8" alignItems="center">
+          <Icon name="circle-dot" size="14" color="2E7D32" />
+          <Text fontSize="13" color="0D2A4D" bold="true">ドーナツ — 予算配分</Text>
+        </HStack>
+        <Chart w="260" h="180" chartType="doughnut" showLegend="true" chartColors='["1565C0","2E7D32","FF6F00","AB47BC","78909C"]'>
           <ChartSeries name="予算">
             <ChartDataPoint label="開発" value="40" />
             <ChartDataPoint label="マーケ" value="20" />
@@ -410,10 +472,13 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
         </Chart>
       </VStack>
     </VStack>
-    <VStack padding="16" backgroundColor="FFFFFF" border.color="E0E0E0" border.width="1" borderRadius="8">
+    <VStack padding="16" backgroundColor="FFFFFF" border.color="E3E8EE" border.width="1" borderRadius="12" shadow.type="outer" shadow.opacity="0.04" shadow.blur="10" shadow.offset="2">
       <VStack gap="8">
-        <Text fontSize="14" color="212121" bold="true">レーダー — スキル評価</Text>
-        <Chart w="260" h="200" chartType="radar" showLegend="true" chartColors='["1565C0","FF6F00"]'>
+        <HStack gap="8" alignItems="center">
+          <Icon name="radar" size="14" color="AB47BC" />
+          <Text fontSize="13" color="0D2A4D" bold="true">レーダー — スキル評価</Text>
+        </HStack>
+        <Chart w="260" h="180" chartType="radar" showLegend="true" chartColors='["1565C0","FF6F00"]'>
           <ChartSeries name="チームA">
             <ChartDataPoint label="技術" value="90" />
             <ChartDataPoint label="管理" value="70" />
@@ -432,10 +497,13 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
       </VStack>
     </VStack>
   </HStack>
-  <VStack w="max" padding="16" backgroundColor="FFFFFF" border.color="E0E0E0" border.width="1" borderRadius="8">
+  <VStack w="max" padding="16" backgroundColor="FFFFFF" border.color="E3E8EE" border.width="1" borderRadius="12" shadow.type="outer" shadow.opacity="0.04" shadow.blur="10" shadow.offset="2">
     <VStack gap="8">
-      <Text fontSize="14" color="212121" bold="true">エリアチャート — トラフィック推移</Text>
-      <Chart w="max" h="180" chartType="area" showLegend="true" chartColors='["1565C0","81D4FA"]'>
+      <HStack gap="8" alignItems="center">
+        <Icon name="area-chart" size="14" color="1565C0" />
+        <Text fontSize="13" color="0D2A4D" bold="true">エリアチャート — トラフィック推移（曜日別）</Text>
+      </HStack>
+      <Chart w="max" h="160" chartType="area" showLegend="true" chartColors='["1565C0","81D4FA"]'>
         <ChartSeries name="オーガニック">
           <ChartDataPoint label="月" value="4500" />
           <ChartDataPoint label="火" value="5200" />
@@ -464,14 +532,16 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
     name: "プロジェクト管理ダッシュボード",
     xml: `<VStack w="max" h="max" padding="28" backgroundColor="0B1220" gap="18">
   <HStack w="max" justifyContent="spaceBetween" alignItems="center">
-    <VStack gap="4">
-      <Text fontSize="30" color="F8FAFC" bold="true">プロジェクト管理ダッシュボード</Text>
-      <Text fontSize="13" color="94A3B8">Project phases, delivery flow, governance, and team structure in one view</Text>
-    </VStack>
-    <HStack gap="10">
-      <Icon name="layout-dashboard" size="22" color="60A5FA" variant="circle-filled" bgColor="172554" w="46" h="46" />
-      <Icon name="git-branch" size="22" color="34D399" variant="circle-filled" bgColor="052E2B" w="46" h="46" />
-      <Icon name="shield-check" size="22" color="FBBF24" variant="circle-filled" bgColor="3B2F07" w="46" h="46" />
+    <HStack gap="14" alignItems="center">
+      <Icon name="layout-dashboard" size="24" color="60A5FA" variant="square-filled" bgColor="172554" w="50" h="50" />
+      <VStack gap="2">
+        <Text fontSize="26" color="F8FAFC" bold="true">プロジェクト管理ダッシュボード</Text>
+        <Text fontSize="11" color="94A3B8">Project phases, delivery flow, governance &amp; team in one view</Text>
+      </VStack>
+    </HStack>
+    <HStack gap="10" alignItems="center">
+      <Shape shapeType="roundRect" w="120" h="28" fill.color="052E2B" border.color="065F46" border.width="1" color="34D399" fontSize="11" bold="true" borderRadius="999">● ON TRACK</Shape>
+      <Shape shapeType="roundRect" w="120" h="28" fill.color="172554" border.color="1E3A8A" border.width="1" color="60A5FA" fontSize="11" bold="true" borderRadius="999">Phase 3｜開発中</Shape>
     </HStack>
   </HStack>
 
@@ -505,7 +575,7 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
             </HStack>
             <Text fontSize="11" color="94A3B8">ProcessArrow</Text>
           </HStack>
-          <ProcessArrow w="max" direction="horizontal" itemHeight="72" fontSize="13" bold="true">
+          <ProcessArrow w="max" direction="horizontal" itemHeight="56" fontSize="12" bold="true">
             <ProcessArrowStep label="Backlog整理" color="1D4ED8" textColor="FFFFFF" />
             <ProcessArrowStep label="Sprint計画" color="4F46E5" textColor="FFFFFF" />
             <ProcessArrowStep label="Build &amp; Code" color="059669" textColor="FFFFFF" />
@@ -524,7 +594,7 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
             </HStack>
             <Text fontSize="11" color="94A3B8">Flow</Text>
           </HStack>
-          <Flow w="max" h="180" direction="horizontal" nodeWidth="118" nodeHeight="54" nodeGap="58" connectorStyle.color="64748B" connectorStyle.width="2" connectorStyle.arrowType="arrow">
+          <Flow w="max" h="130" direction="horizontal" nodeWidth="108" nodeHeight="46" nodeGap="48" connectorStyle.color="64748B" connectorStyle.width="2" connectorStyle.arrowType="arrow">
             <FlowNode id="start" shape="flowChartTerminator" text="要求受付" color="1E3A8A" textColor="FFFFFF" />
             <FlowNode id="review" shape="flowChartProcess" text="影響評価" color="334155" textColor="FFFFFF" />
             <FlowNode id="decision" shape="flowChartDecision" text="承認?" color="7C3AED" textColor="FFFFFF" />
@@ -549,7 +619,7 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
             </HStack>
             <Text fontSize="11" color="94A3B8">Tree</Text>
           </HStack>
-          <Tree w="max" h="300" layout="vertical" nodeShape="roundRect" nodeWidth="120" nodeHeight="42" levelGap="44" siblingGap="16" connectorStyle.color="475569" connectorStyle.width="2">
+          <Tree w="max" h="220" layout="vertical" nodeShape="roundRect" nodeWidth="118" nodeHeight="38" levelGap="36" siblingGap="14" connectorStyle.color="475569" connectorStyle.width="2">
             <TreeItem label="Steering Committee" color="1D4ED8">
               <TreeItem label="PMO" color="0F766E">
                 <TreeItem label="Dev Lead" color="7C3AED" />
@@ -561,39 +631,50 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
         </VStack>
       </VStack>
 
-      <VStack w="max" padding="16" backgroundColor="111827" border.color="334155" border.width="1" borderRadius="18">
-        <VStack gap="14">
-          <Text fontSize="18" color="E2E8F0" bold="true">ステータスハイライト</Text>
-          <HStack w="max" gap="12">
-            <VStack w="max" padding="14" backgroundColor="0F172A" border.color="1E3A8A" border.width="1" borderRadius="14">
-              <VStack gap="8" alignItems="center">
-                <Icon name="target" size="20" color="60A5FA" variant="circle-filled" bgColor="172554" w="44" h="44" />
-                <Text fontSize="12" color="94A3B8">進捗率</Text>
-                <Text fontSize="24" color="F8FAFC" bold="true">68%</Text>
-              </VStack>
+      <VStack w="max" padding="14" backgroundColor="111827" border.color="334155" border.width="1" borderRadius="18">
+        <VStack gap="10">
+          <HStack gap="10" alignItems="center">
+            <Icon name="activity" size="18" color="F472B6" variant="square-filled" bgColor="500724" w="38" h="38" />
+            <Text fontSize="16" color="E2E8F0" bold="true">ステータスハイライト</Text>
+          </HStack>
+          <HStack w="max" gap="10">
+            <VStack w="max" padding="10" backgroundColor="0F172A" border.color="1E3A8A" border.width="1" borderRadius="12">
+              <HStack gap="10" alignItems="center">
+                <Icon name="target" size="18" color="60A5FA" variant="circle-filled" bgColor="172554" w="36" h="36" />
+                <VStack gap="0">
+                  <Text fontSize="10" color="94A3B8">進捗率</Text>
+                  <Text fontSize="20" color="F8FAFC" bold="true">68%</Text>
+                </VStack>
+              </HStack>
             </VStack>
-            <VStack w="max" padding="14" backgroundColor="0F172A" border.color="065F46" border.width="1" borderRadius="14">
-              <VStack gap="8" alignItems="center">
-                <Icon name="check-check" size="20" color="34D399" variant="circle-filled" bgColor="052E2B" w="44" h="44" />
-                <Text fontSize="12" color="94A3B8">完了タスク</Text>
-                <Text fontSize="24" color="F8FAFC" bold="true">124</Text>
-              </VStack>
+            <VStack w="max" padding="10" backgroundColor="0F172A" border.color="065F46" border.width="1" borderRadius="12">
+              <HStack gap="10" alignItems="center">
+                <Icon name="check-check" size="18" color="34D399" variant="circle-filled" bgColor="052E2B" w="36" h="36" />
+                <VStack gap="0">
+                  <Text fontSize="10" color="94A3B8">完了タスク</Text>
+                  <Text fontSize="20" color="F8FAFC" bold="true">124</Text>
+                </VStack>
+              </HStack>
             </VStack>
           </HStack>
-          <HStack w="max" gap="12">
-            <VStack w="max" padding="14" backgroundColor="0F172A" border.color="78350F" border.width="1" borderRadius="14">
-              <VStack gap="8" alignItems="center">
-                <Icon name="alert-triangle" size="20" color="F59E0B" variant="circle-filled" bgColor="3B2F07" w="44" h="44" />
-                <Text fontSize="12" color="94A3B8">リスク</Text>
-                <Text fontSize="24" color="F8FAFC" bold="true">05</Text>
-              </VStack>
+          <HStack w="max" gap="10">
+            <VStack w="max" padding="10" backgroundColor="0F172A" border.color="78350F" border.width="1" borderRadius="12">
+              <HStack gap="10" alignItems="center">
+                <Icon name="alert-triangle" size="18" color="F59E0B" variant="circle-filled" bgColor="3B2F07" w="36" h="36" />
+                <VStack gap="0">
+                  <Text fontSize="10" color="94A3B8">リスク</Text>
+                  <Text fontSize="20" color="F8FAFC" bold="true">05</Text>
+                </VStack>
+              </HStack>
             </VStack>
-            <VStack w="max" padding="14" backgroundColor="0F172A" border.color="4C1D95" border.width="1" borderRadius="14">
-              <VStack gap="8" alignItems="center">
-                <Icon name="clock-3" size="20" color="C084FC" variant="circle-filled" bgColor="2E1065" w="44" h="44" />
-                <Text fontSize="12" color="94A3B8">次回レビュー</Text>
-                <Text fontSize="18" color="F8FAFC" bold="true">Fri 16:00</Text>
-              </VStack>
+            <VStack w="max" padding="10" backgroundColor="0F172A" border.color="4C1D95" border.width="1" borderRadius="12">
+              <HStack gap="10" alignItems="center">
+                <Icon name="clock-3" size="18" color="C084FC" variant="circle-filled" bgColor="2E1065" w="36" h="36" />
+                <VStack gap="0">
+                  <Text fontSize="10" color="94A3B8">次回レビュー</Text>
+                  <Text fontSize="15" color="F8FAFC" bold="true">Fri 16:00</Text>
+                </VStack>
+              </HStack>
             </VStack>
           </HStack>
         </VStack>
@@ -614,9 +695,7 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
  <Text fontSize="13" color="64748B">Strategic Analysis Overview｜重点施策・優先順位・実行計画</Text>
  </VStack>
  </HStack>
- <VStack padding.top="10" padding.right="14" padding.bottom="10" padding.left="14" backgroundColor="EFF6FF" border.color="BFDBFE" border.width="1" borderRadius="18">
- <Text fontSize="12" color="1D4ED8" bold="true">FY2026 Strategic Focus</Text>
- </VStack>
+ <Shape shapeType="roundRect" w="190" h="32" fill.color="EFF6FF" border.color="BFDBFE" border.width="1" color="1D4ED8" fontSize="12" bold="true" borderRadius="18">FY2026 Strategic Focus</Shape>
  </HStack>
 
  <Line x1="32" y1="92" x2="1248" y2="92" color="D6E4FF" lineWidth="2" />
@@ -644,12 +723,24 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
  <Icon name="list-checks" size="20" color="1D4ED8" variant="square-filled" bgColor="DBEAFE" w="40" h="40" />
  <Text fontSize="18" color="1E3A8A" bold="true">アクションプラン</Text>
  </HStack>
- <Ol fontSize="13" color="334155" lineHeight="1.6" numberType="arabicParenR">
- <Li text="重点顧客セグメントを再定義し、営業資源を再配分する" />
- <Li text="基幹業務のデジタル化投資を優先し、収益性を改善する" />
- <Li text="新市場向けパートナー戦略を立ち上げ、成長機会を拡大する" />
- <Li text="KPIレビューを月次化し、施策の継続判断を高速化する" />
- </Ol>
+ <VStack gap="10">
+ <HStack gap="10" alignItems="start">
+ <Shape w="22" h="22" shapeType="ellipse" fill.color="DBEAFE" color="1D4ED8" fontSize="11" bold="true">1</Shape>
+ <Text fontSize="13" color="334155" lineHeight="1.5">重点顧客セグメントを再定義し、営業資源を再配分する</Text>
+ </HStack>
+ <HStack gap="10" alignItems="start">
+ <Shape w="22" h="22" shapeType="ellipse" fill.color="DBEAFE" color="1D4ED8" fontSize="11" bold="true">2</Shape>
+ <Text fontSize="13" color="334155" lineHeight="1.5">基幹業務のデジタル化投資を優先し、収益性を改善する</Text>
+ </HStack>
+ <HStack gap="10" alignItems="start">
+ <Shape w="22" h="22" shapeType="ellipse" fill.color="DBEAFE" color="1D4ED8" fontSize="11" bold="true">3</Shape>
+ <Text fontSize="13" color="334155" lineHeight="1.5">新市場向けパートナー戦略を立ち上げ、成長機会を拡大する</Text>
+ </HStack>
+ <HStack gap="10" alignItems="start">
+ <Shape w="22" h="22" shapeType="ellipse" fill.color="DBEAFE" color="1D4ED8" fontSize="11" bold="true">4</Shape>
+ <Text fontSize="13" color="334155" lineHeight="1.5">KPIレビューを月次化し、施策の継続判断を高速化する</Text>
+ </HStack>
+ </VStack>
  </VStack>
  </VStack>
  </VStack>
@@ -715,11 +806,8 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
       </VStack>
     </HStack>
     <HStack gap="8" alignItems="center">
-      <Shape shapeType="ellipse" w="8" h="8" fill.color="34D399" />
-      <Text fontSize="11" color="34D399">LIVE</Text>
-      <VStack padding.top="4" padding.bottom="4" padding.left="12" padding.right="12" backgroundColor="1E293B" borderRadius="6">
-        <Text fontSize="11" color="94A3B8">最終更新: 2025-06-30 09:00</Text>
-      </VStack>
+      <Shape shapeType="roundRect" w="60" h="24" fill.color="052E2B" border.color="065F46" border.width="1" color="34D399" fontSize="11" bold="true" borderRadius="6">● LIVE</Shape>
+      <Shape shapeType="roundRect" w="180" h="24" fill.color="1E293B" color="94A3B8" fontSize="11" borderRadius="6">最終更新: 2025-06-30 09:00</Shape>
     </HStack>
   </HStack>
 
@@ -989,9 +1077,9 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
         <Icon name="triangle" size="16" color="2563EB" />
         <Text fontSize="15" color="1E3A8A" bold="true">DX成熟度モデル</Text>
       </HStack>
-      <Pyramid w="max" h="180" direction="up" fontSize="12" bold="true">
-        <PyramidLevel label="自律的イノベーション" color="1E40AF" textColor="FFFFFF" />
-        <PyramidLevel label="データドリブン経営" color="2563EB" textColor="FFFFFF" />
+      <Pyramid w="max" h="220" direction="up" fontSize="11" bold="true">
+        <PyramidLevel label="自律進化" color="1E40AF" textColor="FFFFFF" />
+        <PyramidLevel label="データ駆動経営" color="2563EB" textColor="FFFFFF" />
         <PyramidLevel label="業務プロセス最適化" color="3B82F6" textColor="FFFFFF" />
         <PyramidLevel label="デジタル基盤整備" color="60A5FA" textColor="1E3A8A" />
         <PyramidLevel label="アナログ業務中心" color="BFDBFE" textColor="1E40AF" />
@@ -1004,17 +1092,17 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
         <Icon name="layout-grid" size="16" color="7C3AED" />
         <Text fontSize="15" color="4C1D95" bold="true">施策優先順位マトリクス</Text>
       </HStack>
-      <Matrix w="max" h="280">
+      <Matrix w="max" h="320">
         <MatrixAxes x="実現容易性" y="ビジネスインパクト" />
         <MatrixQuadrants topLeft="戦略的投資" topRight="最優先実行" bottomLeft="様子見" bottomRight="即効施策" />
-        <MatrixItem label="AI分析基盤" x="0.3" y="0.85" color="7C3AED" />
-        <MatrixItem label="RPA導入" x="0.8" y="0.45" color="2563EB" />
-        <MatrixItem label="クラウド移行" x="0.75" y="0.8" color="6D28D9" />
-        <MatrixItem label="ペーパーレス" x="0.85" y="0.3" color="3B82F6" />
-        <MatrixItem label="データ基盤" x="0.4" y="0.7" color="8B5CF6" />
-        <MatrixItem label="IoTセンサー" x="0.25" y="0.5" color="4F46E5" />
-        <MatrixItem label="社内SNS" x="0.65" y="0.25" color="60A5FA" />
-        <MatrixItem label="顧客DX" x="0.55" y="0.9" color="5B21B6" />
+        <MatrixItem label="AI分析基盤" x="0.28" y="0.88" color="7C3AED" />
+        <MatrixItem label="顧客DX" x="0.58" y="0.92" color="5B21B6" />
+        <MatrixItem label="クラウド移行" x="0.78" y="0.78" color="6D28D9" />
+        <MatrixItem label="データ基盤" x="0.42" y="0.7" color="8B5CF6" />
+        <MatrixItem label="RPA導入" x="0.82" y="0.46" color="2563EB" />
+        <MatrixItem label="IoTセンサー" x="0.22" y="0.5" color="4F46E5" />
+        <MatrixItem label="社内SNS" x="0.62" y="0.24" color="60A5FA" />
+        <MatrixItem label="ペーパーレス" x="0.86" y="0.28" color="3B82F6" />
       </Matrix>
     </VStack>
 


### PR DESCRIPTION
## 概要

プレイグラウンドの 8 サンプルスライドの見た目をブラッシュアップしました。

## 変更内容

- 絵文字（⚡ 🔒 📱 🌱 🚀 💎）を Lucide ベースの `Icon` node へ差し替え、フォント環境に依存しない統一感のあるアイコン表現に変更
- 各スライドのタイトル周りに **アクセントアイコン + サブテキスト + ステータスバッジ** の構成を導入し、視覚階層を強化
- カード類のスタイル（`borderRadius` / `shadow` / `border` 色）を整理し、奥行きと余白を調整
- `pricing-plan`: ヘッダー〜カード〜フッターの 3 段構成に整理。フッターに保証ポイント（解約可能・カード不要・SOC 2 等）を追加
- `product-landing`: 各機能カードに数値ハイライト（5×, ISO 27001, 24/7）を追加し、CTA 帯にダウンロード/開始の 2 ボタン構成を導入
- `chart-showcase`: 各チャートカードのヘッダーをアイコン付きに統一し、エリアチャートの高さを縮めて見切れを解消
- `financial-summary`: 主要トピックスを横並びに整理しナンバードバッジ + 説明文の構成へ
- `project-dashboard`: タイトル右に \"ON TRACK\" / \"Phase 3｜開発中\" のステータスチップを追加。Tree / Flow / ProcessArrow の高さを最適化して右カラムの見切れを解消
- `strategy-analysis`: アクションプランを `Ol` から番号付き `Shape` ベルへ差し替え（プレビュー時のフォント依存を回避）。ヘッダーバッジを `Shape` ベースに固定幅化
- `dx-roadmap`: ピラミッド頂点の見切れを解消（\"自律進化\"／\"データ駆動経営\" にラベル短縮 + 高さ拡張）。マトリクス項目の配置を分散
- `saas-kpi`: ヘッダーの LIVE / 最終更新表示を `Shape` ベースの固定サイズバッジへ統一

## 検証

- `pnpm run lint` / `pnpm run typecheck` / `pnpm run fmt:check` / `pnpm run test:run` 全て通過
- 8 サンプル全てを `convertPptxToSvg` 経由で SVG 化 → PNG レンダリングして見た目を確認
- `codex-review` で セカンドオピニオン取得済み（critical なし、warning は既存パターン踏襲のため許容と判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)