### PR TITLE
feat!: 最上位 XML を <Slide> 必須ラップに変更

### DIFF
--- a/.changeset/require-slide-wrapper.md
+++ b/.changeset/require-slide-wrapper.md
@@ -1,0 +1,43 @@
+---
+"@hirokisakabe/pom": major
+"@hirokisakabe/pom-md": major
+---
+
+最上位 XML 要素を `<Slide>` で必須ラップする形式に変更（破壊的変更）。
+
+## 変更内容
+
+- `parseXml` の最上位要素は `<Slide>` のみ許容。それ以外を直下に置くとエラー
+- 各 `<Slide>` が 1 つのスライドを表し、その子要素がスライドのルートとなる
+- `<Slide>` は属性なしの最小実装。子要素が複数ある場合は暗黙的に VStack でラップされる
+- pom-md の出力も `<Slide>` ラップ形式に統一
+
+## 移行ガイド
+
+Before:
+
+```xml
+<VStack w="100%" h="max" padding="48">
+  <Text fontSize="32" bold="true">Slide 1</Text>
+</VStack>
+<VStack w="100%" h="max" padding="48">
+  <Text fontSize="32" bold="true">Slide 2</Text>
+</VStack>
+```
+
+After:
+
+```xml
+<Slide>
+  <VStack w="100%" h="max" padding="48">
+    <Text fontSize="32" bold="true">Slide 1</Text>
+  </VStack>
+</Slide>
+<Slide>
+  <VStack w="100%" h="max" padding="48">
+    <Text fontSize="32" bold="true">Slide 2</Text>
+  </VStack>
+</Slide>
+```
+
+各スライドのコンテンツを `<Slide>...</Slide>` で囲んでください。属性は受け付けません（背景色や notes などの per-slide 属性は別 issue で順次対応予定）。

--- a/apps/website/playground/client/lib/sampleTemplates.ts
+++ b/apps/website/playground/client/lib/sampleTemplates.ts
@@ -8,7 +8,7 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
   {
     id: "financial-summary",
     name: "決算サマリー",
-    xml: `<VStack w="max" h="max" padding="24" backgroundColor="F8F6F0" gap="14">
+    xml: `<Slide><VStack w="max" h="max" padding="24" backgroundColor="F8F6F0" gap="14">
   <HStack w="max" justifyContent="spaceBetween" alignItems="center">
     <HStack gap="0" alignItems="center">
       <Shape w="6" h="52" shapeType="rect" fill.color="1F3864" />
@@ -196,12 +196,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
     <Text fontSize="9" color="848591">※本資料に記載の数値はダミーデータです。実際の企業業績とは関係ありません。</Text>
     <Text fontSize="9" color="1F3864">株式会社サンプルホールディングス｜IR資料｜2025年1月発表</Text>
   </HStack>
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "product-landing",
     name: "プロダクト紹介",
-    xml: `<VStack w="1280" h="max" padding="56" gap="36" backgroundColor="F8F6F0" alignItems="stretch">
+    xml: `<Slide><VStack w="1280" h="max" padding="56" gap="36" backgroundColor="F8F6F0" alignItems="stretch">
 
   <VStack gap="18" alignItems="center">
     <HStack gap="8" alignItems="center" padding.top="6" padding.bottom="6" padding.left="14" padding.right="14" backgroundColor="E5EAF1" borderRadius="999">
@@ -284,12 +284,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
     </HStack>
   </VStack>
 
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "pricing-plan",
     name: "料金プラン",
-    xml: `<VStack h="max" w="max" padding="44" backgroundColor="F8F6F0" gap="28" alignItems="center">
+    xml: `<Slide><VStack h="max" w="max" padding="44" backgroundColor="F8F6F0" gap="28" alignItems="center">
   <VStack gap="10" alignItems="center">
     <HStack gap="6" alignItems="center" padding.top="6" padding.bottom="6" padding.left="14" padding.right="14" backgroundColor="EAEEF4" borderRadius="999">
       <Icon name="tag" size="14" color="3D5A80" />
@@ -367,12 +367,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
   </HStack>
 
   <Text fontSize="12" color="475569" textAlign="center" padding.top="4">✓ いつでも解約可能 ・ ✓ クレジットカード不要 ・ ✓ 日本語サポート ・ ✓ SOC 2 Type II 準拠</Text>
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "chart-showcase",
     name: "チャート集",
-    xml: `<VStack w="max" h="max" padding="28" backgroundColor="F2EEE5" gap="16">
+    xml: `<Slide><VStack w="max" h="max" padding="28" backgroundColor="F2EEE5" gap="16">
   <HStack w="max" justifyContent="spaceBetween" alignItems="center">
     <HStack gap="12" alignItems="center">
       <Icon name="bar-chart-3" size="22" color="FFFFFF" variant="square-filled" bgColor="2E4F7A" w="46" h="46" />
@@ -525,12 +525,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
       </Chart>
     </VStack>
   </VStack>
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "project-dashboard",
     name: "プロジェクト管理ダッシュボード",
-    xml: `<VStack w="max" h="max" padding="28" backgroundColor="0B1220" gap="18">
+    xml: `<Slide><VStack w="max" h="max" padding="28" backgroundColor="0B1220" gap="18">
   <HStack w="max" justifyContent="spaceBetween" alignItems="center">
     <HStack gap="14" alignItems="center">
       <Icon name="layout-dashboard" size="24" color="7C95B5" variant="square-filled" bgColor="1A2840" w="50" h="50" />
@@ -681,12 +681,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
       </VStack>
     </VStack>
   </HStack>
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "strategy-analysis",
     name: "経営戦略分析",
-    xml: `<VStack w="1280" h="720" padding="32" backgroundColor="F8F6F0" gap="18">
+    xml: `<Slide><VStack w="1280" h="720" padding="32" backgroundColor="F8F6F0" gap="18">
  <HStack w="max" justifyContent="spaceBetween" alignItems="center">
  <HStack gap="14" alignItems="center">
  <Icon name="briefcase" size="26" color="2E4F7A" variant="circle-filled" bgColor="E5EAF1" w="54" h="54" />
@@ -790,12 +790,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
  </HStack>
  </VStack>
  </HStack>
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "saas-kpi",
     name: "SaaS KPIダッシュボード",
-    xml: `<VStack w="max" h="max" padding="28" backgroundColor="0F172A" gap="18">
+    xml: `<Slide><VStack w="max" h="max" padding="28" backgroundColor="0F172A" gap="18">
 
   <HStack w="max" alignItems="center" justifyContent="spaceBetween">
     <HStack gap="12" alignItems="center">
@@ -1042,12 +1042,12 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
     </HStack>
   </HStack>
 
-</VStack>`,
+</VStack></Slide>`,
   },
   {
     id: "dx-roadmap",
     name: "DX推進ロードマップ",
-    xml: `<VStack w="max" h="max" padding="28" backgroundColor="F2F0EA" gap="14">
+    xml: `<Slide><VStack w="max" h="max" padding="28" backgroundColor="F2F0EA" gap="14">
   
   <HStack w="max" gap="12" alignItems="center">
     <Icon name="rocket" size="28" color="FFFFFF" variant="square-filled" bgColor="6C3AED" w="48" h="48" />
@@ -1162,7 +1162,7 @@ export const SAMPLE_TEMPLATES: SampleTemplate[] = [
     <Text fontSize="9" color="6E7282">DX推進本部｜Corporate Digital Transformation Office</Text>
   </HStack>
 
-</VStack>`,
+</VStack></Slide>`,
   },
 ];
 

--- a/apps/website/public/llm.txt
+++ b/apps/website/public/llm.txt
@@ -10,6 +10,27 @@ A compact reference for the pom XML format, designed to be pasted into LLM promp
 - Nested object attributes use dot notation (e.g. `fill.color="1D4ED8"`)
 - For shorthand + dot-notation attributes (e.g. `padding` + `padding.top`), both can be mixed on the same node. Shorthand sets defaults; dot-notation keys override per side/property.
 
+## Top-Level Structure
+
+The top level of every pom XML document is one or more `<Slide>` elements. Each `<Slide>` wraps the content of a single slide.
+
+```xml
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24">
+    <Text fontSize="32" bold="true">Slide 1</Text>
+  </VStack>
+</Slide>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24">
+    <Text fontSize="32" bold="true">Slide 2</Text>
+  </VStack>
+</Slide>
+```
+
+- Top-level elements other than `<Slide>` are an error.
+- A `<Slide>` must contain at least one child element.
+- `<Slide>` does not currently take attributes; per-slide properties (background, notes, etc.) are tracked separately.
+
 ## Common Attributes (All Nodes)
 
 | Attribute         | Type                                                       | Description                                |
@@ -481,22 +502,26 @@ When the same property is specified via both attributes (JSON string) and child 
 ### Basic Structure
 
 ```xml
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="stretch">
-  <Text fontSize="32" bold="true">Title</Text>
-  <Text fontSize="14">Body text</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="stretch">
+    <Text fontSize="32" bold="true">Title</Text>
+    <Text fontSize="14">Body text</Text>
+  </VStack>
+</Slide>
 ```
 
 ### Two-Column Layout
 
 ```xml
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="stretch">
-  <Text fontSize="28" bold="true">Title</Text>
-  <HStack gap="24" alignItems="start">
-    <Text w="50%" padding="20" backgroundColor="FFFFFF" borderRadius="8" fontSize="14">Left column</Text>
-    <Text w="50%" padding="20" backgroundColor="FFFFFF" borderRadius="8" fontSize="14">Right column</Text>
-  </HStack>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="stretch">
+    <Text fontSize="28" bold="true">Title</Text>
+    <HStack gap="24" alignItems="start">
+      <Text w="50%" padding="20" backgroundColor="FFFFFF" borderRadius="8" fontSize="14">Left column</Text>
+      <Text w="50%" padding="20" backgroundColor="FFFFFF" borderRadius="8" fontSize="14">Right column</Text>
+    </HStack>
+  </VStack>
+</Slide>
 ```
 
 ## Notes

--- a/packages/pom-md/src/parseMd.test.ts
+++ b/packages/pom-md/src/parseMd.test.ts
@@ -106,6 +106,19 @@ describe("parseMd", () => {
       const { xml } = parseMd(md);
       expect(xml).not.toContain("console.log");
     });
+
+    it("pomxml フェンスにフルスライド XML を貼り付けた場合、外側の <Slide> ラッパーを剥がす", () => {
+      const md = `\`\`\`pomxml
+<Slide>
+  <Text fontSize="24">Hello</Text>
+</Slide>
+\`\`\``;
+      const { xml } = parseMd(md);
+      // 外側の <Slide> は parseMd 自身が付与するため、内側の <Slide> はネストしない
+      expect((xml.match(/<Slide>/g) ?? []).length).toBe(1);
+      expect((xml.match(/<\/Slide>/g) ?? []).length).toBe(1);
+      expect(xml).toContain('<Text fontSize="24">Hello</Text>');
+    });
   });
 
   describe("スライド分割", () => {

--- a/packages/pom-md/src/parseMd.ts
+++ b/packages/pom-md/src/parseMd.ts
@@ -72,6 +72,18 @@ function parseFrontmatter(markdown: string): {
   return { frontmatter, body };
 }
 
+/**
+ * pomxml フェンスの内容から、外側の `<Slide>...</Slide>` ラッパーを 1 段だけ
+ * 剥がす。ユーザーが pom 公式ドキュメントなどからフルスライド XML を貼り付けた
+ * 際に、parseMd の出力で `<Slide>` がネストして parseXml が失敗するのを防ぐ。
+ * `<Slide>` を含まない通常のスニペット（例: `<Text>...</Text>`）はそのまま返す。
+ */
+function stripSlideWrapper(content: string): string {
+  const trimmed = content.trim();
+  const match = trimmed.match(/^<Slide\s*>([\s\S]*)<\/Slide>$/);
+  return match ? match[1].trim() : trimmed;
+}
+
 /** XML 特殊文字をエスケープする */
 function escapeXml(str: string): string {
   return str
@@ -181,7 +193,10 @@ function tokensToXml(tokens: Token[]): string {
 
     // --- pomxml コードフェンス ---
     if (token.type === "fence" && token.info.trim() === "pomxml") {
-      parts.push(token.content.trim());
+      // フェンス内容は周囲の <Slide><VStack> 内に埋め込まれるため、ユーザーが
+      // フルスライド XML（`<Slide>...</Slide>`）を貼り付けた場合は外側の
+      // <Slide> ラッパーを剥がして、入れ子になった不正な <Slide> 出力を避ける。
+      parts.push(stripSlideWrapper(token.content.trim()));
       i++;
       continue;
     }
@@ -356,7 +371,7 @@ export function parseMd(markdown: string): ParseMdResult {
     const bgAttr = bgColor ? ` backgroundColor="${escapeXml(bgColor)}"` : "";
 
     xmlSlides.push(
-      `<VStack w="${size.w}" h="${size.h}" padding="48" gap="16"${bgAttr}>\n${content}\n</VStack>`,
+      `<Slide><VStack w="${size.w}" h="${size.h}" padding="48" gap="16"${bgAttr}>\n${content}\n</VStack></Slide>`,
     );
   }
 

--- a/packages/pom-vscode/sample.pom.xml
+++ b/packages/pom-vscode/sample.pom.xml
@@ -1,56 +1,60 @@
-<VStack gap="24" padding="48">
-  <Text fontSize="32" bold="true" color="0F172A">pom XML Feature Showcase</Text>
-  <Text fontSize="16" color="64748B">Declarative PowerPoint generation with <B>pom</B></Text>
-  <HStack gap="32" w="100%">
-    <VStack gap="16" w="50%">
-      <Text fontSize="20" bold="true" color="1D4ED8">Text &amp; Lists</Text>
-      <Text fontSize="14">Inline: <B>bold</B>, <I>italic</I>, <U>underline</U>, <S>strike</S>, <Mark>highlight</Mark></Text>
-      <Ul fontSize="14">
-        <Li>Unordered item 1</Li>
-        <Li>Unordered item 2</Li>
-      </Ul>
-      <Ol fontSize="14" numberType="arabicPeriod">
-        <Li>Ordered item 1</Li>
-        <Li>Ordered item 2</Li>
-      </Ol>
-    </VStack>
-    <VStack gap="16" w="50%">
-      <Text fontSize="20" bold="true" color="1D4ED8">Table</Text>
-      <Table>
-        <Tr>
-          <Td bold="true" backgroundColor="0F172A" color="FFFFFF">Feature</Td>
-          <Td bold="true" backgroundColor="0F172A" color="FFFFFF">Status</Td>
-        </Tr>
-        <Tr>
-          <Td>Live preview</Td>
-          <Td>OK</Td>
-        </Tr>
-        <Tr>
-          <Td>Debounce</Td>
-          <Td>OK</Td>
-        </Tr>
-      </Table>
-    </VStack>
-  </HStack>
-</VStack>
-<VStack gap="24" padding="48">
-  <Text fontSize="28" bold="true" color="0F172A">Shapes &amp; Diagrams</Text>
-  <HStack gap="24" alignItems="center" justifyContent="center" w="100%">
-    <Shape shapeType="roundRect" w="120" h="60" text="roundRect" fill.color="1D4ED8" color="FFFFFF" fontSize="12" />
-    <Shape shapeType="ellipse" w="80" h="60" text="ellipse" fill.color="16A34A" color="FFFFFF" fontSize="12" />
-    <Shape shapeType="diamond" w="80" h="80" text="diamond" fill.color="DC2626" color="FFFFFF" fontSize="12" />
-  </HStack>
-  <ProcessArrow direction="horizontal" w="100%" h="80">
-    <ProcessArrowStep label="Plan" color="1D4ED8" textColor="FFFFFF" />
-    <ProcessArrowStep label="Build" color="2563EB" textColor="FFFFFF" />
-    <ProcessArrowStep label="Test" color="3B82F6" textColor="FFFFFF" />
-    <ProcessArrowStep label="Deploy" color="60A5FA" textColor="FFFFFF" />
-  </ProcessArrow>
-  <HStack gap="32" alignItems="center" justifyContent="center" w="100%">
-    <Icon name="cpu" size="32" color="#1D4ED8" variant="circle-filled" bgColor="#DBEAFE" />
-    <Icon name="database" size="32" color="#16A34A" variant="circle-filled" bgColor="#DCFCE7" />
-    <Icon name="cloud" size="32" color="#9333EA" variant="circle-filled" bgColor="#F3E8FF" />
-    <Icon name="shield" size="32" color="#DC2626" variant="circle-filled" bgColor="#FEE2E2" />
-    <Icon name="settings" size="32" color="#64748B" variant="circle-filled" bgColor="#F1F5F9" />
-  </HStack>
-</VStack>
+<Slide>
+  <VStack gap="24" padding="48">
+    <Text fontSize="32" bold="true" color="0F172A">pom XML Feature Showcase</Text>
+    <Text fontSize="16" color="64748B">Declarative PowerPoint generation with <B>pom</B></Text>
+    <HStack gap="32" w="100%">
+      <VStack gap="16" w="50%">
+        <Text fontSize="20" bold="true" color="1D4ED8">Text &amp; Lists</Text>
+        <Text fontSize="14">Inline: <B>bold</B>, <I>italic</I>, <U>underline</U>, <S>strike</S>, <Mark>highlight</Mark></Text>
+        <Ul fontSize="14">
+          <Li>Unordered item 1</Li>
+          <Li>Unordered item 2</Li>
+        </Ul>
+        <Ol fontSize="14" numberType="arabicPeriod">
+          <Li>Ordered item 1</Li>
+          <Li>Ordered item 2</Li>
+        </Ol>
+      </VStack>
+      <VStack gap="16" w="50%">
+        <Text fontSize="20" bold="true" color="1D4ED8">Table</Text>
+        <Table>
+          <Tr>
+            <Td bold="true" backgroundColor="0F172A" color="FFFFFF">Feature</Td>
+            <Td bold="true" backgroundColor="0F172A" color="FFFFFF">Status</Td>
+          </Tr>
+          <Tr>
+            <Td>Live preview</Td>
+            <Td>OK</Td>
+          </Tr>
+          <Tr>
+            <Td>Debounce</Td>
+            <Td>OK</Td>
+          </Tr>
+        </Table>
+      </VStack>
+    </HStack>
+  </VStack>
+</Slide>
+<Slide>
+  <VStack gap="24" padding="48">
+    <Text fontSize="28" bold="true" color="0F172A">Shapes &amp; Diagrams</Text>
+    <HStack gap="24" alignItems="center" justifyContent="center" w="100%">
+      <Shape shapeType="roundRect" w="120" h="60" text="roundRect" fill.color="1D4ED8" color="FFFFFF" fontSize="12" />
+      <Shape shapeType="ellipse" w="80" h="60" text="ellipse" fill.color="16A34A" color="FFFFFF" fontSize="12" />
+      <Shape shapeType="diamond" w="80" h="80" text="diamond" fill.color="DC2626" color="FFFFFF" fontSize="12" />
+    </HStack>
+    <ProcessArrow direction="horizontal" w="100%" h="80">
+      <ProcessArrowStep label="Plan" color="1D4ED8" textColor="FFFFFF" />
+      <ProcessArrowStep label="Build" color="2563EB" textColor="FFFFFF" />
+      <ProcessArrowStep label="Test" color="3B82F6" textColor="FFFFFF" />
+      <ProcessArrowStep label="Deploy" color="60A5FA" textColor="FFFFFF" />
+    </ProcessArrow>
+    <HStack gap="32" alignItems="center" justifyContent="center" w="100%">
+      <Icon name="cpu" size="32" color="#1D4ED8" variant="circle-filled" bgColor="#DBEAFE" />
+      <Icon name="database" size="32" color="#16A34A" variant="circle-filled" bgColor="#DCFCE7" />
+      <Icon name="cloud" size="32" color="#9333EA" variant="circle-filled" bgColor="#F3E8FF" />
+      <Icon name="shield" size="32" color="#DC2626" variant="circle-filled" bgColor="#FEE2E2" />
+      <Icon name="settings" size="32" color="#64748B" variant="circle-filled" bgColor="#F1F5F9" />
+    </HStack>
+  </VStack>
+</Slide>

--- a/packages/pom-vscode/src/test/extension.test.ts
+++ b/packages/pom-vscode/src/test/extension.test.ts
@@ -142,10 +142,12 @@ suite("pom-vscode Extension", () => {
     // Icon ノードを含む XML でプレビュー生成を検証
     // バンドル後の環境で @resvg/resvg-wasm が正しく解決されることを確認する
     const xml = [
-      '<HStack w="1280" h="720" gap="24" alignItems="center">',
-      '  <Icon name="star" size="48" color="#f59e0b" />',
-      '  <Text fontSize="24">Icon test</Text>',
-      "</HStack>",
+      "<Slide>",
+      '  <HStack w="1280" h="720" gap="24" alignItems="center">',
+      '    <Icon name="star" size="48" color="#f59e0b" />',
+      '    <Text fontSize="24">Icon test</Text>',
+      "  </HStack>",
+      "</Slide>",
     ].join("\n");
 
     const result = await generatePreviewSvg(xml, fontDirs, "xml");

--- a/packages/pom/README.md
+++ b/packages/pom/README.md
@@ -58,15 +58,19 @@ npm install @hirokisakabe/pom
 import { buildPptx } from "@hirokisakabe/pom";
 
 const xml = `
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
-  <Text fontSize="48" bold="true">Presentation Title</Text>
-  <Text fontSize="24" color="666666">Subtitle</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+    <Text fontSize="48" bold="true">Presentation Title</Text>
+    <Text fontSize="24" color="666666">Subtitle</Text>
+  </VStack>
+</Slide>
 `;
 
 const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
 await pptx.writeFile({ fileName: "presentation.pptx" });
 ```
+
+Each slide must be wrapped in a `<Slide>` element. To produce multiple slides, list multiple `<Slide>` elements at the top level.
 
 ## Available Nodes
 

--- a/packages/pom/bench/buildPptx.bench.ts
+++ b/packages/pom/bench/buildPptx.bench.ts
@@ -12,77 +12,83 @@ import { freeYogaTree } from "../src/shared/freeYogaTree.ts";
 // ---------------------------------------------------------------------------
 
 const simpleXml = `
-<VStack w="100%" h="max" padding="48" gap="20" alignItems="stretch">
-  <Text fontSize="28" bold="true">Simple Slide</Text>
-  <Text fontSize="16">Hello World</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="20" alignItems="stretch">
+    <Text fontSize="28" bold="true">Simple Slide</Text>
+    <Text fontSize="16">Hello World</Text>
+  </VStack>
+</Slide>
 `;
 
 const complexXml = `
-<VStack w="100%" h="max" padding="48" gap="16" alignItems="stretch">
-  <Text fontSize="28" bold="true">Complex Slide</Text>
-  <HStack gap="16" alignItems="stretch">
-    <VStack gap="8">
-      <Text fontSize="14" bold="true">Section A</Text>
-      <Ul fontSize="12">
-        <Li>Item 1 with some longer text content</Li>
-        <Li>Item 2 with even more detailed description</Li>
-        <Li>Item 3</Li>
-      </Ul>
-    </VStack>
-    <VStack gap="8">
-      <Text fontSize="14" bold="true">Section B</Text>
-      <Table defaultRowHeight="32">
-        <Col width="100" />
-        <Col width="100" />
-        <Col width="100" />
-        <Tr>
-          <Td fontSize="11" bold="true">Header 1</Td>
-          <Td fontSize="11" bold="true">Header 2</Td>
-          <Td fontSize="11" bold="true">Header 3</Td>
-        </Tr>
-        <Tr>
-          <Td fontSize="11">Cell A1</Td>
-          <Td fontSize="11">Cell A2</Td>
-          <Td fontSize="11">Cell A3</Td>
-        </Tr>
-        <Tr>
-          <Td fontSize="11">Cell B1</Td>
-          <Td fontSize="11">Cell B2</Td>
-          <Td fontSize="11">Cell B3</Td>
-        </Tr>
-        <Tr>
-          <Td fontSize="11">Cell C1</Td>
-          <Td fontSize="11">Cell C2</Td>
-          <Td fontSize="11">Cell C3</Td>
-        </Tr>
-      </Table>
-    </VStack>
-  </HStack>
-  <HStack gap="12">
-    <Shape shapeType="rect" w="120" h="60" fill.color="4472C4" />
-    <Shape shapeType="ellipse" w="120" h="60" fill.color="ED7D31" />
-    <Shape shapeType="roundRect" w="120" h="60" fill.color="70AD47" />
-  </HStack>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="16" alignItems="stretch">
+    <Text fontSize="28" bold="true">Complex Slide</Text>
+    <HStack gap="16" alignItems="stretch">
+      <VStack gap="8">
+        <Text fontSize="14" bold="true">Section A</Text>
+        <Ul fontSize="12">
+          <Li>Item 1 with some longer text content</Li>
+          <Li>Item 2 with even more detailed description</Li>
+          <Li>Item 3</Li>
+        </Ul>
+      </VStack>
+      <VStack gap="8">
+        <Text fontSize="14" bold="true">Section B</Text>
+        <Table defaultRowHeight="32">
+          <Col width="100" />
+          <Col width="100" />
+          <Col width="100" />
+          <Tr>
+            <Td fontSize="11" bold="true">Header 1</Td>
+            <Td fontSize="11" bold="true">Header 2</Td>
+            <Td fontSize="11" bold="true">Header 3</Td>
+          </Tr>
+          <Tr>
+            <Td fontSize="11">Cell A1</Td>
+            <Td fontSize="11">Cell A2</Td>
+            <Td fontSize="11">Cell A3</Td>
+          </Tr>
+          <Tr>
+            <Td fontSize="11">Cell B1</Td>
+            <Td fontSize="11">Cell B2</Td>
+            <Td fontSize="11">Cell B3</Td>
+          </Tr>
+          <Tr>
+            <Td fontSize="11">Cell C1</Td>
+            <Td fontSize="11">Cell C2</Td>
+            <Td fontSize="11">Cell C3</Td>
+          </Tr>
+        </Table>
+      </VStack>
+    </HStack>
+    <HStack gap="12">
+      <Shape shapeType="rect" w="120" h="60" fill.color="4472C4" />
+      <Shape shapeType="ellipse" w="120" h="60" fill.color="ED7D31" />
+      <Shape shapeType="roundRect" w="120" h="60" fill.color="70AD47" />
+    </HStack>
+  </VStack>
+</Slide>
 `;
 
 const multiSlideXml = Array.from(
   { length: 10 },
   (_, i) => `
-<VStack w="100%" h="max" padding="48" gap="16" alignItems="stretch">
-  <Text fontSize="24" bold="true">Slide ${i + 1}</Text>
-  <HStack gap="16" alignItems="stretch">
-    <VStack gap="8">
-      <Text fontSize="14">Content block A for slide ${i + 1}</Text>
-      <Text fontSize="12">Additional details and description text here</Text>
-    </VStack>
-    <VStack gap="8">
-      <Text fontSize="14">Content block B for slide ${i + 1}</Text>
-      <Shape shapeType="rect" w="200" h="100" fill.color="4472C4" />
-    </VStack>
-  </HStack>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="16" alignItems="stretch">
+    <Text fontSize="24" bold="true">Slide ${i + 1}</Text>
+    <HStack gap="16" alignItems="stretch">
+      <VStack gap="8">
+        <Text fontSize="14">Content block A for slide ${i + 1}</Text>
+        <Text fontSize="12">Additional details and description text here</Text>
+      </VStack>
+      <VStack gap="8">
+        <Text fontSize="14">Content block B for slide ${i + 1}</Text>
+        <Shape shapeType="rect" w="200" h="100" fill.color="4472C4" />
+      </VStack>
+    </HStack>
+  </VStack>
+</Slide>
 `,
 ).join("\n");
 

--- a/packages/pom/docs/api-reference.md
+++ b/packages/pom/docs/api-reference.md
@@ -23,16 +23,20 @@ async function buildPptx(
 
 #### `xml` (required)
 
-An XML string describing the slide content. Each root-level element represents one slide. See [Nodes](./nodes.md) for available node types and [llm.txt](/llm.txt) for the complete XML reference.
+An XML string describing the slide content. Each top-level `<Slide>` element represents one slide and wraps that slide's content. See [Nodes](./nodes.md) for available node types and [llm.txt](/llm.txt) for the complete XML reference.
 
 ```typescript
 const xml = `
-<VStack w="100%" h="max" padding="48">
-  <Text fontSize="32" bold="true">Slide 1</Text>
-</VStack>
-<VStack w="100%" h="max" padding="48">
-  <Text fontSize="24">Slide 2</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48">
+    <Text fontSize="32" bold="true">Slide 1</Text>
+  </VStack>
+</Slide>
+<Slide>
+  <VStack w="100%" h="max" padding="48">
+    <Text fontSize="24">Slide 2</Text>
+  </VStack>
+</Slide>
 `;
 ```
 

--- a/packages/pom/docs/index.mdx
+++ b/packages/pom/docs/index.mdx
@@ -30,15 +30,19 @@ npm install @hirokisakabe/pom
 import { buildPptx } from "@hirokisakabe/pom";
 
 const xml = `
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
-  <Text fontSize="48" bold="true">Presentation Title</Text>
-  <Text fontSize="24" color="666666">Subtitle</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+    <Text fontSize="48" bold="true">Presentation Title</Text>
+    <Text fontSize="24" color="666666">Subtitle</Text>
+  </VStack>
+</Slide>
 `;
 
 const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
 await pptx.writeFile({ fileName: "presentation.pptx" });
 ```
+
+Each slide must be wrapped in a `<Slide>` element. To produce multiple slides, list multiple `<Slide>` elements at the top level.
 
 ## Node List
 

--- a/packages/pom/docs/master-slide.md
+++ b/packages/pom/docs/master-slide.md
@@ -8,12 +8,16 @@ You can define a slide master with static objects (text, images, rectangles, lin
 import { buildPptx } from "@hirokisakabe/pom";
 
 const xml = `
-<VStack w="100%" h="max" padding="48">
-  <Text fontSize="32" bold="true">Page 1</Text>
-</VStack>
-<VStack w="100%" h="max" padding="48">
-  <Text fontSize="32" bold="true">Page 2</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48">
+    <Text fontSize="32" bold="true">Page 1</Text>
+  </VStack>
+</Slide>
+<Slide>
+  <VStack w="100%" h="max" padding="48">
+    <Text fontSize="32" bold="true">Page 2</Text>
+  </VStack>
+</Slide>
 `;
 
 const { pptx } = await buildPptx(

--- a/packages/pom/docs/nodes.md
+++ b/packages/pom/docs/nodes.md
@@ -2,6 +2,26 @@
 
 This document provides a complete reference for all node types available in pom.
 
+## Top-Level `<Slide>`
+
+The top level of a pom XML document is one or more `<Slide>` elements. Each `<Slide>` represents one slide and wraps that slide's content (any of the nodes below).
+
+```xml
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24">
+    <Text fontSize="32" bold="true">Title</Text>
+    <Text fontSize="14">Body</Text>
+  </VStack>
+</Slide>
+```
+
+- A `<Slide>` must contain at least one child element.
+- Multiple top-level `<Slide>` elements produce multiple slides.
+- Top-level elements other than `<Slide>` are an error.
+- `<Slide>` does not currently take attributes; per-slide properties (background, notes, etc.) are tracked separately.
+
+The remaining sections describe nodes that go inside a `<Slide>`. For brevity, the example snippets below omit the `<Slide>` wrapper.
+
 ## Common Properties
 
 Layout attributes that all nodes can have.

--- a/packages/pom/main.ts
+++ b/packages/pom/main.ts
@@ -1,37 +1,39 @@
 import { buildPptx } from "./src/index.js";
 
 const xml = `
-<VStack w="1280" h="720" padding.top="24" padding.bottom="24" padding.left="48" padding.right="48" gap="24" backgroundColor="F8FAFC">
-  <Text fontSize="28" bold="true" color="1E293B">Icon Preset Library Demo</Text>
+<Slide>
+  <VStack w="1280" h="720" padding.top="24" padding.bottom="24" padding.left="48" padding.right="48" gap="24" backgroundColor="F8FAFC">
+    <Text fontSize="28" bold="true" color="1E293B">Icon Preset Library Demo</Text>
 
-  <HStack gap="24" alignItems="center">
-    <Icon name="cpu" size="48" color="#1D4ED8" />
-    <Icon name="database" size="48" color="#16A34A" />
-    <Icon name="cloud" size="48" color="#0EA5E9" />
-    <Icon name="server" size="48" color="#DC2626" />
-    <Icon name="shield" size="48" color="#0F172A" />
-    <Icon name="star" size="48" color="#F59E0B" />
-    <Icon name="heart" size="48" color="#DC2626" />
-    <Icon name="zap" size="48" color="#F59E0B" />
-    <Icon name="target" size="48" color="#16A34A" />
-    <Icon name="lightbulb" size="48" color="#1D4ED8" />
-  </HStack>
+    <HStack gap="24" alignItems="center">
+      <Icon name="cpu" size="48" color="#1D4ED8" />
+      <Icon name="database" size="48" color="#16A34A" />
+      <Icon name="cloud" size="48" color="#0EA5E9" />
+      <Icon name="server" size="48" color="#DC2626" />
+      <Icon name="shield" size="48" color="#0F172A" />
+      <Icon name="star" size="48" color="#F59E0B" />
+      <Icon name="heart" size="48" color="#DC2626" />
+      <Icon name="zap" size="48" color="#F59E0B" />
+      <Icon name="target" size="48" color="#16A34A" />
+      <Icon name="lightbulb" size="48" color="#1D4ED8" />
+    </HStack>
 
-  <HStack gap="32" alignItems="end">
-    <Icon name="briefcase" size="16" />
-    <Icon name="briefcase" size="24" />
-    <Icon name="briefcase" size="32" />
-    <Icon name="briefcase" size="48" />
-    <Icon name="briefcase" size="64" />
-  </HStack>
+    <HStack gap="32" alignItems="end">
+      <Icon name="briefcase" size="16" />
+      <Icon name="briefcase" size="24" />
+      <Icon name="briefcase" size="32" />
+      <Icon name="briefcase" size="48" />
+      <Icon name="briefcase" size="64" />
+    </HStack>
 
-  <HStack gap="24" alignItems="center">
-    <Icon name="trending-up" size="32" color="#16A34A" />
-    <Icon name="bar-chart" size="32" color="#1D4ED8" />
-    <Icon name="pie-chart" size="32" color="#9333EA" />
-    <Icon name="line-chart" size="32" color="#DC2626" />
-  </HStack>
-</VStack>
+    <HStack gap="24" alignItems="center">
+      <Icon name="trending-up" size="32" color="#16A34A" />
+      <Icon name="bar-chart" size="32" color="#1D4ED8" />
+      <Icon name="pie-chart" size="32" color="#9333EA" />
+      <Icon name="line-chart" size="32" color="#DC2626" />
+    </HStack>
+  </VStack>
+</Slide>
 `;
 
 async function main() {

--- a/packages/pom/scripts/docs-images/generateNodeImages.ts
+++ b/packages/pom/scripts/docs-images/generateNodeImages.ts
@@ -25,7 +25,7 @@ async function generateNodeImage(
 
   // PPTXを生成
   const { pptx } = await buildPptx(
-    sampleXml,
+    `<Slide>${sampleXml}</Slide>`,
     { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
     { textMeasurement: "opentype" },
   );

--- a/packages/pom/src/buildPptx.test.ts
+++ b/packages/pom/src/buildPptx.test.ts
@@ -7,7 +7,7 @@ describe("buildPptx 並列実行", () => {
   const slideSize = { w: 1280, h: 720 };
 
   it("異なる textMeasurement モードで並列実行しても干渉しない", async () => {
-    const xml = `<VStack><Text fontSize="24">テスト文字列</Text></VStack>`;
+    const xml = `<Slide><VStack><Text fontSize="24">テスト文字列</Text></VStack></Slide>`;
 
     const spy = vi.spyOn(measureTextModule, "measureText");
 
@@ -41,8 +41,8 @@ describe("buildPptx 並列実行", () => {
   });
 
   it("同一オプションで並列実行してもキャッシュが干渉しない", async () => {
-    const xml1 = `<VStack><Text fontSize="20">文字列A</Text></VStack>`;
-    const xml2 = `<VStack><Text fontSize="30">文字列B</Text></VStack>`;
+    const xml1 = `<Slide><VStack><Text fontSize="20">文字列A</Text></VStack></Slide>`;
+    const xml2 = `<Slide><VStack><Text fontSize="30">文字列B</Text></VStack></Slide>`;
 
     const [result1, result2] = await Promise.all([
       buildPptx(xml1, slideSize, { autoFit: false }),
@@ -54,8 +54,8 @@ describe("buildPptx 並列実行", () => {
   });
 
   it("Icon を含む並列実行でキャッシュが干渉しない", async () => {
-    const xml1 = `<VStack><Icon name="star" size="32" color="#FF0000" /></VStack>`;
-    const xml2 = `<VStack><Icon name="heart" size="48" color="#0000FF" /></VStack>`;
+    const xml1 = `<Slide><VStack><Icon name="star" size="32" color="#FF0000" /></VStack></Slide>`;
+    const xml2 = `<Slide><VStack><Icon name="heart" size="48" color="#0000FF" /></VStack></Slide>`;
 
     const [result1, result2] = await Promise.all([
       buildPptx(xml1, slideSize, { autoFit: false }),
@@ -71,27 +71,27 @@ describe("buildPptx diagnostics", () => {
   const slideSize = { w: 1280, h: 720 };
 
   it("正常なビルドでは diagnostics が空配列", async () => {
-    const xml = `<VStack><Text fontSize="24">Hello</Text></VStack>`;
+    const xml = `<Slide><VStack><Text fontSize="24">Hello</Text></VStack></Slide>`;
     const result = await buildPptx(xml, slideSize, { autoFit: false });
     expect(result.diagnostics).toEqual([]);
   });
 
   it("画像測定失敗時に IMAGE_MEASURE_FAILED が記録される", async () => {
-    const xml = `<VStack><Image src="nonexistent-file.png" /></VStack>`;
+    const xml = `<Slide><VStack><Image src="nonexistent-file.png" /></VStack></Slide>`;
     const result = await buildPptx(xml, slideSize, { autoFit: false });
     expect(result.diagnostics.length).toBeGreaterThan(0);
     expect(result.diagnostics[0].code).toBe("IMAGE_MEASURE_FAILED");
   });
 
   it("strict: true で diagnostics がある場合 DiagnosticsError をスロー", async () => {
-    const xml = `<VStack><Image src="nonexistent-file.png" /></VStack>`;
+    const xml = `<Slide><VStack><Image src="nonexistent-file.png" /></VStack></Slide>`;
     await expect(
       buildPptx(xml, slideSize, { autoFit: false, strict: true }),
     ).rejects.toThrow(DiagnosticsError);
   });
 
   it("strict: true で diagnostics がない場合は正常に返る", async () => {
-    const xml = `<VStack><Text fontSize="24">Hello</Text></VStack>`;
+    const xml = `<Slide><VStack><Text fontSize="24">Hello</Text></VStack></Slide>`;
     const result = await buildPptx(xml, slideSize, {
       autoFit: false,
       strict: true,

--- a/packages/pom/src/docsSamples.test.ts
+++ b/packages/pom/src/docsSamples.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { XMLParser, XMLBuilder } from "fast-xml-parser";
 import { buildPptx } from "./buildPptx.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -59,8 +60,45 @@ describe("docs/nodes.md xml samples", () => {
     const skip = SKIP_SECTIONS.has(sample.section);
     const title = `[${sample.index}] ${sample.section} の xml サンプルが diagnostics なしで buildPptx できる`;
     (skip ? it.skip : it)(title, async () => {
-      const { diagnostics } = await buildPptx(sample.xml, { w: 1280, h: 720 });
+      const xml = wrapSampleInSlides(sample.xml);
+      const { diagnostics } = await buildPptx(xml, { w: 1280, h: 720 });
       expect(diagnostics).toEqual([]);
     });
   }
 });
+
+// docs/nodes.md のサンプルはノードに焦点を当てたスニペットとして記述されており、
+// トップレベルに `<Slide>` を含まない。複数のトップレベル要素を 1 つの `<Slide>`
+// でまとめると暗黙の VStack でレイアウトされてオーバーフローするので、各
+// トップレベル要素を独立した `<Slide>` でラップしてから検証する。
+function wrapSampleInSlides(rawXml: string): string {
+  if (rawXml.trimStart().startsWith("<Slide")) {
+    return rawXml;
+  }
+  const parser = new XMLParser({
+    preserveOrder: true,
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    parseAttributeValue: false,
+    parseTagValue: false,
+    trimValues: false,
+  });
+  const builder = new XMLBuilder({
+    preserveOrder: true,
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+  });
+  const wrapped = `<__root__>${rawXml}</__root__>`;
+  const parsed = parser.parse(wrapped) as Array<Record<string, unknown>>;
+  const rootChildren = (parsed[0]?.["__root__"] as unknown[]) ?? [];
+  const topLevelElements = rootChildren.filter(
+    (child): child is Record<string, unknown> =>
+      typeof child === "object" && child !== null && !("#text" in child),
+  );
+  if (topLevelElements.length === 0) {
+    return `<Slide>${rawXml}</Slide>`;
+  }
+  return topLevelElements
+    .map((el) => `<Slide>${String(builder.build([el]))}</Slide>`)
+    .join("\n");
+}

--- a/packages/pom/src/parseMasterPptx.test.ts
+++ b/packages/pom/src/parseMasterPptx.test.ts
@@ -8,7 +8,7 @@ import { parseMasterPptx } from "./parseMasterPptx.ts";
 async function generatePptxBuffer(
   masterBackground?: { color: string } | { data: string },
 ): Promise<Uint8Array> {
-  const xml = '<VStack><Text fontSize="24">test</Text></VStack>';
+  const xml = '<Slide><VStack><Text fontSize="24">test</Text></VStack></Slide>';
   const slideSize = { w: 960, h: 540 };
   const result = await buildPptx(xml, slideSize, {
     master: masterBackground ? { background: masterBackground } : undefined,
@@ -50,7 +50,8 @@ describe("buildPptx with masterPptx option", () => {
     const templateBuffer = await generatePptxBuffer({ color: "0000FF" });
 
     // masterPptx として渡して新しい PPTX を生成
-    const xml = '<VStack><Text fontSize="24">hello</Text></VStack>';
+    const xml =
+      '<Slide><VStack><Text fontSize="24">hello</Text></VStack></Slide>';
     const result = await buildPptx(
       xml,
       { w: 960, h: 540 },
@@ -64,7 +65,8 @@ describe("buildPptx with masterPptx option", () => {
   });
 
   it("不正な masterPptx を渡した場合は diagnostics に警告が追加される", async () => {
-    const xml = '<VStack><Text fontSize="24">hello</Text></VStack>';
+    const xml =
+      '<Slide><VStack><Text fontSize="24">hello</Text></VStack></Slide>';
     const result = await buildPptx(
       xml,
       { w: 960, h: 540 },
@@ -82,7 +84,8 @@ describe("buildPptx with masterPptx option", () => {
     const templateBuffer = await generatePptxBuffer({ color: "0000FF" });
 
     // masterPptx と master.background の両方を指定
-    const xml = '<VStack><Text fontSize="24">hello</Text></VStack>';
+    const xml =
+      '<Slide><VStack><Text fontSize="24">hello</Text></VStack></Slide>';
     const result = await buildPptx(
       xml,
       { w: 960, h: 540 },

--- a/packages/pom/src/parseXml/parseXml.test.ts
+++ b/packages/pom/src/parseXml/parseXml.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseXml, ParseXmlError } from "./parseXml.ts";
+import { parseXml as parseXmlRaw, ParseXmlError } from "./parseXml.ts";
+
+// Most tests below validate slide-content parsing. They predate the
+// `<Slide>` wrapper requirement, so a helper transparently wraps single-slide
+// content. Tests that exercise top-level behavior (multi-slide, missing
+// `<Slide>`, etc.) call `parseXmlRaw` directly.
+const parseXml = (xml: string) => parseXmlRaw(`<Slide>${xml}</Slide>`);
 
 describe("parseXml", () => {
   // ===== 基本的なノード変換 =====
@@ -870,22 +876,53 @@ describe("parseXml", () => {
     });
   });
 
-  // ===== 複数ルート要素 =====
-  describe("複数ルート要素", () => {
-    it("複数のルート要素を配列として返す", () => {
-      const xml = "<Text>Slide 1</Text><Text>Slide 2</Text>";
-      const result = parseXml(xml);
+  // ===== 複数 Slide =====
+  describe("複数 Slide", () => {
+    it("複数の <Slide> を別々のスライドとして配列で返す", () => {
+      const xml =
+        "<Slide><Text>Slide 1</Text></Slide><Slide><Text>Slide 2</Text></Slide>";
+      const result = parseXmlRaw(xml);
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual({ type: "text", text: "Slide 1" });
       expect(result[1]).toEqual({ type: "text", text: "Slide 2" });
+    });
+
+    it("Slide が複数子要素を持つ場合は VStack で暗黙的にラップする", () => {
+      const xml = "<Slide><Text>A</Text><Text>B</Text></Slide>";
+      const result = parseXmlRaw(xml);
+      expect(result).toEqual([
+        {
+          type: "vstack",
+          children: [
+            { type: "text", text: "A" },
+            { type: "text", text: "B" },
+          ],
+        },
+      ]);
+    });
+
+    it("最上位 <Slide> 以外の要素はエラーになる", () => {
+      expect(() => parseXmlRaw("<Text>not in Slide</Text>")).toThrow(
+        ParseXmlError,
+      );
+    });
+
+    it("空の <Slide> はエラーになる", () => {
+      expect(() => parseXmlRaw("<Slide></Slide>")).toThrow(ParseXmlError);
+    });
+
+    it("<Slide> に属性を付けるとエラーになる", () => {
+      expect(() =>
+        parseXmlRaw('<Slide title="x"><Text>A</Text></Slide>'),
+      ).toThrow(ParseXmlError);
     });
   });
 
   // ===== エッジケース =====
   describe("エッジケース", () => {
     it("空文字列で空配列を返す", () => {
-      expect(parseXml("")).toEqual([]);
-      expect(parseXml("  ")).toEqual([]);
+      expect(parseXmlRaw("")).toEqual([]);
+      expect(parseXmlRaw("  ")).toEqual([]);
     });
 
     it("backgroundImage をドット記法で変換する", () => {

--- a/packages/pom/src/parseXml/parseXml.ts
+++ b/packages/pom/src/parseXml/parseXml.ts
@@ -1244,6 +1244,10 @@ function convertPomNode(
 /**
  * XML 文字列を POMNode 配列に変換する。
  *
+ * 最上位は `<Slide>` 要素のみが許容される。各 `<Slide>` が 1 つのスライドに
+ * 対応し、その子要素がスライドのルート POMNode となる。子要素が複数ある場合は
+ * 暗黙的に VStack でラップされる。
+ *
  * XML タグは POM ノードタイプにマッピングされ、属性値は Zod スキーマを参照して
  * 適切な型（number, boolean, array, object）に変換される。
  * 未知のタグ名が指定された場合はエラーがスローされる。
@@ -1253,9 +1257,11 @@ function convertPomNode(
  * import { parseXml, buildPptx } from "@hirokisakabe/pom";
  *
  * const xml = `
- *   <VStack gap="16" padding="32">
- *     <Text fontSize="32" bold="true">売上レポート</Text>
- *   </VStack>
+ *   <Slide>
+ *     <VStack gap="16" padding="32">
+ *       <Text fontSize="32" bold="true">売上レポート</Text>
+ *     </VStack>
+ *   </Slide>
  * `;
  *
  * const nodes = parseXml(xml);
@@ -1283,12 +1289,40 @@ export function parseXml(xmlString: string): POMNode[] {
   const rootChildren = (rootElement["__root__"] ?? []) as XmlNode[];
 
   const errors: string[] = [];
-  const nodes = rootChildren
-    .filter((child): child is XmlElement => !isTextNode(child))
-    .map((child) => convertElement(child, errors))
-    .filter(
-      (child): child is Record<string, unknown> => child !== null,
-    ) as POMNode[];
+  const slideElements = rootChildren.filter(
+    (child): child is XmlElement => !isTextNode(child),
+  );
+
+  const nodes: POMNode[] = [];
+  for (const slideEl of slideElements) {
+    const tagName = getTagName(slideEl);
+    if (tagName !== "Slide") {
+      errors.push(
+        `Top-level element must be <Slide>, but got <${tagName}>. Wrap your slide content in <Slide>...</Slide>.`,
+      );
+      continue;
+    }
+    if (Object.keys(getAttributes(slideEl)).length > 0) {
+      errors.push(`<Slide>: Attributes are not supported`);
+    }
+    const slideChildren = getChildElements(slideEl);
+    if (slideChildren.length === 0) {
+      errors.push(`<Slide> must contain at least one child element`);
+      continue;
+    }
+    const converted = slideChildren
+      .map((child) => convertElement(child, errors))
+      .filter((c): c is Record<string, unknown> => c !== null);
+    if (converted.length === 0) continue;
+    if (converted.length === 1) {
+      nodes.push(converted[0] as POMNode);
+    } else {
+      nodes.push({
+        type: "vstack",
+        children: converted,
+      } as POMNode);
+    }
+  }
 
   if (errors.length > 0) {
     throw new ParseXmlError(errors);

--- a/packages/pom/vrt/lib/generatePptx.ts
+++ b/packages/pom/vrt/lib/generatePptx.ts
@@ -83,7 +83,9 @@ export async function generatePptx(outputPath: string): Promise<void> {
     page36InlineFormattingXml,
     page37TableCellBorderXml,
     page38CustomFontExtendedXml,
-  ].join("\n");
+  ]
+    .map((pageXml) => `<Slide>${pageXml}</Slide>`)
+    .join("\n");
 
   const { pptx } = await buildPptx(
     allPagesXml,


### PR DESCRIPTION
close #672

## 概要

pom XML の最上位要素を `<Slide>` で必須ラップする形式に変更します（破壊的変更）。複数スライド時の可読性向上と、将来的な per-slide 属性（背景色 / notes / per-slide layout 上書き等）の受け皿を確保するための準備です。

## 主な変更

- **`parseXml`** (`packages/pom/src/parseXml/parseXml.ts`)
  - 最上位要素は `<Slide>` のみ許容。それ以外を直下に置くとエラー
  - `<Slide>` 直下の子要素が 1 つならそのままスライドルート、複数なら暗黙的に `VStack` でラップ
  - `<Slide>` に属性が付くとエラー（属性は別 issue で順次追加）
- **pom-md** (`packages/pom-md/src/parseMd.ts`)
  - 出力が `<Slide><VStack>...</VStack></Slide>` 形式に変更
  - `pomxml` フェンスにフルスライド XML（`<Slide>...</Slide>`）が貼り付けられた場合、外側の `<Slide>` を 1 段だけ剥がしてネストを回避
- **ドキュメント / サンプル / fixtures**
  - `packages/pom/docs/{index.mdx,nodes.md,api-reference.md,master-slide.md}`、`packages/pom/README.md`、`apps/website/public/llm.txt`、`apps/website/playground/client/lib/sampleTemplates.ts`、`packages/pom-vscode/sample.pom.xml`、`packages/pom/main.ts`、`packages/pom/bench/buildPptx.bench.ts`、`packages/pom/vrt/lib/generatePptx.ts`、`packages/pom/scripts/docs-images/generateNodeImages.ts` を新形式に更新
  - `packages/pom/src/docsSamples.test.ts`: ノードスニペットを各トップレベル要素ごとに `<Slide>` でラップしてから検証
- **changelog**: `.changeset/require-slide-wrapper.md` に移行ガイドを記載（major bump）

## 移行ガイド

Before:

\`\`\`xml
<VStack w="100%" h="max" padding="48">
  <Text fontSize="32" bold="true">Slide 1</Text>
</VStack>
\`\`\`

After:

\`\`\`xml
<Slide>
  <VStack w="100%" h="max" padding="48">
    <Text fontSize="32" bold="true">Slide 1</Text>
  </VStack>
</Slide>
\`\`\`

## 影響パッケージ

- `@hirokisakabe/pom` (major)
- `@hirokisakabe/pom-md` (major)
- `apps/website` / `pom-vscode` のサンプル類

## ローカル検証手順

\`\`\`bash
pnpm --filter @hirokisakabe/pom run lint
pnpm --filter @hirokisakabe/pom run typecheck
pnpm --filter @hirokisakabe/pom run test:run
pnpm --filter @hirokisakabe/pom-md run lint
pnpm --filter @hirokisakabe/pom-md run typecheck
pnpm --filter @hirokisakabe/pom-md run test:run
pnpm --filter pom-docs run test:run
\`\`\`

pom-vscode のプレビュー動作確認は VSCode 上で `packages/pom-vscode` を開き F5 で Extension Development Host を起動し、`sample.pom.md` / `sample.pom.xml` を開いてライブプレビューが 2 ページ表示されることを目視確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)