### PR TITLE
ci(release): release.yml に pom-jsx のビルド・検証ステップを追加する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
       - run: pnpm --filter @hirokisakabe/pom-cli run fmt:check
       - run: pnpm --filter @hirokisakabe/pom-cli run lint
       - run: pnpm --filter @hirokisakabe/pom-cli run typecheck
+      - run: pnpm --filter @hirokisakabe/pom-jsx run build
+      - run: pnpm --filter @hirokisakabe/pom-jsx run fmt:check
+      - run: pnpm --filter @hirokisakabe/pom-jsx run lint
+      - run: pnpm --filter @hirokisakabe/pom-jsx run typecheck
+      - run: pnpm --filter @hirokisakabe/pom-jsx run test:run
 
       - name: Create Release PR or Publish
         id: changesets


### PR DESCRIPTION
close #721

## 目的

`release.yml`（changesets ベースのリリースワークフロー）に `@hirokisakabe/pom-jsx` のビルド・検証ステップを追加し、changeset publish の対象として npm 自動公開が機能するようにする。

## 変更内容

- `.github/workflows/release.yml`: `pom-cli` ステップの後に `pom-jsx` の以下5ステップを追加
  - `build`
  - `fmt:check`
  - `lint`
  - `typecheck`
  - `test:run`

## 影響パッケージ

- `.github/workflows/release.yml`（CI ワークフロー設定のみ）

## changeset publish への影響

`.changeset/config.json` には既に `"access": "public"` が設定されており、`pom-jsx/package.json` は `private` フィールドを持たないため、changeset を作成するだけで `@hirokisakabe/pom-jsx` が npm publish 対象になる。設定ファイルの変更は不要。

## ローカル検証手順

```bash
# ワークフロー内容の確認
grep -A6 "pom-jsx" .github/workflows/release.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)