### PR TITLE
fix(release): changeset publish を pnpm publish -r に変更して workspace:* を解決する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm exec changeset publish
+          publish: pnpm publish -r --access public --no-git-checks && pnpm exec changeset tag
           version: pnpm exec changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

`@hirokisakabe/pom-cli@0.2.0` が npm から正常にインストールできない状態だった。

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

公開された `package.json` の依存関係に `workspace:*` がそのまま残っており、npm がプロトコルを解釈できないのが原因。

## 原因

`changeset publish` は pnpm の `workspace:*` プロトコルを実バージョンに置換せずにパブリッシュする既知のバグ ([changesets/action#246](https://github.com/changesets/action/issues/246))。

`pom-md` など他のパッケージでは workspace 依存がないため今まで問題が顕在化していなかったが、`pom-cli` が初めて内部パッケージ (`@hirokisakabe/pom`, `@hirokisakabe/pom-md`) に依存するパッケージになったことで発覚した。

## 変更内容

`changeset publish` を `pnpm publish -r` に変更する。pnpm は publish 前に `workspace:*` を実際のバージョン番号へ自動置換するため、問題が解消される。

```yaml
# 変更前
publish: pnpm exec changeset publish

# 変更後
publish: pnpm publish -r --access public --no-git-checks && pnpm exec changeset tag
```

- `pnpm publish -r` — 全パッケージを再帰的にパブリッシュ（`workspace:*` を自動解決）
- `--access public` — スコープ付きパッケージを public で公開
- `--no-git-checks` — CI 上での git clean チェックをスキップ
- `&& pnpm exec changeset tag` — `changeset publish` が担っていた git タグ作成を補う