### PR TITLE
fix(pom-cli): 壊れた 0.2.0 の patch 再リリース

### DIFF
--- a/.changeset/fix-pom-cli-workspace-deps.md
+++ b/.changeset/fix-pom-cli-workspace-deps.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": patch
+---
+
+fix: workspace:* 依存が npm publish 時に解決されない問題を修正する


### PR DESCRIPTION
## 概要

`@hirokisakabe/pom-cli@0.2.0` は `workspace:*` が解決されない状態で公開されており、npm からインストール不可な状態。

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

この PR は patch バンプ用 changeset を追加し、#727 の修正済みリリースパイプラインで `0.2.1` を再リリースすることを目的とする。

## 対応内容

- `@hirokisakabe/pom-cli` の patch changeset を追加
- マージ後、changeset の Release PR (`changeset-release/main`) が自動作成され、マージすると `0.2.1` が正常に publish される