### PR TITLE
fix(release): pnpm publish -r を changeset publish + 事前スクリプトに変更する

### DIFF
--- a/.github/scripts/resolve-workspace-deps.js
+++ b/.github/scripts/resolve-workspace-deps.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// changeset publish は workspace:* を置換しないため、publish 前にこのスクリプトで解決する
+// https://github.com/changesets/action/issues/246
+
+const fs = require('fs');
+const path = require('path');
+
+const packagesDir = path.resolve(__dirname, '../../packages');
+const packageDirs = fs.readdirSync(packagesDir).filter((dir) =>
+  fs.existsSync(path.join(packagesDir, dir, 'package.json')),
+);
+
+const versions = {};
+for (const dir of packageDirs) {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(packagesDir, dir, 'package.json'), 'utf8'),
+  );
+  if (pkg.name && pkg.version) versions[pkg.name] = pkg.version;
+}
+
+for (const dir of packageDirs) {
+  const pkgPath = path.join(packagesDir, dir, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  let changed = false;
+
+  for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+    for (const [name, ver] of Object.entries(pkg[field] || {})) {
+      if (ver === 'workspace:*' && versions[name]) {
+        pkg[field][name] = '^' + versions[name];
+        changed = true;
+        console.log(`${pkg.name}: ${name} workspace:* -> ^${versions[name]}`);
+      }
+    }
+  }
+
+  if (changed) fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm publish -r --access public --no-git-checks && pnpm exec changeset tag
+          publish: node .github/scripts/resolve-workspace-deps.js && pnpm exec changeset publish
           version: pnpm exec changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

前回の PR #727 で `pnpm publish -r` に変更したが、CI で 404 エラーが発生し publish が失敗した。

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@hirokisakabe%2fpom-cli - Not found
```

## 原因

`pnpm publish -r` は pnpm 独自の HTTP クライアントで publish するため、`changesets/action` が OIDC で用意した認証情報（`NPM_CONFIG_USERCONFIG` の `.npmrc`）を読まない。一方 `changeset publish` は changesets が OIDC 処理を内包しているため認証が通る。

ただし `changeset publish` には `workspace:*` を解決しないという既知のバグがある（[changesets/action#246](https://github.com/changesets/action/issues/246)）。

## 変更内容

`changeset publish` の実行前に `resolve-workspace-deps.js` スクリプトを挟み、両方の問題を解決する。

```yaml
publish: node .github/scripts/resolve-workspace-deps.js && pnpm exec changeset publish
```

### スクリプトの動作

- `packages/` 配下の全パッケージを走査してバージョンマップを構築
- `workspace:*` の依存を `^VERSION` に置換してから changeset publish を実行
- 将来 workspace 依存が増えても自動対応