### PR TITLE
chore(changeset): pom-cli 0.2.2 用 changeset を追加する

### DIFF
--- a/.changeset/fix-pom-cli-rerelease-2.md
+++ b/.changeset/fix-pom-cli-rerelease-2.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": patch
+---
+
+fix: リリースパイプラインの修正に伴う再リリース (workspace:* 解決)


### PR DESCRIPTION
## 概要

PR #730 でリリースパイプラインを修正済み。`workspace:*` が正しく解決される状態で `pom-cli@0.2.2` を publish するための patch バンプ用 changeset。

マージ後、changeset の Release PR が自動作成される。