### PR TITLE
chore(changeset): pom-cli 0.2.3 用 changeset を追加する

### DIFF
--- a/.changeset/fix-pom-cli-rerelease-3.md
+++ b/.changeset/fix-pom-cli-rerelease-3.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": patch
+---
+
+fix: workspace:* 依存を正しく解決した状態で再リリースする


### PR DESCRIPTION
## 概要

0.2.2 は `npm publish` で公開したため `workspace:*` が未解決のままになっている。
`pnpm publish` を使って再度公開するための patch バンプ。

## この PR マージ後の手順

Release PR (Version Packages) が自動生成されるのでマージ後、以下を手動で実行：

```bash
cd packages/pom-cli
pnpm publish --access public --no-git-checks
```

`pnpm publish` は `workspace:*` を実バージョンに自動置換してから publish する。

## 根本原因

npm の OIDC Trusted Publishing が `@hirokisakabe/pom-cli` に設定されていないため CI からの publish が 404 で失敗する。長期的には npmjs.com の Trusted Publishers 設定を追加することで CI からの自動 publish が可能になる。