### PR TITLE
feat(pom-jsx): JSX.IntrinsicElements に全コンポーネントの props 型を登録する

### DIFF
--- a/packages/pom-jsx/src/jsx-runtime.ts
+++ b/packages/pom-jsx/src/jsx-runtime.ts
@@ -1,3 +1,34 @@
+import type {
+  SlideProps,
+  TextProps,
+  VStackProps,
+  HStackProps,
+  LayerProps,
+  UlProps,
+  OlProps,
+  LiProps,
+  ImageProps,
+  ShapeProps,
+  ChartProps,
+  TimelineProps,
+  MatrixProps,
+  TreeProps,
+  FlowProps,
+  ProcessArrowProps,
+  PyramidProps,
+  LineProps,
+  IconProps,
+  SvgProps,
+  TableProps,
+  TrProps,
+  TdProps,
+  ThProps,
+  InlineProps,
+  AnchorProps,
+  SpanProps,
+  MarkProps,
+} from "./types.ts";
+
 export interface PomJsxElement {
   type: string;
   props: Record<string, unknown>;
@@ -30,7 +61,37 @@ export function Fragment(props: Record<string, unknown>): PomJsxElement {
 export namespace JSX {
   export type Element = PomJsxElement;
   export interface IntrinsicElements {
-    [elemName: string]: unknown;
+    Slide: SlideProps;
+    Text: TextProps;
+    VStack: VStackProps;
+    HStack: HStackProps;
+    Layer: LayerProps;
+    Ul: UlProps;
+    Ol: OlProps;
+    Li: LiProps;
+    Image: ImageProps;
+    Shape: ShapeProps;
+    Chart: ChartProps;
+    Timeline: TimelineProps;
+    Matrix: MatrixProps;
+    Tree: TreeProps;
+    Flow: FlowProps;
+    ProcessArrow: ProcessArrowProps;
+    Pyramid: PyramidProps;
+    Line: LineProps;
+    Icon: IconProps;
+    Svg: SvgProps;
+    Table: TableProps;
+    Tr: TrProps;
+    Td: TdProps;
+    Th: ThProps;
+    B: InlineProps;
+    I: InlineProps;
+    U: InlineProps;
+    S: InlineProps;
+    A: AnchorProps;
+    Span: SpanProps;
+    Mark: MarkProps;
   }
   export interface IntrinsicAttributes {
     key?: string | number | null;

--- a/packages/pom-jsx/src/type-safety.test.tsx
+++ b/packages/pom-jsx/src/type-safety.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it } from "vitest";
+import { Text, VStack, Image, Slide } from "./components.ts";
+
+describe("型安全性の回帰テスト", () => {
+  it("有効な props は型エラーにならない", () => {
+    const _valid = (
+      <Slide>
+        <VStack w={200} h={100}>
+          <Text fontSize={16} color="red">
+            hello
+          </Text>
+        </VStack>
+      </Slide>
+    );
+  });
+
+  it("不正な props が TypeScript の型エラーになる (コンパイル時検証)", () => {
+    // @ts-expect-error unknownProp は TextProps に存在しない
+    const _invalidText = <Text unknownProp={1}>hello</Text>;
+
+    // @ts-expect-error unknownProp は VStackProps に存在しない
+    const _invalidVStack = <VStack unknownProp="x" />;
+
+    // @ts-expect-error src は必須なのに渡していない
+    const _invalidImage = <Image />;
+  });
+});


### PR DESCRIPTION
close #719

## 目的

`jsx-runtime.ts` の `JSX.IntrinsicElements` を `[elemName: string]: unknown` の wildcard から、各コンポーネントの具体的な props 型に変更する。これにより、存在しない props を渡した場合にコンパイル時に型エラーが検出されるようになる。

## 変更内容

### `packages/pom-jsx/src/jsx-runtime.ts`

- `types.ts` から全コンポーネントの props 型（`SlideProps`, `TextProps`, `VStackProps` 等 28 種）を import
- `JSX.IntrinsicElements` に全コンポーネント（`Slide`, `Text`, `VStack`, `HStack`, `Layer`, `Ul`, `Ol`, `Li`, `Image`, `Shape`, `Chart`, `Timeline`, `Matrix`, `Tree`, `Flow`, `ProcessArrow`, `Pyramid`, `Line`, `Icon`, `Svg`, `Table`, `Tr`, `Td`, `Th`, `B`, `I`, `U`, `S`, `A`, `Span`, `Mark`）の props 型を登録

### `packages/pom-jsx/src/type-safety.test.tsx`（新規追加）

- `@ts-expect-error` を使った型レベルの回帰テスト
- 不正な props（`unknownProp`, 必須属性の欠落）がコンパイル時エラーになることを検証

## 補足

TypeScript は PascalCase JSX 要素（`<Text>` 等）を value-based component として解決するため、型チェックは `components.ts` の関数シグネチャが主体。`JSX.IntrinsicElements` への登録は props 型の single source of truth としての役割と、wildcard 除去による未登録タグ名の排除を担う。

## ローカル検証手順

```bash
cd packages/pom-jsx
pnpm run typecheck  # 型チェック通過
pnpm run test:run   # 3 test files, 47 tests passed
pnpm run lint       # lint 通過
```