### PR TITLE
docs(readme): pom-slide スキルのインストール手順を追記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ This repository is a pnpm monorepo containing the following packages:
 | [packages/pom-vscode](./packages/pom-vscode/) | VS Code extension for live preview                           | [Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode) |
 | [apps/website](./apps/website/)               | Documentation website ([pom.pptx.app](https://pom.pptx.app)) | —                                                                                          |
 
+## Claude Code Skill
+
+The `pom-slide` skill lets you generate presentation slides from natural language inside [Claude Code](https://claude.ai/code) sessions.
+
+**Install:**
+
+```bash
+gh skill install hirokisakabe/pom pom-slide
+```
+
+**Usage:**
+
+After installation, use `/pom-slide` in Claude Code:
+
+```
+/pom-slide 四半期の売上レポート。3 枚構成で、タイトル・グラフ・まとめを含む
+```
+
+Claude generates a `slides.pom.xml` file in the current directory. If [pom-cli](https://www.npmjs.com/package/@hirokisakabe/pom-cli) is installed (`npm install -g @hirokisakabe/pom-cli`), a live preview server starts automatically at `http://localhost:3000`.
+
 ## Documentation
 
 | Document                                                    | Description                           |


### PR DESCRIPTION
close #737

## 目的

README に `pom-slide` スキルへの導線がなく、リポジトリを訪れた Claude Code ユーザーがスキルの存在を知る手段がなかった。`Packages` セクションの直後に `Claude Code Skill` セクションを追加し、インストール手順・使い方・プレビュー自動化の説明を記載する。

## 変更内容

- `README.md` に `## Claude Code Skill` セクションを追加
  - インストールコマンド: `gh skill install hirokisakabe/pom pom-slide`
  - `/pom-slide` の使い方と自然言語指示の例
  - pom-cli がインストール済みの場合は `http://localhost:3000` でプレビューが自動起動される旨

## 影響パッケージ

- `README.md` のみ（コードの変更なし）

## ローカル検証

- README を目視確認：受け入れ条件 3 項目すべて満たすことを確認済み