### PR TITLE
feat(ci): skills/ 変更 PR で gh skill publish --dry-run を CI で実行する

### DIFF
--- a/.github/workflows/ci-skills.yml
+++ b/.github/workflows/ci-skills.yml
@@ -1,6 +1,11 @@
 name: CI - skills
 
 on:
+  push:
+    branches: ["main"]
+    paths:
+      - "skills/**"
+      - ".github/workflows/ci-skills.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -14,6 +19,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Upgrade gh CLI
+        run: sudo apt-get update -qq && sudo apt-get install -y gh
       - name: Validate skills
         run: gh skill publish --dry-run
         env:

--- a/.github/workflows/ci-skills.yml
+++ b/.github/workflows/ci-skills.yml
@@ -1,0 +1,20 @@
+name: CI - skills
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "skills/**"
+      - ".github/workflows/ci-skills.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate skills
+        run: gh skill publish --dry-run
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
close #740

## 目的

`skills/` 以下を変更する PR に対して `gh skill publish --dry-run` を CI で自動実行し、フォーマット崩れや frontmatter の不備を merge 前に自動検出できるようにする。

## 変更内容

`.github/workflows/ci-skills.yml` を新規追加。

- **トリガー**: `skills/**` または当ワークフローファイル自体の変更を含む `push`（main）/ `pull_request`（main）
- **実行コマンド**: `gh skill publish --dry-run`
- **エラー時のみ CI 失敗**: warning（body 行数超過等）は exit 0 のため CI には影響しない
- **gh CLI アップグレード**: `gh skill` は v2.90.0 以上が必要なため、`apt-get install gh` で最新版を明示的に取得

## 影響パッケージ / ファイル

- `.github/workflows/ci-skills.yml`（新規）

## ローカル検証手順

```bash
# dry-run が warning のみ → exit 0 を確認
gh skill publish --dry-run

# actionlint でワークフロー構文を検証
actionlint .github/workflows/ci-skills.yml
```