### PR TITLE
docs: CLAUDE.md / AGENTS.md の Directory Structure に pom-cli・pom-jsx を追記する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Root: `pnpm --filter @hirokisakabe/pom run <script>`
 ```
 packages/
 ├── pom/              # Core library — src/ (parseXml/ → calcYogaLayout/ → toPositioned/ → renderPptx/), vrt/, preview/, docs/, main.ts
+├── pom-cli/          # CLI tool — preview and build presentations
+├── pom-jsx/          # JSX/TSX authoring package
 ├── pom-md/           # Markdown → pom XML converter
 ├── pom-vscode/       # VS Code extension for live preview
 apps/


### PR DESCRIPTION
close #752

## 目的

`AGENTS.md`（`CLAUDE.md` はそのシンボリックリンク）の `## Directory Structure` セクションが実際のパッケージ構成と乖離していたため、`pom-cli/` と `pom-jsx/` を追記した。

## 変更内容

- `AGENTS.md` の `## Directory Structure` に以下の 2 エントリを追加:
  - `pom-cli/` — CLI tool — preview and build presentations
  - `pom-jsx/` — JSX/TSX authoring package
- `CLAUDE.md` は `AGENTS.md` へのシンボリックリンクのため自動的に同期済み

## 影響パッケージ

- `AGENTS.md` (ルート)

## ローカル検証手順

```bash
grep "pom-cli\|pom-jsx" CLAUDE.md AGENTS.md
```

両ファイルで各エントリが確認できること。