### PR TITLE
fix(ci): changesets/action の publish スクリプトを shell で実行されるよう修正する

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+node .github/scripts/resolve-workspace-deps.js
+pnpm exec changeset publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: node .github/scripts/resolve-workspace-deps.js && pnpm exec changeset publish
+          publish: bash .github/scripts/publish.sh
           version: pnpm exec changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

`changesets/action@v1` は publish スクリプトを以下のように処理していた:

```typescript
let [publishCommand, ...publishArgs] = script.split(/\s+/);
await getExecOutput(publishCommand, publishArgs, { cwd });
```

`getExecOutput` はシェルを経由せず直接 spawn するため、`&&` はシェル演算子として解釈されない。
その結果、設定していた `publish: node .github/scripts/resolve-workspace-deps.js && pnpm exec changeset publish` は `node` に対して `&&`、`pnpm`、`exec`、`changeset`、`publish` が引数として渡されるだけで、**`pnpm exec changeset publish` が一度も実行されていなかった**。

今まで CI から npm publish が成功したことはなく、`pom-cli` の各バージョンはすべて手動で publish されていた。

## 修正内容

- `.github/scripts/publish.sh` を追加（`resolve-workspace-deps.js` の実行 + `changeset publish` を bash スクリプトとして定義）
- `publish:` を `bash .github/scripts/publish.sh` に変更（bash 経由で実行することで `&&` が正しく動作する）

## 確認方法

マージ後の次回 Release ワークフロー実行時に、changeset publish が実際に動作して npm publish されることを確認する。