### PR TITLE
docs: .claude/rules/ に pom-cli・pom-jsx・pom-editor 用のルールファイルを追加

### DIFF
--- a/.claude/rules/pom-cli.md
+++ b/.claude/rules/pom-cli.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - packages/pom-cli/**
+---
+
+## pom-cli (`packages/pom-cli/`)
+
+CLI tool for pom — preview and build presentations. Wraps `@hirokisakabe/pom` and `@hirokisakabe/pom-md` to provide `pom` binary for rendering `.pom.xml` / `.pom.md` files to PPTX or launching a live preview server.
+
+```bash
+pnpm --filter @hirokisakabe/pom-cli run build       # TypeScript compilation + chmod dist/cli.js
+pnpm --filter @hirokisakabe/pom-cli run lint        # ESLint
+pnpm --filter @hirokisakabe/pom-cli run fmt         # Prettier formatting
+pnpm --filter @hirokisakabe/pom-cli run fmt:check   # Format check
+pnpm --filter @hirokisakabe/pom-cli run typecheck   # Type checking
+pnpm --filter @hirokisakabe/pom-cli run knip        # Detect unused code
+```
+
+### Release Flow
+
+pom-cli uses Changesets for versioning. The release is handled by the unified `release.yml` workflow.
+
+1. Add a changeset: `pnpm exec changeset add`
+2. Release PR merges → `changeset version` bumps `package.json` version
+3. `release.yml` runs `changeset publish` → publishes to npm as `@hirokisakabe/pom-cli`

--- a/.claude/rules/pom-editor.md
+++ b/.claude/rules/pom-editor.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - packages/pom-editor/**
+---
+
+## pom-editor (`packages/pom-editor/`)
+
+Visual DnD AST editor component for pom. Exports `PomAstEditor` — a React component that receives pom XML via `xml` prop, renders the AST as a draggable tree, and calls `onChange` with updated XML when nodes are reordered.
+
+```bash
+pnpm --filter @hirokisakabe/pom-editor run build       # TypeScript compilation
+pnpm --filter @hirokisakabe/pom-editor run lint        # ESLint
+pnpm --filter @hirokisakabe/pom-editor run fmt         # Prettier formatting
+pnpm --filter @hirokisakabe/pom-editor run fmt:check   # Format check
+pnpm --filter @hirokisakabe/pom-editor run typecheck   # Type checking
+pnpm --filter @hirokisakabe/pom-editor run knip        # Detect unused code
+```
+
+React 18+ is a peer dependency. DnD is powered by `@dnd-kit/core` + `@dnd-kit/sortable`.
+
+### Release Flow
+
+pom-editor uses Changesets for versioning. The release is handled by the unified `release.yml` workflow.
+
+1. Add a changeset: `pnpm exec changeset add`
+2. Release PR merges → `changeset version` bumps `package.json` version
+3. `release.yml` runs `changeset publish` → publishes to npm as `@hirokisakabe/pom-editor`

--- a/.claude/rules/pom-jsx.md
+++ b/.claude/rules/pom-jsx.md
@@ -1,0 +1,37 @@
+---
+paths:
+  - packages/pom-jsx/**
+---
+
+## pom-jsx (`packages/pom-jsx/`)
+
+JSX/TSX authoring package for pom. Provides a custom JSX runtime so users can write pom slides as JSX/TSX components, which are serialized to pom XML strings and passed to `buildPptx()`.
+
+```bash
+pnpm --filter @hirokisakabe/pom-jsx run build           # TypeScript compilation
+pnpm --filter @hirokisakabe/pom-jsx run lint            # ESLint
+pnpm --filter @hirokisakabe/pom-jsx run fmt             # Prettier formatting
+pnpm --filter @hirokisakabe/pom-jsx run fmt:check       # Format check
+pnpm --filter @hirokisakabe/pom-jsx run typecheck       # Type checking (tsconfig.test.json)
+pnpm --filter @hirokisakabe/pom-jsx run knip            # Detect unused code
+pnpm --filter @hirokisakabe/pom-jsx run test:run        # Run tests
+pnpm --filter @hirokisakabe/pom-jsx run test:coverage   # Run tests with coverage
+```
+
+### Adding a New Node Type
+
+When a new node type is added to `@hirokisakabe/pom`, update the following files in order:
+
+1. **`src/types.ts`** — Add props type for the new node
+2. **`src/components.ts`** — Export the new JSX component
+3. **`src/jsx-runtime.ts`** — Register the new tag in the JSX runtime if needed
+4. **`src/integration.test.tsx`** — Add integration test covering the new node
+5. **`README.md`** — Document the new component
+
+### Release Flow
+
+pom-jsx uses Changesets for versioning. The release is handled by the unified `release.yml` workflow.
+
+1. Add a changeset: `pnpm exec changeset add`
+2. Release PR merges → `changeset version` bumps `package.json` version
+3. `release.yml` runs `changeset publish` → publishes to npm as `@hirokisakabe/pom-jsx`

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -5,8 +5,8 @@ paths:
 
 ## Release Flow (Changesets)
 
-`@hirokisakabe/pom`, `@hirokisakabe/pom-md`, and `pom-vscode` use [Changesets](https://github.com/changesets/changesets) for versioning. The unified workflow (`release.yml`) handles all packages.
+All npm packages (`@hirokisakabe/pom`, `@hirokisakabe/pom-md`, `@hirokisakabe/pom-cli`, `@hirokisakabe/pom-jsx`, `@hirokisakabe/pom-editor`) and `pom-vscode` use [Changesets](https://github.com/changesets/changesets) for versioning. The unified workflow (`release.yml`) handles all packages.
 
 1. Add a changeset: `pnpm exec changeset add`
 2. Push to main → GitHub Actions creates a Release PR (version bump + CHANGELOG)
-3. Merge the Release PR → `changeset publish` publishes pom/pom-md to npm, then detects pom-vscode version change → `vsce publish` to VS Code Marketplace + Git tag + GitHub Release
+3. Merge the Release PR → `changeset publish` publishes all npm packages, then detects pom-vscode version change → `vsce publish` to VS Code Marketplace + Git tag + GitHub Release


### PR DESCRIPTION
close #749

## 概要

`.claude/rules/` に `pom-cli`・`pom-jsx`・`pom-editor` 用のルールファイルを追加し、各パッケージ編集時に AI エージェントへ必要なコンテキストが注入されるようにする。

## 変更内容

- `.claude/rules/pom-cli.md` — CLI ツールの概要・コマンド一覧・リリースフローを記述
- `.claude/rules/pom-jsx.md` — JSX/TSX 向けパッケージの概要・コマンド一覧・新ノード追加手順・リリースフローを記述
- `.claude/rules/pom-editor.md` — Visual DnD AST editor コンポーネントの概要・コマンド一覧・リリースフローを記述
- `.claude/rules/release.md` — cross-review の指摘に基づき、`pom-cli`・`pom-jsx`・`pom-editor` が Changesets で管理されている旨を追記

## ローカル検証

```bash
# ファイルの存在と frontmatter を確認
ls .claude/rules/
head -5 .claude/rules/pom-cli.md
head -5 .claude/rules/pom-jsx.md
head -5 .claude/rules/pom-editor.md
```