### PR TITLE
docs: feature-addition.md に pom-jsx・pom-editor の更新手順を追加

### DIFF
--- a/.claude/rules/feature-addition.md
+++ b/.claude/rules/feature-addition.md
@@ -24,3 +24,12 @@ When adding new properties or features, update the following files:
    - Define sample XML in `packages/pom/scripts/docs-images/sampleNodes.ts`
    - Run `pnpm run docs:images:docker:update` (from `packages/pom/`)
 10. **Add changeset**: Run `pnpm exec changeset add` before creating a PR
+11. **pom-jsx updates** (when adding new node types):
+    - `packages/pom-jsx/src/types.ts` - Add `{NodeName}Props` interface
+    - `packages/pom-jsx/src/components.ts` - Add component function
+    - `packages/pom-jsx/src/jsx-runtime.ts` - Add to `JSX.IntrinsicElements`
+    - `packages/pom-jsx/src/index.ts` - Export the new component
+    - `packages/pom-jsx/src/integration.test.tsx` - Add test case
+    - `packages/pom-jsx/README.md` - Add to component table
+12. **pom-editor updates** (when adding new node types):
+    - `packages/pom-editor/src/ast.ts` - Add new node type to AST mapping if needed

--- a/.claude/rules/feature-addition.md
+++ b/.claude/rules/feature-addition.md
@@ -28,8 +28,9 @@ When adding new properties or features, update the following files:
     - `packages/pom-jsx/src/types.ts` - Add `{NodeName}Props` interface
     - `packages/pom-jsx/src/components.ts` - Add component function
     - `packages/pom-jsx/src/jsx-runtime.ts` - Add to `JSX.IntrinsicElements`
-    - `packages/pom-jsx/src/index.ts` - Export the new component
+    - `packages/pom-jsx/src/index.ts` - Export the new component and `{NodeName}Props` type
     - `packages/pom-jsx/src/integration.test.tsx` - Add test case
     - `packages/pom-jsx/README.md` - Add to component table
 12. **pom-editor updates** (when adding new node types):
     - `packages/pom-editor/src/ast.ts` - Add new node type to AST mapping if needed
+    - `packages/pom-editor/src/AstTree.tsx` - Add label to `NODE_LABELS` if needed


### PR DESCRIPTION
close #751

## 目的

新ノード追加時に pom-jsx・pom-editor への追従が漏れるケースを防ぐため、`.claude/rules/feature-addition.md` の Feature Addition Checklist に手順 11・12 を追記する。

## 変更内容

- **手順 11 (pom-jsx updates)** を追加
  - `packages/pom-jsx/src/types.ts` — `{NodeName}Props` インターフェースの追加
  - `packages/pom-jsx/src/components.ts` — コンポーネント関数の追加
  - `packages/pom-jsx/src/jsx-runtime.ts` — `JSX.IntrinsicElements` への追加
  - `packages/pom-jsx/src/index.ts` — 新コンポーネントと `{NodeName}Props` 型の export
  - `packages/pom-jsx/src/integration.test.tsx` — テストケースの追加
  - `packages/pom-jsx/README.md` — コンポーネントテーブルへの追記
- **手順 12 (pom-editor updates)** を追加
  - `packages/pom-editor/src/ast.ts` — AST マッピングへの追加（必要な場合）
  - `packages/pom-editor/src/AstTree.tsx` — `NODE_LABELS` へのラベル追加（必要な場合）

## 影響パッケージ

- `.claude/rules/feature-addition.md`（ドキュメント更新のみ）

## ローカル検証手順

```bash
cat .claude/rules/feature-addition.md
```

手順 11・12 が追記されていることを目視確認。