### PR TITLE
ci: actions/checkout を v4 から v6 に更新

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -14,5 +14,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rhysd/actionlint@v1.7.11

--- a/.github/workflows/ci-docs-site.yml
+++ b/.github/workflows/ci-docs-site.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-pom-benchmark.yml
+++ b/.github/workflows/ci-pom-benchmark.yml
@@ -32,7 +32,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci-pom-docs-images-vrt.yml
+++ b/.github/workflows/ci-pom-docs-images-vrt.yml
@@ -28,7 +28,7 @@ jobs:
   docs-images-vrt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run docs images VRT in Docker
         working-directory: packages/pom
         run: docker compose run --rm docs-images-vrt

--- a/.github/workflows/ci-pom-editor.yml
+++ b/.github/workflows/ci-pom-editor.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         working-directory: packages/pom-editor
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-pom-jsx.yml
+++ b/.github/workflows/ci-pom-jsx.yml
@@ -32,7 +32,7 @@ jobs:
       run:
         working-directory: packages/pom-jsx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-pom-md.yml
+++ b/.github/workflows/ci-pom-md.yml
@@ -32,7 +32,7 @@ jobs:
       run:
         working-directory: packages/pom-md
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-pom-size-limit.yml
+++ b/.github/workflows/ci-pom-size-limit.yml
@@ -30,7 +30,7 @@ jobs:
   size-limit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-pom-vrt.yml
+++ b/.github/workflows/ci-pom-vrt.yml
@@ -26,7 +26,7 @@ jobs:
   vrt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run VRT in Docker
         working-directory: packages/pom
         run: docker compose run --rm vrt

--- a/.github/workflows/ci-pom-vscode.yml
+++ b/.github/workflows/ci-pom-vscode.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-pom.yml
+++ b/.github/workflows/ci-pom.yml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-skills.yml
+++ b/.github/workflows/ci-skills.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Upgrade gh CLI
         run: sudo apt-get update -qq && sudo apt-get install -y gh
       - name: Validate skills

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## 概要

全 GitHub Actions ワークフローで使用している `actions/checkout` を最新バージョン `v6.0.2` へ更新する。

- 変更前: `actions/checkout@v4`
- 変更後: `actions/checkout@v6`
- 対象ファイル: `.github/workflows/` 以下の 13 ファイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)