### PR TITLE
feat(pom-cli): preview --port オプションを追加

### DIFF
--- a/.changeset/pom-cli-preview-port-option.md
+++ b/.changeset/pom-cli-preview-port-option.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+`pom preview` に `--port <number>` オプションを追加。ポート番号を指定してサーバーを起動できるようになった。未指定時は従来通り 3000 番を使用。

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -21,6 +21,12 @@ pom preview slides.pom.md
 
 Open http://localhost:3000 in your browser. The page updates automatically when the file is saved.
 
+To use a different port (e.g. when 3000 is already in use):
+
+```bash
+pom preview slides.pom.xml --port 3001
+```
+
 Use the zoom buttons in the toolbar or press `+` / `-` to zoom in and out. The current zoom level is saved across sessions.
 
 ### Build

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -8,11 +8,23 @@ const command = args[0];
 if (command === "preview") {
   const inputFile = args[1];
   if (!inputFile) {
-    console.error("Usage: pom preview <input.pom.xml|input.pom.md>");
+    console.error(
+      "Usage: pom preview <input.pom.xml|input.pom.md> [--port <number>]",
+    );
     process.exit(1);
   }
+  const portIndex = args.indexOf("--port");
+  let port: number | undefined;
+  if (portIndex !== -1) {
+    const portArg = args[portIndex + 1];
+    port = Number(portArg);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      console.error(`Invalid port: ${portArg}`);
+      process.exit(1);
+    }
+  }
   try {
-    runPreview(inputFile);
+    runPreview(inputFile, port);
   } catch (err: unknown) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
@@ -33,7 +45,7 @@ if (command === "preview") {
   });
 } else {
   console.error("Usage:");
-  console.error("  pom preview <input.pom.xml|input.pom.md>");
+  console.error("  pom preview <input.pom.xml|input.pom.md> [--port <number>]");
   console.error("  pom build <input.pom.xml|input.pom.md> -o <output.pptx>");
   process.exit(1);
 }

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -364,7 +364,10 @@ function buildPreviewHtml(filename: string): string {
 </html>`;
 }
 
-export function runPreview(inputFile: string): void {
+export function runPreview(
+  inputFile: string,
+  port: number = DEFAULT_PORT,
+): void {
   const absInput = path.resolve(inputFile);
 
   if (!fs.existsSync(absInput)) {
@@ -456,7 +459,7 @@ export function runPreview(inputFile: string): void {
   server.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {
       console.error(
-        `Port ${DEFAULT_PORT} is already in use. Is another pom preview running?`,
+        `Port ${port} is already in use. Is another pom preview running?`,
       );
     } else {
       console.error(`Server error: ${err.message}`);
@@ -464,8 +467,8 @@ export function runPreview(inputFile: string): void {
     process.exit(1);
   });
 
-  server.listen(DEFAULT_PORT, () => {
-    console.log(`Preview server: http://localhost:${DEFAULT_PORT}`);
+  server.listen(port, () => {
+    console.log(`Preview server: http://localhost:${port}`);
     console.log(`Watching: ${absInput}`);
     console.log("Press Ctrl+C to stop");
   });


### PR DESCRIPTION
close #762

## 目的

`pom preview` のポート番号をコマンドラインから変更できるようにする。3000 番が使用中の場合や複数スライドを並列プレビューしたい場合に対応する。

## 変更内容

- `packages/pom-cli/src/cli.ts`: `--port <number>` オプションのパース追加（1〜65535 の整数バリデーション付き）
- `packages/pom-cli/src/preview.ts`: `runPreview` にポート引数を追加（デフォルト 3000）、EADDRINUSE エラーメッセージに実際のポート番号を表示
- `packages/pom-cli/README.md`: `--port` の使用例を Preview セクションに追記

## 使用方法

```bash
# 従来通り（デフォルト 3000）
pom preview slides.pom.xml

# ポート指定
pom preview slides.pom.xml --port 3001
```

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom-cli run build
node packages/pom-cli/dist/cli.js preview <file> --port 3001
# → http://localhost:3001 でサーバーが起動することを確認
node packages/pom-cli/dist/cli.js preview <file>
# → http://localhost:3000 で起動することを確認（後方互換）
```