### PR TITLE
feat: llm.txt と SKILL.md の埋め込みブロックを CI で同期チェックする仕組みを追加

### DIFF
--- a/.github/workflows/ci-skills.yml
+++ b/.github/workflows/ci-skills.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "skills/**"
       - "apps/website/public/llm.txt"
+      - "scripts/**"
       - ".github/workflows/ci-skills.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "skills/**"
       - "apps/website/public/llm.txt"
+      - "scripts/**"
       - ".github/workflows/ci-skills.yml"
 
 jobs:

--- a/.github/workflows/ci-skills.yml
+++ b/.github/workflows/ci-skills.yml
@@ -5,11 +5,13 @@ on:
     branches: ["main"]
     paths:
       - "skills/**"
+      - "apps/website/public/llm.txt"
       - ".github/workflows/ci-skills.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "skills/**"
+      - "apps/website/public/llm.txt"
       - ".github/workflows/ci-skills.yml"
 
 jobs:
@@ -25,3 +27,12 @@ jobs:
         run: gh skill publish --dry-run
         env:
           GH_TOKEN: ${{ github.token }}
+
+  check-skill-llm-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check SKILL.md llm.txt sync
+        run: bash scripts/check-skill-llm-sync.sh

--- a/scripts/check-skill-llm-sync.sh
+++ b/scripts/check-skill-llm-sync.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Check that the embedded llm.txt block in skills/pom-slide/SKILL.md matches
+# apps/website/public/llm.txt. Exit 1 if they differ.
+set -euo pipefail
+
+LLM_TXT="apps/website/public/llm.txt"
+SKILL_MD="skills/pom-slide/SKILL.md"
+
+if [ ! -f "$LLM_TXT" ]; then
+  echo "ERROR: $LLM_TXT が見つかりません" >&2
+  exit 1
+fi
+
+if [ ! -f "$SKILL_MD" ]; then
+  echo "ERROR: $SKILL_MD が見つかりません" >&2
+  exit 1
+fi
+
+embedded=$(awk '/<!-- BEGIN llm\.txt -->/{found=1; next} /<!-- END llm\.txt -->/{found=0} found' "$SKILL_MD")
+
+if diff <(printf '%s\n' "$embedded") "$LLM_TXT" > /dev/null 2>&1; then
+  echo "OK: $SKILL_MD の埋め込みブロックは $LLM_TXT と一致しています"
+  exit 0
+fi
+
+echo "ERROR: $SKILL_MD の埋め込みブロックが $LLM_TXT と一致しません" >&2
+echo "以下のコマンドで同期してください:" >&2
+echo "  bash scripts/sync-skill-llm.sh" >&2
+echo "" >&2
+diff <(printf '%s\n' "$embedded") "$LLM_TXT" >&2 || true
+exit 1

--- a/scripts/sync-skill-llm.sh
+++ b/scripts/sync-skill-llm.sh
@@ -24,12 +24,17 @@ with open('apps/website/public/llm.txt') as f:
 with open('skills/pom-slide/SKILL.md') as f:
     skill = f.read()
 
-new = re.sub(
+content = llm if llm.endswith('\n') else llm + '\n'
+new, count = re.subn(
     r'(?<=<!-- BEGIN llm\.txt -->\n).*?(?=<!-- END llm\.txt -->)',
-    llm + '\n',
+    content,
     skill,
     flags=re.DOTALL,
 )
+
+if count != 1:
+    print(f'ERROR: マーカーが見つかりません (置換回数={count})。<!-- BEGIN llm.txt --> / <!-- END llm.txt --> の存在を確認してください。', file=sys.stderr)
+    sys.exit(1)
 
 if new == skill:
     print('already up to date')

--- a/scripts/sync-skill-llm.sh
+++ b/scripts/sync-skill-llm.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Update the embedded llm.txt block in skills/pom-slide/SKILL.md to match
+# the current content of apps/website/public/llm.txt.
+set -euo pipefail
+
+LLM_TXT="apps/website/public/llm.txt"
+SKILL_MD="skills/pom-slide/SKILL.md"
+
+if [ ! -f "$LLM_TXT" ]; then
+  echo "ERROR: $LLM_TXT が見つかりません" >&2
+  exit 1
+fi
+
+if [ ! -f "$SKILL_MD" ]; then
+  echo "ERROR: $SKILL_MD が見つかりません" >&2
+  exit 1
+fi
+
+python3 - <<'PYEOF'
+import re, sys
+
+with open('apps/website/public/llm.txt') as f:
+    llm = f.read()
+with open('skills/pom-slide/SKILL.md') as f:
+    skill = f.read()
+
+new = re.sub(
+    r'(?<=<!-- BEGIN llm\.txt -->\n).*?(?=<!-- END llm\.txt -->)',
+    llm + '\n',
+    skill,
+    flags=re.DOTALL,
+)
+
+if new == skill:
+    print('already up to date')
+    sys.exit(0)
+
+with open('skills/pom-slide/SKILL.md', 'w') as f:
+    f.write(new)
+
+print('OK: skills/pom-slide/SKILL.md を apps/website/public/llm.txt で更新しました')
+PYEOF

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -23,6 +23,7 @@ allowed-tools: Write,Bash
 
 ---
 
+<!-- BEGIN llm.txt -->
 # pom XML Reference
 
 A compact reference for the pom XML format, designed to be pasted into LLM prompts.
@@ -531,10 +532,10 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 | Parent Node      | Child Tags                                          | Mapped Property              |
 | ---------------- | --------------------------------------------------- | ---------------------------- |
 | `<Chart>`        | `<ChartSeries>` > `<ChartDataPoint>`                | `data`                       |
-| `<Table>`        | `<Col>`, `<Tr>` > `<Td>`                           | `columns`, `rows`            |
+| `<Table>`        | `<Col>`, `<Tr>` > `<Td>`       | `columns`, `rows`            |
 | `<Text>`         | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
 | `<Li>`           | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
-| `<Td>`           | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
+| `<Td>`    | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
 | `<Timeline>`     | `<TimelineItem>`                                    | `items`                      |
 | `<Matrix>`       | `<MatrixAxes>`, `<MatrixQuadrants>`, `<MatrixItem>` | `axes`, `quadrants`, `items` |
 | `<Tree>`         | `<TreeItem>` (recursive)                            | `data`                       |
@@ -578,6 +579,7 @@ When the same property is specified via both attributes (JSON string) and child 
 - Property names are `w` / `h` (not `width` / `height`)
 - Children of `Layer` require `x` and `y`
 - `Tree` must have exactly one root `<TreeItem>`
+<!-- END llm.txt -->
 
 ---
 


### PR DESCRIPTION
close #742

## 目的

`apps/website/public/llm.txt` が更新されたとき、`skills/pom-slide/SKILL.md` の埋め込みブロックとの不一致を CI で自動検出できるようにする。

## 変更概要

- **`skills/pom-slide/SKILL.md`**: llm.txt の埋め込みブロックを `<!-- BEGIN llm.txt -->` / `<!-- END llm.txt -->` マーカーで明示。埋め込み内容を llm.txt と完全一致させた
- **`scripts/check-skill-llm-sync.sh`**: マーカー間の内容と llm.txt を比較し、差分があれば exit 1 で CI を失敗させる
- **`scripts/sync-skill-llm.sh`**: llm.txt の内容で SKILL.md を手動更新するユーティリティ（同期漏れを修正するときに使う）
- **`.github/workflows/ci-skills.yml`**: `check-skill-llm-sync` ジョブを追加。`llm.txt` / `scripts/**` の変更もトリガーパスに追加

## 影響範囲

- `skills/pom-slide/SKILL.md` — マーカー追加・テーブル空白修正のみ、機能変化なし
- `.github/workflows/ci-skills.yml` — 既存の `validate` ジョブと独立した新ジョブの追加のみ
- `release.yml` への依存なし（pom コアのリリースフローに影響しない）

## ローカル検証

```bash
# 一致チェック
bash scripts/check-skill-llm-sync.sh
# → OK: skills/pom-slide/SKILL.md の埋め込みブロックは apps/website/public/llm.txt と一致しています

# 不一致時の検出確認
echo "extra" >> apps/website/public/llm.txt
bash scripts/check-skill-llm-sync.sh
# → exit 1 + diff 出力

# sync による修正
bash scripts/sync-skill-llm.sh
bash scripts/check-skill-llm-sync.sh
# → OK
```