### PR TITLE
feat: pom-slide スキルのリリースを CI で自動化する

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -1,12 +1,22 @@
 ---
 paths:
   - .changeset/**
+  - skills/**
 ---
 
-## Release Flow (Changesets)
+## Release Flow (Changesets) — npm packages + pom-vscode
 
 All npm packages (`@hirokisakabe/pom`, `@hirokisakabe/pom-md`, `@hirokisakabe/pom-cli`, `@hirokisakabe/pom-jsx`, `@hirokisakabe/pom-editor`) and `pom-vscode` use [Changesets](https://github.com/changesets/changesets) for versioning. The unified workflow (`release.yml`) handles all packages.
 
 1. Add a changeset: `pnpm exec changeset add`
 2. Push to main → GitHub Actions creates a Release PR (version bump + CHANGELOG)
 3. Merge the Release PR → `changeset publish` publishes all npm packages, then detects pom-vscode version change → `vsce publish` to VS Code Marketplace + Git tag + GitHub Release
+
+## Release Flow (pom-slide skill)
+
+`pom-slide` uses a separate workflow (`release-skill.yml`) independent of Changesets.
+
+- **Version management**: `metadata.version` field in `skills/pom-slide/SKILL.md` frontmatter
+- **Trigger**: push to main with changes to `skills/**`
+- **Flow**: bump `metadata.version` in `SKILL.md` → push to main → `release-skill.yml` runs `gh skill publish --tag pom-slide-v${VERSION}` → git tag + GitHub Release + skill registry publish
+- **Idempotency**: if tag `pom-slide-v${VERSION}` already exists, the workflow skips

--- a/.github/workflows/release-skill.yml
+++ b/.github/workflows/release-skill.yml
@@ -1,0 +1,61 @@
+name: Release - pom-slide skill
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+
+jobs:
+  release-pom-slide:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Upgrade gh CLI
+        run: sudo apt-get update -qq && sudo apt-get install -y gh
+
+      - name: Read version from SKILL.md
+        id: skill-version
+        run: |
+          VERSION=$(python3 - <<'PYEOF'
+          import re, sys
+          with open('skills/pom-slide/SKILL.md') as f:
+              text = f.read()
+          m = re.search(r'^---\n(.*?)\n---', text, re.DOTALL)
+          if m:
+              vm = re.search(r'version:\s*["\']?([0-9][^\s"\']*)', m.group(1))
+              if vm:
+                  print(vm.group(1))
+                  sys.exit(0)
+          sys.exit(1)
+          PYEOF
+          )
+          if [ -z "${VERSION}" ]; then
+            echo "Failed to read version from SKILL.md" >&2
+            exit 1
+          fi
+          TAG="pom-slide-v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: tag-check
+        run: |
+          TAG="${{ steps.skill-version.outputs.tag }}"
+          if git ls-remote --tags origin "${TAG}" | grep -q "${TAG}"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists, skipping"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish skill
+        if: steps.tag-check.outputs.exists == 'false'
+        run: gh skill publish --tag "${{ steps.skill-version.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -3,6 +3,8 @@ name: pom-slide
 description: Generate pom presentation slides from natural language. Creates a pom XML file and optionally launches a live preview with pom-cli.
 license: MIT
 allowed-tools: Write,Bash
+metadata:
+  version: "1.0.0"
 ---
 
 自然言語の指示から pom XML スライドを生成し、ファイルに保存する。pom-cli がインストール済みの場合はプレビューサーバーを起動する。


### PR DESCRIPTION
close #738

## 概要

- `skills/pom-slide/SKILL.md` frontmatter に `metadata.version: "1.0.0"` を追加
- `.github/workflows/release-skill.yml` を新規追加し、`skills/**` への main push で `gh skill publish` を自動実行するワークフローを実装

## 変更内容

### `skills/pom-slide/SKILL.md`

```yaml
metadata:
  version: "1.0.0"
```

を frontmatter に追加。バージョンアップ時はこのフィールドを更新する。

### `.github/workflows/release-skill.yml`

- **トリガー**: `main` ブランチへの push で `skills/**` に変更が含まれる場合
- **バージョン取得**: `SKILL.md` frontmatter の `metadata.version` を Python で抽出
- **冪等性**: `git ls-remote --tags` でタグ存在確認 → 既存タグの場合はスキップ
- **リリース**: `gh skill publish --tag pom-slide-v${VERSION}` で git tag・GitHub Release・スキル publish を一括実行
- **分離**: `release.yml`（npm / vscode リリース）とは独立したワークフローファイルのため、失敗しても他のリリースフローに影響しない

## 影響パッケージパス

- `.github/workflows/release-skill.yml`（新規）
- `skills/pom-slide/SKILL.md`

## ローカル検証手順

1. `skills/**` に変更を加えて main へ push し、Actions タブで確認
2. `pom-slide-v1.0.0` の git tag と GitHub Release が作成されることを確認
3. 同じバージョンで再 push した場合に「Tag already exists, skipping」でスキップされることを確認