### PR TITLE
docs(.claude/rules): パッケージ別ルールに PR 作成前チェックセクションを追加

### DIFF
--- a/.claude/rules/pom-cli.md
+++ b/.claude/rules/pom-cli.md
@@ -23,3 +23,7 @@ pom-cli uses Changesets for versioning. The release is handled by the unified `r
 1. Add a changeset: `pnpm exec changeset add`
 2. Release PR merges → `changeset version` bumps `package.json` version
 3. `release.yml` runs `changeset publish` → publishes to npm as `@hirokisakabe/pom-cli`
+
+### PR 作成前チェック
+
+- [ ] changeset を追加する: `pnpm exec changeset add`

--- a/.claude/rules/pom-editor.md
+++ b/.claude/rules/pom-editor.md
@@ -25,3 +25,7 @@ pom-editor uses Changesets for versioning. The release is handled by the unified
 1. Add a changeset: `pnpm exec changeset add`
 2. Release PR merges → `changeset version` bumps `package.json` version
 3. `release.yml` runs `changeset publish` → publishes to npm as `@hirokisakabe/pom-editor`
+
+### PR 作成前チェック
+
+- [ ] changeset を追加する: `pnpm exec changeset add`

--- a/.claude/rules/pom-jsx.md
+++ b/.claude/rules/pom-jsx.md
@@ -35,3 +35,7 @@ pom-jsx uses Changesets for versioning. The release is handled by the unified `r
 1. Add a changeset: `pnpm exec changeset add`
 2. Release PR merges → `changeset version` bumps `package.json` version
 3. `release.yml` runs `changeset publish` → publishes to npm as `@hirokisakabe/pom-jsx`
+
+### PR 作成前チェック
+
+- [ ] changeset を追加する: `pnpm exec changeset add`

--- a/.claude/rules/pom-md.md
+++ b/.claude/rules/pom-md.md
@@ -28,3 +28,7 @@ Pipeline: `Markdown → parseMd() → pom XML string → buildPptx() (core)`
 cd apps/website/content/pom-md
 ln -s ../../../../packages/pom-md/docs/<new-file>.md <new-file>.md
 ```
+
+### PR 作成前チェック
+
+- [ ] changeset を追加する: `pnpm exec changeset add`

--- a/.claude/rules/pom-vscode.md
+++ b/.claude/rules/pom-vscode.md
@@ -43,3 +43,7 @@ pom-vscode uses Changesets for versioning (`privatePackages` config). The releas
 3. `release.yml` detects pom-vscode version change → builds, tests, and publishes to VS Code Marketplace + creates Git tag (`pom-vscode-v{version}`) + GitHub Release
 
 Each publish/tag/release step is idempotent: if the workflow fails midway, re-running will skip already-completed steps and resume from the point of failure.
+
+### PR 作成前チェック
+
+- [ ] changeset を追加する: `pnpm exec changeset add`


### PR DESCRIPTION
close #772

## 概要

- `.claude/rules/pom-cli.md` / `pom-editor.md` / `pom-jsx.md` / `pom-vscode.md` の各ファイルに `### PR 作成前チェック` セクションを追加し、changeset 追加を明示的なチェック項目として記載した
- cross-review の指摘を受け、`release.md` で Changesets 管理対象と明示されている `pom-md.md` にも同様のセクションを追加した
- `feature-addition.md` の項目 10 と同等の強度で「PR を出すたびに必ずやること」として認識できる形式に統一した

## 変更ファイル

- `.claude/rules/pom-cli.md`
- `.claude/rules/pom-editor.md`
- `.claude/rules/pom-jsx.md`
- `.claude/rules/pom-vscode.md`
- `.claude/rules/pom-md.md`（issue スコープ外だが cross-review の warning に基づき追加）

## ローカル検証

```bash
grep -n "PR 作成前チェック" .claude/rules/pom-*.md
```

各ファイルに `### PR 作成前チェック` と `- [ ] changeset を追加する: \`pnpm exec changeset add\`` が含まれることを確認できる。