### PR TITLE
feat(pom-cli): --verbose フラグでビルドのステップ別処理時間を stderr に出力する

### DIFF
--- a/.changeset/pom-cli-verbose-flag.md
+++ b/.changeset/pom-cli-verbose-flag.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+`pom build` と `pom preview` に `--verbose` フラグを追加した。指定するとビルド処理の各ステップ（ファイル読み込み・Markdown パース・PPTX ビルド・書き出し）の処理時間が `[pom] ...` 形式で stderr に出力される。

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -29,6 +29,12 @@ pom preview slides.pom.xml --port 3001
 
 Use the zoom buttons in the toolbar or press `+` / `-` to zoom in and out. The current zoom level is saved across sessions.
 
+To print per-step timing on stderr when each rebuild completes:
+
+```bash
+pom preview slides.pom.xml --verbose
+```
+
 ### Build
 
 Converts a pom file to a PPTX file.
@@ -36,6 +42,12 @@ Converts a pom file to a PPTX file.
 ```bash
 pom build slides.pom.xml -o output.pptx
 pom build slides.pom.md -o output.pptx
+```
+
+To print per-step timing on stderr:
+
+```bash
+pom build slides.pom.xml -o output.pptx --verbose
 ```
 
 ## Fonts

--- a/packages/pom-cli/src/build.ts
+++ b/packages/pom-cli/src/build.ts
@@ -3,10 +3,20 @@ import path from "path";
 import { buildPptx } from "@hirokisakabe/pom";
 import { parseMd } from "@hirokisakabe/pom-md";
 
+function makeLog(verbose: boolean) {
+  if (!verbose) return (_msg: string) => {};
+  return (msg: string) => process.stderr.write(`[pom] ${msg}\n`);
+}
+
 export async function runBuild(
   inputFile: string,
   outputFile: string,
+  options: { verbose?: boolean } = {},
 ): Promise<void> {
+  const verbose = options.verbose ?? false;
+  const log = makeLog(verbose);
+  const totalStart = Date.now();
+
   const absInput = path.resolve(inputFile);
   const absOutput = path.resolve(outputFile);
 
@@ -14,6 +24,7 @@ export async function runBuild(
     throw new Error(`Input file not found: ${absInput}`);
   }
 
+  log(`Reading file: ${absInput}`);
   const content = fs.readFileSync(absInput, "utf-8");
   const ext = path.extname(absInput);
 
@@ -23,10 +34,12 @@ export async function runBuild(
   let masterPptxData: Uint8Array | undefined;
 
   if (ext === ".md") {
+    const t = Date.now();
     const result = parseMd(content);
     xml = result.xml;
     slideWidth = result.meta.size.w;
     slideHeight = result.meta.size.h;
+    log(`Parsing Markdown... done (${Date.now() - t}ms)`);
 
     if (result.meta.masterPptx) {
       const masterPath = path.resolve(
@@ -47,6 +60,7 @@ export async function runBuild(
     xml = content;
   }
 
+  const t1 = Date.now();
   const { pptx } = await buildPptx(
     xml,
     { w: slideWidth, h: slideHeight },
@@ -55,12 +69,20 @@ export async function runBuild(
       strict: true,
     },
   );
+  log(`Building PPTX... done (${Date.now() - t1}ms)`);
 
+  const t2 = Date.now();
   const buffer = await pptx.write({ outputType: "uint8array" });
   if (!(buffer instanceof Uint8Array)) {
     throw new Error("Unexpected output type from pptx.write");
   }
-
   fs.writeFileSync(absOutput, buffer);
-  console.log(`PPTX saved: ${absOutput}`);
+  log(`Writing output... done (${Date.now() - t2}ms)`);
+
+  const total = Date.now() - totalStart;
+  console.log(
+    verbose
+      ? `PPTX saved: ${absOutput} (total: ${total}ms)`
+      : `PPTX saved: ${absOutput}`,
+  );
 }

--- a/packages/pom-cli/src/build.ts
+++ b/packages/pom-cli/src/build.ts
@@ -80,9 +80,6 @@ export async function runBuild(
   log(`Writing output... done (${Date.now() - t2}ms)`);
 
   const total = Date.now() - totalStart;
-  console.log(
-    verbose
-      ? `PPTX saved: ${absOutput} (total: ${total}ms)`
-      : `PPTX saved: ${absOutput}`,
-  );
+  log(`Total: ${total}ms`);
+  console.log(`PPTX saved: ${absOutput}`);
 }

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -20,7 +20,8 @@ program
   .description("Start a live preview server for a presentation")
   .argument("<input>", "Input file (.pom.xml or .pom.md)")
   .option("--port <number>", "Port to listen on")
-  .action((input: string, options: { port?: string }) => {
+  .option("--verbose", "Show build step timing on stderr")
+  .action((input: string, options: { port?: string; verbose?: boolean }) => {
     let port: number | undefined;
     if (options.port !== undefined) {
       port = Number(options.port);
@@ -30,7 +31,7 @@ program
       }
     }
     try {
-      runPreview(input, port);
+      runPreview(input, port, { verbose: options.verbose });
     } catch (err: unknown) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
@@ -42,21 +43,24 @@ program
   .description("Build a presentation to PPTX")
   .argument("<input>", "Input file (.pom.xml or .pom.md)")
   .requiredOption("-o <output>", "Output PPTX file")
-  .action((input: string, options: { o: string }) => {
-    runBuild(input, options.o).catch((err: unknown) => {
-      if (err instanceof DiagnosticsError) {
-        const count = err.diagnostics.length;
-        console.error(
-          `✗ Build failed (${count} ${count === 1 ? "error" : "errors"})\n`,
-        );
-        for (const d of err.diagnostics) {
-          console.error(`  [${d.code}] ${d.message}`);
+  .option("--verbose", "Show build step timing on stderr")
+  .action((input: string, options: { o: string; verbose?: boolean }) => {
+    runBuild(input, options.o, { verbose: options.verbose }).catch(
+      (err: unknown) => {
+        if (err instanceof DiagnosticsError) {
+          const count = err.diagnostics.length;
+          console.error(
+            `✗ Build failed (${count} ${count === 1 ? "error" : "errors"})\n`,
+          );
+          for (const d of err.diagnostics) {
+            console.error(`  [${d.code}] ${d.message}`);
+          }
+        } else {
+          console.error(err instanceof Error ? err.message : String(err));
         }
-      } else {
-        console.error(err instanceof Error ? err.message : String(err));
-      }
-      process.exit(1);
-    });
+        process.exit(1);
+      },
+    );
   });
 
 program.parse();

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -9,6 +9,11 @@ import { convertPptxToSvg } from "pptx-glimpse";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_PORT = 3000;
 
+function makeLog(verbose: boolean) {
+  if (!verbose) return (_msg: string) => {};
+  return (msg: string) => process.stderr.write(`[pom] ${msg}\n`);
+}
+
 const EXTRA_FONT_MAPPING: Record<string, string> = {
   "游ゴシック Light": "Noto Sans CJK JP",
   "Yu Gothic Light": "Noto Sans CJK JP",
@@ -19,7 +24,11 @@ type SvgResult =
   | { type: "error"; message: string }
   | { type: "empty" };
 
-async function generateSvgs(inputFile: string): Promise<SvgResult> {
+async function generateSvgs(
+  inputFile: string,
+  verbose = false,
+): Promise<SvgResult> {
+  const log = makeLog(verbose);
   const content = fs.readFileSync(inputFile, "utf-8");
   const ext = path.extname(inputFile);
 
@@ -29,10 +38,12 @@ async function generateSvgs(inputFile: string): Promise<SvgResult> {
   let masterPptxData: Uint8Array | undefined;
 
   if (ext === ".md") {
+    const t = Date.now();
     const result = parseMd(content);
     xml = result.xml;
     slideWidth = result.meta.size.w;
     slideHeight = result.meta.size.h;
+    log(`Parsing Markdown... done (${Date.now() - t}ms)`);
 
     if (result.meta.masterPptx) {
       const masterPath = path.resolve(
@@ -59,6 +70,7 @@ async function generateSvgs(inputFile: string): Promise<SvgResult> {
     return { type: "empty" };
   }
 
+  const t1 = Date.now();
   const { pptx } = await buildPptx(
     xml,
     { w: slideWidth, h: slideHeight },
@@ -67,6 +79,7 @@ async function generateSvgs(inputFile: string): Promise<SvgResult> {
       ...(masterPptxData ? { masterPptx: masterPptxData } : {}),
     },
   );
+  log(`Building PPTX... done (${Date.now() - t1}ms)`);
 
   const buffer = await pptx.write({ outputType: "uint8array" });
   if (!(buffer instanceof Uint8Array)) {
@@ -81,12 +94,15 @@ async function generateSvgs(inputFile: string): Promise<SvgResult> {
   }
   const fontDirs = [fontsDir];
 
+  const t2 = Date.now();
   const slides = await convertPptxToSvg(buffer, {
     width: slideWidth,
     fontDirs,
     fontMapping: EXTRA_FONT_MAPPING,
     skipSystemFonts: true,
   });
+  log(`Converting to SVG... done (${Date.now() - t2}ms)`);
+
   const svgs = slides.map((s: { svg: string }) => s.svg);
 
   return { type: "success", svgs, slideWidth };
@@ -367,7 +383,10 @@ function buildPreviewHtml(filename: string): string {
 export function runPreview(
   inputFile: string,
   port: number = DEFAULT_PORT,
+  options: { verbose?: boolean } = {},
 ): void {
+  const verbose = options.verbose ?? false;
+  const log = makeLog(verbose);
   const absInput = path.resolve(inputFile);
 
   if (!fs.existsSync(absInput)) {
@@ -394,9 +413,14 @@ export function runPreview(
   }
 
   function refresh(): void {
+    const totalStart = Date.now();
+    log("File changed, rebuilding...");
     broadcastBuilding();
-    generateSvgs(absInput)
-      .then(broadcast)
+    generateSvgs(absInput, verbose)
+      .then((result) => {
+        log(`Done (total: ${Date.now() - totalStart}ms)`);
+        broadcast(result);
+      })
       .catch((err: unknown) => {
         broadcast({
           type: "error",
@@ -405,10 +429,12 @@ export function runPreview(
       });
   }
 
-  generateSvgs(absInput)
+  const initialStart = Date.now();
+  generateSvgs(absInput, verbose)
     .then((result) => {
       currentResult = result;
       initialBuildDone = true;
+      log(`Initial build done (total: ${Date.now() - initialStart}ms)`);
       broadcast(result);
     })
     .catch((err: unknown) => {


### PR DESCRIPTION
close #760

## 概要

`pom build` と `pom preview` に `--verbose` フラグを追加しました。指定するとビルド処理の各ステップの処理時間が `[pom] ...` 形式で stderr に出力されます。

## 変更内容

- `packages/pom-cli/src/build.ts`: `runBuild` に `options.verbose` パラメータを追加。verbose 時はファイル読み込み・Markdown パース・PPTX ビルド・書き出しの各ステップを stderr に出力
- `packages/pom-cli/src/preview.ts`: `generateSvgs` / `runPreview` に verbose 対応を追加。ファイル変更時の再ビルドでもステップログが出力される
- `packages/pom-cli/src/cli.ts`: `build` / `preview` コマンド両方に `--verbose` オプションを追加
- `packages/pom-cli/README.md`: `--verbose` の使用例と「タイミングは stderr」の旨を追記

## 出力例

```
# stderr
[pom] Reading file: /path/to/slides.pom.xml
[pom] Building PPTX... done (187ms)
[pom] Writing output... done (11ms)
[pom] Total: 198ms

# stdout（従来と同じ）
PPTX saved: /path/to/output.pptx
```

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom-cli run build
node packages/pom-cli/dist/cli.js build slides.pom.xml -o out.pptx --verbose
node packages/pom-cli/dist/cli.js preview slides.pom.xml --verbose
```

## 後方互換性

- `--verbose` なし時は stdout の出力が従来と完全に同一（`PPTX saved: <path>` のみ）
- verbose 時のステップログはすべて stderr に出力し、stdout は変更しない