### PR TITLE
feat(ci): pom-cli の CI ワークフローを追加する

### DIFF
--- a/.github/workflows/ci-pom-cli.yml
+++ b/.github/workflows/ci-pom-cli.yml
@@ -6,20 +6,24 @@ on:
     paths:
       - "packages/pom-cli/**"
       - "packages/pom/src/**"
+      - "packages/pom-md/**"
       - "package.json"
       - "packages/pom/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - ".node-version"
       - ".github/workflows/ci-pom-cli.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "packages/pom-cli/**"
       - "packages/pom/src/**"
+      - "packages/pom-md/**"
       - "package.json"
       - "packages/pom/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - ".node-version"
       - ".github/workflows/ci-pom-cli.yml"
 
 jobs:
@@ -38,6 +42,10 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+        working-directory: .
+      - run: pnpm --filter @hirokisakabe/pom run build
+        working-directory: .
+      - run: pnpm --filter @hirokisakabe/pom-md run build
         working-directory: .
       - run: pnpm run fmt:check
       - run: pnpm run lint

--- a/.github/workflows/ci-pom-cli.yml
+++ b/.github/workflows/ci-pom-cli.yml
@@ -1,0 +1,46 @@
+name: CI - pom-cli
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "packages/pom-cli/**"
+      - "packages/pom/src/**"
+      - "package.json"
+      - "packages/pom/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/ci-pom-cli.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/pom-cli/**"
+      - "packages/pom/src/**"
+      - "package.json"
+      - "packages/pom/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/ci-pom-cli.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/pom-cli
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+        working-directory: .
+      - run: pnpm run fmt:check
+      - run: pnpm run lint
+      - run: pnpm run knip
+      - run: pnpm run typecheck
+      - run: pnpm run build

--- a/packages/pom-cli/knip.json
+++ b/packages/pom-cli/knip.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "project": ["src/**/*.ts"],
+  "ignoreBinaries": ["eslint", "knip", "prettier", "tsc"],
+  "ignoreDependencies": ["typescript-eslint"],
+  "rules": {
+    "exports": "warn"
+  }
+}


### PR DESCRIPTION
close #775

## 目的

`packages/pom-cli/` への変更を検証する GitHub Actions ワークフロー `ci-pom-cli.yml` が欠けていたため追加する。他パッケージ（pom-md、pom-jsx など）と整合性を揃え、PR 時に品質チェックが自動実行されるようにする。

## 変更内容

- `.github/workflows/ci-pom-cli.yml` を新規追加
  - `packages/pom-cli/**`、`packages/pom/src/**`、`packages/pom-md/**`、`.node-version` 等への変更で push/PR トリガー
  - ステップ: `fmt:check` → `lint` → `knip` → `typecheck` → `build`
  - pom-cli の依存パッケージ（`@hirokisakabe/pom`、`@hirokisakabe/pom-md`）を事前ビルドしてから検証

## 影響パッケージ

- `.github/workflows/ci-pom-cli.yml`（新規）

## ローカル検証手順

1. このブランチで `packages/pom-cli/` 内のファイルを変更して push/PR を開くと CI がトリガーされることを確認