### PR TITLE
fix: pom-editor / pom-jsx / pom-md に publishConfig を追加

### DIFF
--- a/packages/pom-editor/package.json
+++ b/packages/pom-editor/package.json
@@ -50,5 +50,8 @@
   "devDependencies": {
     "@types/react": "^19",
     "typescript-eslint": "^8.59.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/pom-jsx/package.json
+++ b/packages/pom-jsx/package.json
@@ -61,5 +61,8 @@
     "@hirokisakabe/pom": "workspace:*",
     "@vitest/coverage-v8": "^4.1.7",
     "typescript-eslint": "^8.59.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/pom-md/package.json
+++ b/packages/pom-md/package.json
@@ -56,5 +56,8 @@
     "@types/markdown-it": "^14.1.2",
     "@vitest/coverage-v8": "^4.1.7",
     "typescript-eslint": "^8.59.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## 背景

npm Trusted Publishing (OIDC) を使ったリリースで `@hirokisakabe/pom-editor@0.2.1` の publish が E404 で失敗していた。

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@hirokisakabe%2fpom-editor - Not found
npm error 404  The requested resource '@hirokisakabe/pom-editor@0.2.1' could not be found or you do not have permission to access it.
```

## 原因

`@hirokisakabe/pom` と `@hirokisakabe/pom-cli` には `publishConfig: { access: "public" }` が設定されていたが、`pom-editor` / `pom-jsx` / `pom-md` の 3 パッケージに欠けていた。

## 変更内容

- `packages/pom-editor/package.json` — `publishConfig: { access: "public" }` を追加
- `packages/pom-jsx/package.json` — 同上
- `packages/pom-md/package.json` — 同上

## 備考

npm.com 側の Trusted Publishing 設定（`@hirokisakabe/pom-editor` へのリポジトリ・ワークフロー登録）は別途実施済み。本 PR はコード側の設定漏れを補完するもの。