### PR TITLE
feat(pom-cli): pom preview の起動体験を向上する（自動オープン・live reload 堅牢化・ワンコマンド化）

### DIFF
--- a/.changeset/pom-preview-launch-ux.md
+++ b/.changeset/pom-preview-launch-ux.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+`pom preview` 起動時にブラウザを自動オープンするようにした（`--no-open` で抑止可能）。ファイル監視をディレクトリ監視方式に変更し、エディタの atomic save 後も live reload が継続するようにした。

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -8,6 +8,16 @@ CLI tool for [pom](https://github.com/hirokisakabe/pom) — preview and build pr
 npm install -g @hirokisakabe/pom-cli
 ```
 
+## Quick Start
+
+One command is all it takes — no global install required:
+
+```bash
+npx @hirokisakabe/pom-cli preview slides.pom.xml
+```
+
+This starts a local preview server, opens your browser automatically, and live-reloads the preview every time the file is saved. This also works well when invoked from agent skills or scripts.
+
 ## Usage
 
 ### Preview
@@ -19,7 +29,13 @@ pom preview slides.pom.xml
 pom preview slides.pom.md
 ```
 
-Open http://localhost:3000 in your browser. The page updates automatically when the file is saved.
+The browser opens http://localhost:3000 automatically. The page updates whenever the file is saved — including atomic saves performed by editors like Vim.
+
+To suppress the automatic browser open (e.g. in CI or headless environments):
+
+```bash
+pom preview slides.pom.xml --no-open
+```
 
 To use a different port (e.g. when 3000 is already in use):
 

--- a/packages/pom-cli/src/build.ts
+++ b/packages/pom-cli/src/build.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { buildPptx, DiagnosticsError } from "@hirokisakabe/pom";
 import { parseMd } from "@hirokisakabe/pom-md";
+import { watchInputFile } from "./watch.ts";
 
 function makeLog(verbose: boolean) {
   if (!verbose) return (_msg: string) => {};
@@ -141,12 +142,8 @@ export async function runBuildWatch(
 
   await doBuild();
 
-  let debounceTimer: NodeJS.Timeout | null = null;
-  fs.watch(absInput, () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      watchLog("File changed, rebuilding...");
-      void doBuild();
-    }, 100);
+  watchInputFile(absInput, () => {
+    watchLog("File changed, rebuilding...");
+    void doBuild();
   });
 }

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -21,22 +21,31 @@ program
   .argument("<input>", "Input file (.pom.xml or .pom.md)")
   .option("--port <number>", "Port to listen on")
   .option("--verbose", "Show build step timing on stderr")
-  .action((input: string, options: { port?: string; verbose?: boolean }) => {
-    let port: number | undefined;
-    if (options.port !== undefined) {
-      port = Number(options.port);
-      if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-        console.error(`Invalid port: ${options.port}`);
+  .option("--no-open", "Do not open the browser automatically")
+  .action(
+    (
+      input: string,
+      options: { port?: string; verbose?: boolean; open: boolean },
+    ) => {
+      let port: number | undefined;
+      if (options.port !== undefined) {
+        port = Number(options.port);
+        if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+          console.error(`Invalid port: ${options.port}`);
+          process.exit(1);
+        }
+      }
+      try {
+        runPreview(input, port, {
+          verbose: options.verbose,
+          open: options.open,
+        });
+      } catch (err: unknown) {
+        console.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }
-    }
-    try {
-      runPreview(input, port, { verbose: options.verbose });
-    } catch (err: unknown) {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+    },
+  );
 
 program
   .command("build")

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { buildPptx } from "@hirokisakabe/pom";
 import { parseMd } from "@hirokisakabe/pom-md";
 import { convertPptxToSvg } from "pptx-glimpse";
+import { watchInputFile } from "./watch.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_PORT = 3000;
@@ -412,7 +413,16 @@ export function runPreview(
     }
   }
 
+  let isBuilding = false;
+  let pendingRefresh = false;
+
   function refresh(): void {
+    if (isBuilding) {
+      pendingRefresh = true;
+      return;
+    }
+    isBuilding = true;
+    pendingRefresh = false;
     const totalStart = Date.now();
     log("File changed, rebuilding...");
     broadcastBuilding();
@@ -426,30 +436,34 @@ export function runPreview(
           type: "error",
           message: err instanceof Error ? err.message : String(err),
         });
+      })
+      .finally(() => {
+        isBuilding = false;
+        if (pendingRefresh) refresh();
       });
   }
 
+  isBuilding = true;
   const initialStart = Date.now();
   generateSvgs(absInput, verbose)
     .then((result) => {
       currentResult = result;
-      initialBuildDone = true;
       log(`Initial build done (total: ${Date.now() - initialStart}ms)`);
       broadcast(result);
     })
     .catch((err: unknown) => {
-      initialBuildDone = true;
       broadcast({
         type: "error",
         message: err instanceof Error ? err.message : String(err),
       });
+    })
+    .finally(() => {
+      initialBuildDone = true;
+      isBuilding = false;
+      if (pendingRefresh) refresh();
     });
 
-  let debounceTimer: NodeJS.Timeout | null = null;
-  fs.watch(absInput, () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(refresh, 100);
-  });
+  watchInputFile(absInput, refresh);
 
   const html = buildPreviewHtml(path.basename(absInput));
 

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -1,3 +1,4 @@
+import { spawn } from "child_process";
 import fs from "fs";
 import http from "http";
 import { fileURLToPath } from "url";
@@ -13,6 +14,27 @@ const DEFAULT_PORT = 3000;
 function makeLog(verbose: boolean) {
   if (!verbose) return (_msg: string) => {};
   return (msg: string) => process.stderr.write(`[pom] ${msg}\n`);
+}
+
+function openBrowser(url: string): void {
+  let cmd: string;
+  let args: string[];
+  if (process.platform === "darwin") {
+    cmd = "open";
+    args = [url];
+  } else if (process.platform === "win32") {
+    // 空文字はウィンドウタイトル。省略すると URL がタイトル扱いされる
+    cmd = "cmd";
+    args = ["/c", "start", "", url];
+  } else {
+    cmd = "xdg-open";
+    args = [url];
+  }
+  const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+  child.on("error", () => {
+    console.log(`Could not open browser automatically. Open ${url} manually.`);
+  });
+  child.unref();
 }
 
 const EXTRA_FONT_MAPPING: Record<string, string> = {
@@ -384,7 +406,7 @@ function buildPreviewHtml(filename: string): string {
 export function runPreview(
   inputFile: string,
   port: number = DEFAULT_PORT,
-  options: { verbose?: boolean } = {},
+  options: { verbose?: boolean; open?: boolean } = {},
 ): void {
   const verbose = options.verbose ?? false;
   const log = makeLog(verbose);
@@ -508,8 +530,12 @@ export function runPreview(
   });
 
   server.listen(port, () => {
-    console.log(`Preview server: http://localhost:${port}`);
+    const url = `http://localhost:${port}`;
+    console.log(`Preview server: ${url}`);
     console.log(`Watching: ${absInput}`);
     console.log("Press Ctrl+C to stop");
+    if (options.open ?? true) {
+      openBrowser(url);
+    }
   });
 }

--- a/packages/pom-cli/src/watch.ts
+++ b/packages/pom-cli/src/watch.ts
@@ -13,10 +13,26 @@ export function watchInputFile(
   const base = path.basename(absPath);
   let debounceTimer: NodeJS.Timeout | null = null;
 
+  let lastMtimeMs = -1;
+  try {
+    lastMtimeMs = fs.statSync(absPath).mtimeMs;
+  } catch {
+    // 監視開始時点でファイルが無くても、作成され次第のイベントで拾う
+  }
+
   return fs.watch(dir, (_eventType, filename) => {
     // filename can be null on some platforms; treat it as a potential match
     if (filename !== null && filename !== base) return;
-    if (!fs.existsSync(absPath)) return;
+    // 同一ディレクトリの別ファイル変更 (filename が null の環境) や
+    // 自前の出力ファイル書き込みで発火しないよう、mtime の実変化を確認する
+    let mtimeMs: number;
+    try {
+      mtimeMs = fs.statSync(absPath).mtimeMs;
+    } catch {
+      return;
+    }
+    if (mtimeMs === lastMtimeMs) return;
+    lastMtimeMs = mtimeMs;
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(onChange, DEBOUNCE_MS);
   });

--- a/packages/pom-cli/src/watch.ts
+++ b/packages/pom-cli/src/watch.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+const DEBOUNCE_MS = 100;
+
+// Watches the parent directory instead of the file itself so the watcher
+// survives atomic saves (rename + replace) performed by editors like Vim.
+export function watchInputFile(
+  absPath: string,
+  onChange: () => void,
+): fs.FSWatcher {
+  const dir = path.dirname(absPath);
+  const base = path.basename(absPath);
+  let debounceTimer: NodeJS.Timeout | null = null;
+
+  return fs.watch(dir, (_eventType, filename) => {
+    // filename can be null on some platforms; treat it as a potential match
+    if (filename !== null && filename !== base) return;
+    if (!fs.existsSync(absPath)) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(onChange, DEBOUNCE_MS);
+  });
+}


### PR DESCRIPTION
close #790

## 目的

pom-cli のプレビューサーバーを「skill から呼ばれてワンコマンドで立ち上がり、編集が即反映される」体験にする（親 issue #787 の pom kit 構想の一部）。

## 変更内容

- **ブラウザ自動オープン**: `pom preview` のサーバー listen 後に OS 標準コマンド（`open` / `xdg-open` / `cmd start`）でプレビュー URL を自動で開く。`--no-open` で抑止可能。新規依存は追加していない
- **ファイル監視の共通化・堅牢化**: `watchInputFile` を `src/watch.ts` に切り出し、preview と `build --watch` で共用。ディレクトリ監視方式に変更し、エディタの atomic save（rename + replace）後も監視が継続するようにした。`filename` が `null` になる環境や自前の出力ファイル書き込みで誤発火しないよう mtime ガード付き（cross-review 指摘対応）。preview の再ビルドに `build --watch` と同じ isBuilding / pendingRefresh ガードを導入し、連続保存時の同時ビルドを防止
- **README**: ワンコマンド起動の Quick Start（`npx @hirokisakabe/pom-cli preview slides.pom.xml`）と `--no-open` を追記
- changeset（minor）追加

## 影響パッケージ

- `packages/pom-cli/` のみ

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom-cli run build
node packages/pom-cli/dist/cli.js preview <file>.pom.xml          # ブラウザが自動で開く
node packages/pom-cli/dist/cli.js preview <file>.pom.xml --no-open # 開かない
```

検証済み:
- PATH に偽の `open` を置いた検証で、デフォルトで `open <URL>` が呼ばれ `--no-open` で呼ばれないことを確認
- SSE 接続下で通常保存・atomic save（一時ファイル + `mv`）の両方で `building` → `success` が届き、ペイロードが更新されることを確認
- 同一ディレクトリの無関係ファイル変更では再ビルドが発火しないことを確認
- typecheck / lint / fmt:check / knip すべてパス

## 備考

- cross-review（codex / gpt-5.4）: critical 0 / warning 2。watch の誤発火リスクは mtime ガードで修正済み。「自動テスト追加」の指摘は、pom-cli にテスト基盤が無く Vitest 導入は本 issue のスコープを超えるため見送り（必要なら別 issue 化）
- issue 実装方針にある tsx の監視は、pom-cli が現状 tsx 入力自体に対応していないため対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)
