### PR TITLE
NodeDefinition metadata を単一ソース化

### DIFF
--- a/packages/pom/src/parseXml/parseXml.ts
+++ b/packages/pom/src/parseXml/parseXml.ts
@@ -1,24 +1,11 @@
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
-import { z } from "zod";
+import type { z } from "zod";
+import type { POMNode } from "../types.ts";
 import {
-  type POMNode,
-  textNodeSchema,
-  ulNodeSchema,
-  olNodeSchema,
-  imageNodeSchema,
-  tableNodeSchema,
-  shapeNodeSchema,
-  chartNodeSchema,
-  timelineNodeSchema,
-  matrixNodeSchema,
-  treeNodeSchema,
-  flowNodeSchema,
-  processArrowNodeSchema,
-  pyramidNodeSchema,
-  lineNodeSchema,
-  arrowNodeSchema,
-  iconNodeSchema,
-} from "../types.ts";
+  getNodeMetadata,
+  getNodeMetadataByTag,
+  NODE_METADATA,
+} from "../registry/nodeMetadata.ts";
 import {
   type CoercionRule,
   NODE_COERCION_MAP,
@@ -41,36 +28,9 @@ export class ParseXmlError extends Error {
 }
 
 // ===== Tag name → POM node type mapping =====
-export const TAG_TO_TYPE: Record<string, string> = {
-  Text: "text",
-  Image: "image",
-  Table: "table",
-  Shape: "shape",
-  Chart: "chart",
-  Timeline: "timeline",
-  Matrix: "matrix",
-  Tree: "tree",
-  Flow: "flow",
-  ProcessArrow: "processArrow",
-  Pyramid: "pyramid",
-  Ul: "ul",
-  Ol: "ol",
-  Line: "line",
-  Arrow: "arrow",
-  VStack: "vstack",
-  HStack: "hstack",
-  Layer: "layer",
-  Icon: "icon",
-  Svg: "svg",
-};
-
-// Reverse mapping: node type → tag name
-const TYPE_TO_TAG: Record<string, string> = Object.fromEntries(
-  Object.entries(TAG_TO_TYPE).map(([tag, type]) => [type, tag]),
+export const TAG_TO_TYPE: Record<string, string> = Object.fromEntries(
+  NODE_METADATA.map((def) => [def.tagName, def.type]),
 );
-
-const CONTAINER_TYPES = new Set(["vstack", "hstack", "layer"]);
-const TEXT_CONTENT_NODES = new Set(["text", "shape"]);
 // Attributes allowed on any node (e.g., x/y for Layer children positioning)
 const UNIVERSAL_ATTRS = new Set(["x", "y"]);
 
@@ -125,26 +85,6 @@ function getKnownChildAttributes(tagName: string): string[] {
   if (!rules) return [];
   return Object.keys(rules);
 }
-
-// ===== Leaf node Zod validation schemas =====
-const leafNodeValidationSchemas: Record<string, z.ZodTypeAny> = {
-  text: textNodeSchema,
-  image: imageNodeSchema,
-  table: tableNodeSchema,
-  shape: shapeNodeSchema,
-  chart: chartNodeSchema,
-  timeline: timelineNodeSchema,
-  matrix: matrixNodeSchema,
-  tree: treeNodeSchema,
-  flow: flowNodeSchema,
-  processArrow: processArrowNodeSchema,
-  pyramid: pyramidNodeSchema,
-  line: lineNodeSchema,
-  arrow: arrowNodeSchema,
-  ul: ulNodeSchema,
-  ol: olNodeSchema,
-  icon: iconNodeSchema,
-};
 
 function formatZodIssue(
   issue: z.core.$ZodIssue,
@@ -202,30 +142,20 @@ function formatZodIssue(
 
 // Properties that may be legitimately absent when using child element notation
 // or when the property is optional in practice (even if required in schema).
-const CHILD_ELEMENT_PROPS: Record<string, Set<string>> = {
-  flow: new Set(["nodes", "connections"]),
-  table: new Set(["columns", "rows"]),
-  chart: new Set(["data"]),
-  timeline: new Set(["items"]),
-  matrix: new Set(["axes", "items", "quadrants"]),
-  processArrow: new Set(["steps"]),
-  pyramid: new Set(["levels"]),
-  tree: new Set(["data"]),
-  ul: new Set(["items"]),
-  ol: new Set(["items"]),
-  icon: new Set(["name"]),
-  svg: new Set(["svgContent"]),
-};
-
 function validateLeafNode(
   nodeType: string,
   result: Record<string, unknown>,
   errors: string[],
 ): void {
-  const schema = leafNodeValidationSchemas[nodeType];
-  if (!schema) return;
-  const tagName = TYPE_TO_TAG[nodeType] ?? nodeType;
-  const childProps = CHILD_ELEMENT_PROPS[nodeType];
+  const def = getNodeMetadata(nodeType as POMNode["type"]);
+  if (def.childPolicy.kind === "pom-children") return;
+  const schema = def.schema;
+  const tagName = def.tagName;
+  const optionalChildProps = new Set(
+    def.childPolicy.kind === "custom"
+      ? (def.childPolicy.optionalProperties ?? [])
+      : [],
+  );
   const parseResult = schema.safeParse(result);
   if (!parseResult.success) {
     const seen = new Set<string>();
@@ -233,9 +163,9 @@ function validateLeafNode(
       // Skip only top-level missing child-element properties (path.length === 1)
       // Nested issues (e.g., data.children[0].label) must still be reported
       if (
-        childProps &&
+        optionalChildProps.size > 0 &&
         issue.path.length === 1 &&
-        childProps.has(String(issue.path[0])) &&
+        optionalChildProps.has(String(issue.path[0])) &&
         issue.code === "invalid_type" &&
         issue.input === undefined
       ) {
@@ -1101,14 +1031,14 @@ function convertElement(
   errors: string[],
 ): Record<string, unknown> | null {
   const tagName = getTagName(node);
-  const nodeType = TAG_TO_TYPE[tagName];
+  const def = getNodeMetadataByTag(tagName);
   const attrs = getAttributes(node);
   const childElements = getChildElements(node);
   const textContent = getTextContent(node);
 
-  if (nodeType) {
+  if (def) {
     return convertPomNode(
-      nodeType,
+      def.type,
       tagName,
       attrs,
       childElements,
@@ -1132,6 +1062,7 @@ function convertPomNode(
   xmlNode?: XmlElement,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { type: nodeType };
+  const def = getNodeMetadata(nodeType as POMNode["type"]);
 
   // Expand dot-notation attributes (e.g., fill.color="hex" → { fill: { color: "hex" } })
   const { regular: regularAttrs, dotGroups } = expandDotNotation(attrs);
@@ -1203,9 +1134,9 @@ function convertPomNode(
   }
 
   // Text content → text property for nodes that support it
-  if (textContent !== undefined && TEXT_CONTENT_NODES.has(nodeType)) {
-    if (!("text" in result)) {
-      result.text = textContent;
+  if (textContent !== undefined && def.textContentProperty) {
+    if (!(def.textContentProperty in result)) {
+      result[def.textContentProperty] = textContent;
     }
   }
 
@@ -1215,7 +1146,10 @@ function convertPomNode(
     childConverter(childElements, result, errors, xmlNode);
   }
   // Children for container nodes
-  else if (CONTAINER_TYPES.has(nodeType) && childElements.length > 0) {
+  else if (
+    def.childPolicy.kind === "pom-children" &&
+    childElements.length > 0
+  ) {
     const convertedChildren = childElements
       .map((child) => convertElement(child, errors))
       .filter((child): child is Record<string, unknown> => child !== null);
@@ -1223,7 +1157,7 @@ function convertPomNode(
   }
   // Leaf nodes that shouldn't have child elements
   else if (
-    !CONTAINER_TYPES.has(nodeType) &&
+    def.childPolicy.kind !== "pom-children" &&
     !childConverter &&
     childElements.length > 0
   ) {
@@ -1233,7 +1167,7 @@ function convertPomNode(
   }
 
   // Zod validation for leaf nodes
-  if (!CONTAINER_TYPES.has(nodeType)) {
+  if (def.childPolicy.kind !== "pom-children") {
     validateLeafNode(nodeType, result, errors);
   }
 

--- a/packages/pom/src/parseXml/serializeXml.ts
+++ b/packages/pom/src/parseXml/serializeXml.ts
@@ -4,9 +4,6 @@ import { getNodeMetadata } from "../registry/nodeMetadata.ts";
 // runs と svgContent は専用の直列化パスで処理する
 const SKIP_KEYS = new Set(["type", "children", "runs", "svgContent"]);
 
-// runs によるインライン装飾を child element として直列化するノードタイプ
-const INLINE_CONTENT_TYPES = new Set(["text", "shape"]);
-
 interface TextRun {
   text: string;
   bold?: boolean;
@@ -123,7 +120,7 @@ function serializeNode(node: POMNode, depth: number): string {
 
   // Text / Shape: runs があればインライン child element として直列化し装飾を保持する
   if (
-    INLINE_CONTENT_TYPES.has(node.type) &&
+    def.supportsInlineRuns &&
     Array.isArray(nodeRecord.runs) &&
     (nodeRecord.runs as unknown[]).length > 0
   ) {

--- a/packages/pom/src/parseXml/serializeXml.ts
+++ b/packages/pom/src/parseXml/serializeXml.ts
@@ -1,17 +1,11 @@
 import type { POMNode } from "../types.ts";
-import { TAG_TO_TYPE } from "./parseXml.ts";
-
-const TYPE_TO_TAG: Record<string, string> = Object.fromEntries(
-  Object.entries(TAG_TO_TYPE).map(([tag, type]) => [type, tag]),
-);
+import { getNodeMetadata } from "../registry/nodeMetadata.ts";
 
 // runs と svgContent は専用の直列化パスで処理する
 const SKIP_KEYS = new Set(["type", "children", "runs", "svgContent"]);
 
 // runs によるインライン装飾を child element として直列化するノードタイプ
 const INLINE_CONTENT_TYPES = new Set(["text", "shape"]);
-
-const CONTAINER_TYPES = new Set(["vstack", "hstack", "layer"]);
 
 interface TextRun {
   text: string;
@@ -105,10 +99,11 @@ function serializeRuns(runs: TextRun[]): string {
 
 function serializeNode(node: POMNode, depth: number): string {
   const indent = "  ".repeat(depth);
-  const tag = TYPE_TO_TAG[node.type];
+  const def = getNodeMetadata(node.type);
+  const tag = def.tagName;
   const nodeRecord = node as Record<string, unknown>;
 
-  if (CONTAINER_TYPES.has(node.type)) {
+  if (def.childPolicy.kind === "pom-children") {
     const children = (nodeRecord.children as POMNode[]) ?? [];
     const attrStr = serializeAttrs(nodeRecord);
     if (children.length === 0) {

--- a/packages/pom/src/registry/definitions/arrow.ts
+++ b/packages/pom/src/registry/definitions/arrow.ts
@@ -1,10 +1,10 @@
 import type { POMNode } from "../../types.ts";
 import type { NodeDefinition } from "../types.ts";
 import { renderArrowNode } from "../../renderPptx/nodes/arrow.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const arrowNodeDef: NodeDefinition = {
-  type: "arrow",
-  category: "leaf",
+  ...getNodeMetadata("arrow"),
   applyYogaStyle(_node, yn) {
     // arrow ノードは ID 参照で位置を決定するため、Yoga レイアウトではサイズ 0 として扱う
     yn.setWidth(0);

--- a/packages/pom/src/registry/definitions/chart.ts
+++ b/packages/pom/src/registry/definitions/chart.ts
@@ -1,9 +1,9 @@
 import type { NodeDefinition } from "../types.ts";
 import { renderChartNode } from "../../renderPptx/nodes/chart.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const chartNodeDef: NodeDefinition = {
-  type: "chart",
-  category: "leaf",
+  ...getNodeMetadata("chart"),
   render(node, ctx) {
     renderChartNode(node as Extract<typeof node, { type: "chart" }>, ctx);
   },

--- a/packages/pom/src/registry/definitions/compositeNodes.ts
+++ b/packages/pom/src/registry/definitions/compositeNodes.ts
@@ -1,4 +1,4 @@
-import type { POMNode } from "../../types.ts";
+import { type POMNode } from "../../types.ts";
 import type { NodeDefinition, Yoga } from "../types.ts";
 import type { Node as YogaNode } from "yoga-layout";
 import {
@@ -15,6 +15,7 @@ import { renderTreeNode } from "../../renderPptx/nodes/tree.ts";
 import { renderFlowNode } from "../../renderPptx/nodes/flow.ts";
 import { renderProcessArrowNode } from "../../renderPptx/nodes/processArrow.ts";
 import { renderPyramidNode } from "../../renderPptx/nodes/pyramid.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 /**
  * コンポジットノードの最小スケール閾値。
@@ -53,8 +54,7 @@ function applyCompositeMeasure(
 }
 
 export const timelineNodeDef: NodeDefinition = {
-  type: "timeline",
-  category: "leaf",
+  ...getNodeMetadata("timeline"),
   applyYogaStyle: applyCompositeMeasure(
     measureTimeline as (node: POMNode) => { width: number; height: number },
   ),
@@ -64,8 +64,7 @@ export const timelineNodeDef: NodeDefinition = {
 };
 
 export const matrixNodeDef: NodeDefinition = {
-  type: "matrix",
-  category: "leaf",
+  ...getNodeMetadata("matrix"),
   applyYogaStyle: applyCompositeMeasure(
     measureMatrix as (node: POMNode) => { width: number; height: number },
   ),
@@ -75,8 +74,7 @@ export const matrixNodeDef: NodeDefinition = {
 };
 
 export const treeNodeDef: NodeDefinition = {
-  type: "tree",
-  category: "leaf",
+  ...getNodeMetadata("tree"),
   applyYogaStyle: applyCompositeMeasure(
     measureTree as (node: POMNode) => { width: number; height: number },
   ),
@@ -86,8 +84,7 @@ export const treeNodeDef: NodeDefinition = {
 };
 
 export const flowNodeDef: NodeDefinition = {
-  type: "flow",
-  category: "leaf",
+  ...getNodeMetadata("flow"),
   applyYogaStyle: applyCompositeMeasure(
     measureFlow as (node: POMNode) => { width: number; height: number },
   ),
@@ -97,8 +94,7 @@ export const flowNodeDef: NodeDefinition = {
 };
 
 export const processArrowNodeDef: NodeDefinition = {
-  type: "processArrow",
-  category: "leaf",
+  ...getNodeMetadata("processArrow"),
   applyYogaStyle: applyCompositeMeasure(
     measureProcessArrow as (node: POMNode) => { width: number; height: number },
   ),
@@ -111,8 +107,7 @@ export const processArrowNodeDef: NodeDefinition = {
 };
 
 export const pyramidNodeDef: NodeDefinition = {
-  type: "pyramid",
-  category: "leaf",
+  ...getNodeMetadata("pyramid"),
   applyYogaStyle: applyCompositeMeasure(
     measurePyramid as (node: POMNode) => { width: number; height: number },
   ),

--- a/packages/pom/src/registry/definitions/icon.ts
+++ b/packages/pom/src/registry/definitions/icon.ts
@@ -1,12 +1,12 @@
-import type { POMNode, PositionedNode } from "../../types.ts";
+import { type POMNode, type PositionedNode } from "../../types.ts";
 import type { NodeDefinition } from "../types.ts";
 import { rasterizeIcon } from "../../icons/index.ts";
 import { renderIconNode } from "../../renderPptx/nodes/icon.ts";
 import { getContentArea } from "../../renderPptx/utils/contentArea.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const iconNodeDef: NodeDefinition = {
-  type: "icon",
-  category: "leaf",
+  ...getNodeMetadata("icon"),
   applyYogaStyle(node, yn) {
     const n = node as Extract<POMNode, { type: "icon" }>;
     const iconSize = n.size ?? 24;

--- a/packages/pom/src/registry/definitions/image.ts
+++ b/packages/pom/src/registry/definitions/image.ts
@@ -4,10 +4,10 @@ import type { Node as YogaNode } from "yoga-layout";
 import { measureImage, getImageData } from "../../shared/measureImage.ts";
 import type { BuildContext } from "../../buildContext.ts";
 import { renderImageNode } from "../../renderPptx/nodes/image.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const imageNodeDef: NodeDefinition = {
-  type: "image",
-  category: "leaf",
+  ...getNodeMetadata("image"),
   applyYogaStyle(node: POMNode, yn: YogaNode, _yoga: Yoga, ctx: BuildContext) {
     const n = node as Extract<POMNode, { type: "image" }>;
     const src = n.src;

--- a/packages/pom/src/registry/definitions/layer.ts
+++ b/packages/pom/src/registry/definitions/layer.ts
@@ -1,10 +1,10 @@
-import type { POMNode, PositionedLayerChild } from "../../types.ts";
+import { type POMNode, type PositionedLayerChild } from "../../types.ts";
 import type { NodeDefinition } from "../types.ts";
 import { toPositioned } from "../../toPositioned/toPositioned.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const layerNodeDef: NodeDefinition = {
-  type: "layer",
-  category: "absolute-child",
+  ...getNodeMetadata("layer"),
   // applyYogaStyle: layer は子を絶対配置するコンテナ。サイズは明示的に指定されることを期待
   async toPositioned(pom, absoluteX, absoluteY, layout, ctx, map) {
     const n = pom as Extract<POMNode, { type: "layer" }>;

--- a/packages/pom/src/registry/definitions/line.ts
+++ b/packages/pom/src/registry/definitions/line.ts
@@ -1,10 +1,10 @@
 import type { POMNode } from "../../types.ts";
 import type { NodeDefinition } from "../types.ts";
 import { renderLineNode } from "../../renderPptx/nodes/line.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const lineNodeDef: NodeDefinition = {
-  type: "line",
-  category: "leaf",
+  ...getNodeMetadata("line"),
   applyYogaStyle(_node, yn) {
     // line ノードは絶対座標を使用するため、Yoga レイアウトではサイズ 0 として扱う
     yn.setWidth(0);

--- a/packages/pom/src/registry/definitions/list.ts
+++ b/packages/pom/src/registry/definitions/list.ts
@@ -5,6 +5,7 @@ import { measureText } from "../../calcYogaLayout/measureText.ts";
 import { measureFontLineHeightRatio } from "../../calcYogaLayout/fontLoader.ts";
 import type { BuildContext } from "../../buildContext.ts";
 import { renderUlNode, renderOlNode } from "../../renderPptx/nodes/list.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 function applyListYogaStyle(
   node: POMNode,
@@ -60,8 +61,7 @@ function applyListYogaStyle(
 }
 
 export const ulNodeDef: NodeDefinition = {
-  type: "ul",
-  category: "leaf",
+  ...getNodeMetadata("ul"),
   applyYogaStyle: applyListYogaStyle,
   render(node, ctx) {
     renderUlNode(node as Extract<typeof node, { type: "ul" }>, ctx);
@@ -69,8 +69,7 @@ export const ulNodeDef: NodeDefinition = {
 };
 
 export const olNodeDef: NodeDefinition = {
-  type: "ol",
-  category: "leaf",
+  ...getNodeMetadata("ol"),
   applyYogaStyle: applyListYogaStyle,
   render(node, ctx) {
     renderOlNode(node as Extract<typeof node, { type: "ol" }>, ctx);

--- a/packages/pom/src/registry/definitions/shape.ts
+++ b/packages/pom/src/registry/definitions/shape.ts
@@ -4,10 +4,10 @@ import type { Node as YogaNode } from "yoga-layout";
 import { measureText } from "../../calcYogaLayout/measureText.ts";
 import type { BuildContext } from "../../buildContext.ts";
 import { renderShapeNode } from "../../renderPptx/nodes/shape.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const shapeNodeDef: NodeDefinition = {
-  type: "shape",
-  category: "leaf",
+  ...getNodeMetadata("shape"),
   applyYogaStyle(node: POMNode, yn: YogaNode, yoga: Yoga, ctx: BuildContext) {
     const n = node as Extract<POMNode, { type: "shape" }>;
     if (n.text) {

--- a/packages/pom/src/registry/definitions/stack.ts
+++ b/packages/pom/src/registry/definitions/stack.ts
@@ -1,6 +1,7 @@
-import type { POMNode, VStackNode, HStackNode } from "../../types.ts";
+import { type HStackNode, type POMNode, type VStackNode } from "../../types.ts";
 import type { NodeDefinition, Yoga } from "../types.ts";
 import type { Node as YogaNode } from "yoga-layout";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 /**
  * vstack/hstack 共通の Flex プロパティを適用する
@@ -71,8 +72,7 @@ function applyFlexProperties(
 }
 
 export const vstackNodeDef: NodeDefinition = {
-  type: "vstack",
-  category: "multi-child",
+  ...getNodeMetadata("vstack"),
   applyYogaStyle(node: POMNode, yn: YogaNode, yoga: Yoga) {
     yn.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN);
     applyFlexProperties(node as VStackNode, yn, yoga);
@@ -81,8 +81,7 @@ export const vstackNodeDef: NodeDefinition = {
 };
 
 export const hstackNodeDef: NodeDefinition = {
-  type: "hstack",
-  category: "multi-child",
+  ...getNodeMetadata("hstack"),
   applyYogaStyle(node: POMNode, yn: YogaNode, yoga: Yoga) {
     yn.setFlexDirection(yoga.FLEX_DIRECTION_ROW);
     applyFlexProperties(node as HStackNode, yn, yoga);

--- a/packages/pom/src/registry/definitions/svg.ts
+++ b/packages/pom/src/registry/definitions/svg.ts
@@ -2,10 +2,10 @@ import type { POMNode } from "../../types.ts";
 import type { NodeDefinition } from "../types.ts";
 import { rasterizeSvgContent } from "../../icons/index.ts";
 import { renderSvgNode } from "../../renderPptx/nodes/svg.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const svgNodeDef: NodeDefinition = {
-  type: "svg",
-  category: "leaf",
+  ...getNodeMetadata("svg"),
   applyYogaStyle(node, yn) {
     const n = node as Extract<POMNode, { type: "svg" }>;
     const width = n.w ?? 24;

--- a/packages/pom/src/registry/definitions/table.ts
+++ b/packages/pom/src/registry/definitions/table.ts
@@ -2,10 +2,10 @@ import type { POMNode } from "../../types.ts";
 import type { NodeDefinition } from "../types.ts";
 import { calcTableIntrinsicSize } from "../../shared/tableUtils.ts";
 import { renderTableNode } from "../../renderPptx/nodes/table.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const tableNodeDef: NodeDefinition = {
-  type: "table",
-  category: "leaf",
+  ...getNodeMetadata("table"),
   applyYogaStyle(node, yn) {
     const n = node as Extract<POMNode, { type: "table" }>;
     yn.setMeasureFunc(() => {

--- a/packages/pom/src/registry/definitions/text.ts
+++ b/packages/pom/src/registry/definitions/text.ts
@@ -4,10 +4,10 @@ import type { Node as YogaNode } from "yoga-layout";
 import { measureText } from "../../calcYogaLayout/measureText.ts";
 import type { BuildContext } from "../../buildContext.ts";
 import { renderTextNode } from "../../renderPptx/nodes/text.ts";
+import { getNodeMetadata } from "../nodeMetadata.ts";
 
 export const textNodeDef: NodeDefinition = {
-  type: "text",
-  category: "leaf",
+  ...getNodeMetadata("text"),
   applyYogaStyle(node: POMNode, yn: YogaNode, yoga: Yoga, ctx: BuildContext) {
     const n = node as Extract<POMNode, { type: "text" }>;
     const text = n.text;

--- a/packages/pom/src/registry/index.ts
+++ b/packages/pom/src/registry/index.ts
@@ -42,4 +42,9 @@ registerNode(hstackNodeDef);
 registerNode(layerNodeDef);
 registerNode(svgNodeDef);
 
-export { getNodeDef } from "./nodeRegistry.ts";
+export {
+  getAllNodeDefs,
+  getNodeDef,
+  getNodeDefByTag,
+  getTagName,
+} from "./nodeRegistry.ts";

--- a/packages/pom/src/registry/nodeMetadata.ts
+++ b/packages/pom/src/registry/nodeMetadata.ts
@@ -32,6 +32,7 @@ export type NodeMetadata = Pick<
   | "defaults"
   | "childPolicy"
   | "textContentProperty"
+  | "supportsInlineRuns"
 >;
 
 const none: ChildPolicy = { kind: "none" };
@@ -42,7 +43,10 @@ function leaf(
   tagName: string,
   schema: NodeDefinition["schema"],
   options: Partial<
-    Pick<NodeMetadata, "defaults" | "childPolicy" | "textContentProperty">
+    Pick<
+      NodeMetadata,
+      "defaults" | "childPolicy" | "textContentProperty" | "supportsInlineRuns"
+    >
   > = {},
 ): NodeMetadata {
   return {
@@ -79,6 +83,7 @@ export const NODE_METADATA = [
     },
     childPolicy: { kind: "custom" },
     textContentProperty: "text",
+    supportsInlineRuns: true,
   }),
   leaf("ul", "Ul", ulNodeSchema, {
     defaults: {
@@ -112,6 +117,7 @@ export const NODE_METADATA = [
       lineHeight: 1.3,
     },
     textContentProperty: "text",
+    supportsInlineRuns: true,
   }),
   leaf("chart", "Chart", chartNodeSchema, {
     childPolicy: { kind: "custom", optionalProperties: ["data"] },

--- a/packages/pom/src/registry/nodeMetadata.ts
+++ b/packages/pom/src/registry/nodeMetadata.ts
@@ -1,0 +1,181 @@
+import {
+  arrowNodeSchema,
+  chartNodeSchema,
+  flowNodeSchema,
+  hStackNodeSchema,
+  iconNodeSchema,
+  imageNodeSchema,
+  layerNodeSchema,
+  lineNodeSchema,
+  matrixNodeSchema,
+  olNodeSchema,
+  processArrowNodeSchema,
+  pyramidNodeSchema,
+  shapeNodeSchema,
+  svgNodeSchema,
+  tableNodeSchema,
+  textNodeSchema,
+  timelineNodeSchema,
+  treeNodeSchema,
+  ulNodeSchema,
+  vStackNodeSchema,
+  type POMNode,
+} from "../types.ts";
+import type { ChildPolicy, NodeCategory, NodeDefinition } from "./types.ts";
+
+export type NodeMetadata = Pick<
+  NodeDefinition,
+  | "type"
+  | "tagName"
+  | "category"
+  | "schema"
+  | "defaults"
+  | "childPolicy"
+  | "textContentProperty"
+>;
+
+const none: ChildPolicy = { kind: "none" };
+const pomChildren: ChildPolicy = { kind: "pom-children" };
+
+function leaf(
+  type: POMNode["type"],
+  tagName: string,
+  schema: NodeDefinition["schema"],
+  options: Partial<
+    Pick<NodeMetadata, "defaults" | "childPolicy" | "textContentProperty">
+  > = {},
+): NodeMetadata {
+  return {
+    type,
+    tagName,
+    category: "leaf",
+    schema,
+    childPolicy: none,
+    ...options,
+  };
+}
+
+function container(
+  type: POMNode["type"],
+  tagName: string,
+  category: Extract<NodeCategory, "multi-child" | "absolute-child">,
+  schema: NodeDefinition["schema"],
+): NodeMetadata {
+  return {
+    type,
+    tagName,
+    category,
+    schema,
+    childPolicy: pomChildren,
+  };
+}
+
+export const NODE_METADATA = [
+  leaf("text", "Text", textNodeSchema, {
+    defaults: {
+      fontSize: 24,
+      fontFamily: "Noto Sans JP",
+      lineHeight: 1.3,
+    },
+    childPolicy: { kind: "custom" },
+    textContentProperty: "text",
+  }),
+  leaf("ul", "Ul", ulNodeSchema, {
+    defaults: {
+      fontSize: 24,
+      fontFamily: "Noto Sans JP",
+      lineHeight: 1.3,
+    },
+    childPolicy: { kind: "custom", optionalProperties: ["items"] },
+  }),
+  leaf("ol", "Ol", olNodeSchema, {
+    defaults: {
+      fontSize: 24,
+      fontFamily: "Noto Sans JP",
+      lineHeight: 1.3,
+    },
+    childPolicy: { kind: "custom", optionalProperties: ["items"] },
+  }),
+  leaf("image", "Image", imageNodeSchema),
+  leaf("table", "Table", tableNodeSchema, {
+    childPolicy: {
+      kind: "custom",
+      optionalProperties: ["columns", "rows"],
+    },
+  }),
+  container("vstack", "VStack", "multi-child", vStackNodeSchema),
+  container("hstack", "HStack", "multi-child", hStackNodeSchema),
+  leaf("shape", "Shape", shapeNodeSchema, {
+    defaults: {
+      fontSize: 24,
+      fontFamily: "Noto Sans JP",
+      lineHeight: 1.3,
+    },
+    textContentProperty: "text",
+  }),
+  leaf("chart", "Chart", chartNodeSchema, {
+    childPolicy: { kind: "custom", optionalProperties: ["data"] },
+  }),
+  leaf("timeline", "Timeline", timelineNodeSchema, {
+    childPolicy: { kind: "custom", optionalProperties: ["items"] },
+  }),
+  leaf("matrix", "Matrix", matrixNodeSchema, {
+    childPolicy: {
+      kind: "custom",
+      optionalProperties: ["axes", "items", "quadrants"],
+    },
+  }),
+  leaf("tree", "Tree", treeNodeSchema, {
+    childPolicy: { kind: "custom", optionalProperties: ["data"] },
+  }),
+  leaf("flow", "Flow", flowNodeSchema, {
+    childPolicy: {
+      kind: "custom",
+      optionalProperties: ["nodes", "connections"],
+    },
+  }),
+  leaf("processArrow", "ProcessArrow", processArrowNodeSchema, {
+    childPolicy: { kind: "custom", optionalProperties: ["steps"] },
+  }),
+  leaf("pyramid", "Pyramid", pyramidNodeSchema, {
+    childPolicy: { kind: "custom", optionalProperties: ["levels"] },
+  }),
+  leaf("line", "Line", lineNodeSchema),
+  leaf("arrow", "Arrow", arrowNodeSchema),
+  container("layer", "Layer", "absolute-child", layerNodeSchema),
+  leaf("icon", "Icon", iconNodeSchema, {
+    defaults: {
+      size: 24,
+      color: "#000000",
+    },
+  }),
+  leaf("svg", "Svg", svgNodeSchema, {
+    defaults: {
+      w: 24,
+      h: 24,
+    },
+    childPolicy: {
+      kind: "custom",
+      optionalProperties: ["svgContent"],
+    },
+  }),
+] as const satisfies readonly NodeMetadata[];
+
+const metadataByType = new Map<POMNode["type"], NodeMetadata>(
+  NODE_METADATA.map((metadata) => [metadata.type, metadata]),
+);
+const metadataByTag = new Map<string, NodeMetadata>(
+  NODE_METADATA.map((metadata) => [metadata.tagName, metadata]),
+);
+
+export function getNodeMetadata(type: POMNode["type"]): NodeMetadata {
+  const metadata = metadataByType.get(type);
+  if (!metadata) throw new Error(`Unknown node type: ${type}`);
+  return metadata;
+}
+
+export function getNodeMetadataByTag(
+  tagName: string,
+): NodeMetadata | undefined {
+  return metadataByTag.get(tagName);
+}

--- a/packages/pom/src/registry/nodeRegistry.test.ts
+++ b/packages/pom/src/registry/nodeRegistry.test.ts
@@ -89,8 +89,8 @@ describe("NodeRegistry", () => {
       const def = getNodeDef(type);
       expect(def.tagName).toMatch(/^[A-Z]/);
       expect(def.schema).toBeDefined();
-      expect(def.childPolicy.kind).toMatch(
-        /^(none|multi-child|pom-children|custom)$/,
+      expect(["none", "pom-children", "custom"]).toContain(
+        def.childPolicy.kind,
       );
     }
   });
@@ -106,6 +106,7 @@ describe("NodeRegistry", () => {
         defaults: def.defaults,
         childPolicy: def.childPolicy,
         textContentProperty: def.textContentProperty,
+        supportsInlineRuns: def.supportsInlineRuns,
       }).toEqual(metadata);
     }
   });

--- a/packages/pom/src/registry/nodeRegistry.test.ts
+++ b/packages/pom/src/registry/nodeRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { POMNode } from "../types.ts";
 import { getNodeDef } from "./index.ts";
+import { NODE_METADATA } from "./nodeMetadata.ts";
 
 /**
  * POMNode の全 type リテラル一覧。
@@ -26,6 +27,7 @@ const ALL_NODE_TYPES: POMNode["type"][] = [
   "arrow",
   "layer",
   "icon",
+  "svg",
 ];
 
 describe("NodeRegistry", () => {
@@ -75,9 +77,36 @@ describe("NodeRegistry", () => {
       "line",
       "arrow",
       "icon",
+      "svg",
     ];
     for (const type of leafTypes) {
       expect(getNodeDef(type).category).toBe("leaf");
+    }
+  });
+
+  it("全ノード定義から XML metadata と schema を参照できること", () => {
+    for (const type of ALL_NODE_TYPES) {
+      const def = getNodeDef(type);
+      expect(def.tagName).toMatch(/^[A-Z]/);
+      expect(def.schema).toBeDefined();
+      expect(def.childPolicy.kind).toMatch(
+        /^(none|multi-child|pom-children|custom)$/,
+      );
+    }
+  });
+
+  it("NodeDefinition metadata は nodeMetadata を単一ソースとして持つこと", () => {
+    for (const metadata of NODE_METADATA) {
+      const def = getNodeDef(metadata.type);
+      expect({
+        type: def.type,
+        tagName: def.tagName,
+        category: def.category,
+        schema: def.schema,
+        defaults: def.defaults,
+        childPolicy: def.childPolicy,
+        textContentProperty: def.textContentProperty,
+      }).toEqual(metadata);
     }
   });
 });

--- a/packages/pom/src/registry/nodeRegistry.ts
+++ b/packages/pom/src/registry/nodeRegistry.ts
@@ -4,16 +4,34 @@ import type { NodeDefinition } from "./types.ts";
 type NodeType = POMNode["type"];
 
 const registry = new Map<NodeType, NodeDefinition>();
+const tagToType = new Map<string, NodeType>();
 
 export function registerNode(def: NodeDefinition): void {
   if (registry.has(def.type)) {
     throw new Error(`Duplicate node registration: ${def.type}`);
   }
+  if (tagToType.has(def.tagName)) {
+    throw new Error(`Duplicate node tag registration: ${def.tagName}`);
+  }
   registry.set(def.type, def);
+  tagToType.set(def.tagName, def.type);
 }
 
 export function getNodeDef(type: NodeType): NodeDefinition {
   const def = registry.get(type);
   if (!def) throw new Error(`Unknown node type: ${type}`);
   return def;
+}
+
+export function getNodeDefByTag(tagName: string): NodeDefinition | undefined {
+  const type = tagToType.get(tagName);
+  return type ? getNodeDef(type) : undefined;
+}
+
+export function getTagName(type: NodeType): string {
+  return getNodeDef(type).tagName;
+}
+
+export function getAllNodeDefs(): NodeDefinition[] {
+  return [...registry.values()];
 }

--- a/packages/pom/src/registry/types.ts
+++ b/packages/pom/src/registry/types.ts
@@ -4,6 +4,7 @@ import type { RenderContext } from "../renderPptx/types.ts";
 import type { loadYoga } from "yoga-layout/load";
 import type { BuildContext } from "../buildContext.ts";
 import type { LayoutResultMap } from "../calcYogaLayout/types.ts";
+import type { z } from "zod";
 
 export type Yoga = Awaited<ReturnType<typeof loadYoga>>;
 
@@ -13,12 +14,32 @@ export type NodeCategory =
   | "multi-child" // 子要素複数（vstack, hstack）
   | "absolute-child"; // 子要素複数・絶対配置（layer）
 
+export type ChildPolicy =
+  | { kind: "none" }
+  | { kind: "pom-children" }
+  | { kind: "custom"; optionalProperties?: readonly string[] };
+
 export interface NodeDefinition {
   /** ノードタイプ名 */
   type: POMNode["type"];
 
+  /** XML タグ名 */
+  tagName: string;
+
   /** ノードカテゴリ */
   category: NodeCategory;
+
+  /** 属性/構造の検証 schema */
+  schema: z.ZodTypeAny;
+
+  /** 実行時に補完される既定値のメモ。schema の optional とは別に参照用 metadata として保持する */
+  defaults?: Readonly<Record<string, unknown>>;
+
+  /** XML child element の受け入れルール */
+  childPolicy: ChildPolicy;
+
+  /** テキスト content を流し込む属性名 */
+  textContentProperty?: string;
 
   /** YogaNode にノード固有のスタイル/measureFunc を適用する */
   applyYogaStyle?: (

--- a/packages/pom/src/registry/types.ts
+++ b/packages/pom/src/registry/types.ts
@@ -41,6 +41,9 @@ export interface NodeDefinition {
   /** テキスト content を流し込む属性名 */
   textContentProperty?: string;
 
+  /** runs をインライン child element として直列化できる */
+  supportsInlineRuns?: boolean;
+
   /** YogaNode にノード固有のスタイル/measureFunc を適用する */
   applyYogaStyle?: (
     node: POMNode,

--- a/packages/pom/src/types.ts
+++ b/packages/pom/src/types.ts
@@ -859,7 +859,7 @@ export type POMNode =
   | SvgNode;
 
 // Define schemas using passthrough to maintain type safety
-const vStackNodeSchemaBase = basePOMNodeSchema.extend({
+export const vStackNodeSchema = basePOMNodeSchema.extend({
   type: z.literal("vstack"),
   children: z.array(z.lazy(() => pomNodeSchema)),
   gap: z.number().optional(),
@@ -868,7 +868,7 @@ const vStackNodeSchemaBase = basePOMNodeSchema.extend({
   flexWrap: flexWrapSchema.optional(),
 });
 
-const hStackNodeSchemaBase = basePOMNodeSchema.extend({
+export const hStackNodeSchema = basePOMNodeSchema.extend({
   type: z.literal("hstack"),
   children: z.array(z.lazy(() => pomNodeSchema)),
   gap: z.number().optional(),
@@ -886,7 +886,7 @@ const layerChildSchemaBase = z.lazy(() =>
   ),
 );
 
-const layerNodeSchemaBase = basePOMNodeSchema.extend({
+export const layerNodeSchema = basePOMNodeSchema.extend({
   type: z.literal("layer"),
   children: z.array(layerChildSchemaBase),
 });
@@ -898,8 +898,8 @@ const pomNodeSchema: z.ZodType<POMNode> = z.lazy(() =>
     olNodeSchema,
     imageNodeSchema,
     tableNodeSchema,
-    vStackNodeSchemaBase,
-    hStackNodeSchemaBase,
+    vStackNodeSchema,
+    hStackNodeSchema,
     shapeNodeSchema,
     chartNodeSchema,
     timelineNodeSchema,
@@ -910,7 +910,7 @@ const pomNodeSchema: z.ZodType<POMNode> = z.lazy(() =>
     pyramidNodeSchema,
     lineNodeSchema,
     arrowNodeSchema,
-    layerNodeSchemaBase,
+    layerNodeSchema,
     iconNodeSchema,
     svgNodeSchema,
   ]),
@@ -983,10 +983,10 @@ const positionedNodeSchema: z.ZodType<PositionedNode> = z.lazy(() =>
       imageData: z.string().optional(),
     }),
     tableNodeSchema.merge(positionedBaseSchema),
-    vStackNodeSchemaBase.merge(positionedBaseSchema).extend({
+    vStackNodeSchema.merge(positionedBaseSchema).extend({
       children: z.array(z.lazy(() => positionedNodeSchema)),
     }),
-    hStackNodeSchemaBase.merge(positionedBaseSchema).extend({
+    hStackNodeSchema.merge(positionedBaseSchema).extend({
       children: z.array(z.lazy(() => positionedNodeSchema)),
     }),
     shapeNodeSchema.merge(positionedBaseSchema),
@@ -999,7 +999,7 @@ const positionedNodeSchema: z.ZodType<PositionedNode> = z.lazy(() =>
     pyramidNodeSchema.merge(positionedBaseSchema),
     lineNodeSchema.merge(positionedBaseSchema),
     arrowNodeSchema.merge(positionedBaseSchema),
-    layerNodeSchemaBase.merge(positionedBaseSchema).extend({
+    layerNodeSchema.merge(positionedBaseSchema).extend({
       children: z.array(positionedLayerChildSchema),
     }),
     iconNodeSchema.merge(positionedBaseSchema).extend({


### PR DESCRIPTION
close #808

## 概要
- ノードごとの tag/schema/default/children/text/runs metadata を nodeMetadata に集約
- 各 NodeDefinition が nodeMetadata を spread して同じ metadata を保持するように変更
- parseXml / serializeXml の tag・schema・children・inline runs 判定を metadata 由来に変更

## 影響範囲
- packages/pom/src/registry
- packages/pom/src/parseXml
- packages/pom/src/types.ts

## 検証
- pnpm --filter @hirokisakabe/pom run typecheck
- pnpm --filter @hirokisakabe/pom run lint
- pnpm --filter @hirokisakabe/pom run test:run
- pnpm --filter @hirokisakabe/pom run build

## 補足
- public entrypoint の export は変更していません
- cross-review の info 指摘 2 件は追加 commit で対応済みです