### PR TITLE
refactor: 見た目属性の resolver/helper を renderPptx 内部で共通化

### DIFF
--- a/packages/pom/src/renderPptx/nodes/image.ts
+++ b/packages/pom/src/renderPptx/nodes/image.ts
@@ -2,6 +2,7 @@ import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToIn } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
+import { convertShadow } from "../utils/visualStyle.ts";
 
 type ImagePositionedNode = Extract<PositionedNode, { type: "image" }>;
 
@@ -15,16 +16,7 @@ export function renderImageNode(
     y: pxToIn(content.y),
     w: pxToIn(content.w),
     h: pxToIn(content.h),
-    shadow: node.shadow
-      ? {
-          type: node.shadow.type ?? ("outer" as const),
-          opacity: node.shadow.opacity,
-          blur: node.shadow.blur,
-          angle: node.shadow.angle,
-          offset: node.shadow.offset,
-          color: node.shadow.color,
-        }
-      : undefined,
+    shadow: convertShadow(node.shadow),
   };
 
   if (node.sizing) {

--- a/packages/pom/src/renderPptx/nodes/shape.ts
+++ b/packages/pom/src/renderPptx/nodes/shape.ts
@@ -3,6 +3,7 @@ import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { convertUnderline, convertStrike } from "../textOptions.ts";
 import { getContentArea } from "../utils/contentArea.ts";
+import { convertBorderLine, convertShadow } from "../utils/visualStyle.ts";
 
 type ShapePositionedNode = Extract<PositionedNode, { type: "shape" }>;
 
@@ -22,24 +23,8 @@ export function renderShapeNode(
           transparency: node.fill.transparency,
         }
       : undefined,
-    line: node.line
-      ? {
-          color: node.line.color,
-          width:
-            node.line.width !== undefined ? pxToPt(node.line.width) : undefined,
-          dashType: node.line.dashType,
-        }
-      : undefined,
-    shadow: node.shadow
-      ? {
-          type: node.shadow.type ?? ("outer" as const),
-          opacity: node.shadow.opacity,
-          blur: node.shadow.blur,
-          angle: node.shadow.angle,
-          offset: node.shadow.offset,
-          color: node.shadow.color,
-        }
-      : undefined,
+    line: node.line ? convertBorderLine(node.line) : undefined,
+    shadow: convertShadow(node.shadow),
   };
 
   if (node.text) {

--- a/packages/pom/src/renderPptx/renderPptx.ts
+++ b/packages/pom/src/renderPptx/renderPptx.ts
@@ -30,6 +30,11 @@ import { pxToIn, pxToPt } from "./units.ts";
 import { convertUnderline, convertStrike } from "./textOptions.ts";
 import { getImageData } from "../shared/measureImage.ts";
 import { renderBackgroundAndBorder } from "./utils/backgroundBorder.ts";
+import {
+  convertBorderLine,
+  hasVisibleBorder,
+  resolveRectRadius,
+} from "./utils/visualStyle.ts";
 import { registerBackgroundGradient } from "./gradientFills.ts";
 import { getNodeDef } from "../registry/index.ts";
 
@@ -312,25 +317,12 @@ export async function renderPptx(
         ) {
           // border のみ描画（backgroundColor/backgroundImage はスキップ）
           const { border, borderRadius } = node;
-          const hasBorder = Boolean(
-            border &&
-            (border.color !== undefined ||
-              border.width !== undefined ||
-              border.dashType !== undefined),
-          );
-          if (hasBorder) {
-            const line = {
-              color: border?.color ?? "000000",
-              width:
-                border?.width !== undefined ? pxToPt(border.width) : undefined,
-              dashType: border?.dashType,
-            };
+          if (hasVisibleBorder(border)) {
+            const line = convertBorderLine(border, "000000");
             const shapeType = borderRadius
               ? ctx.pptx.ShapeType.roundRect
               : ctx.pptx.ShapeType.rect;
-            const rectRadius = borderRadius
-              ? Math.min((borderRadius / Math.min(node.w, node.h)) * 2, 1)
-              : undefined;
+            const rectRadius = resolveRectRadius(borderRadius, node.w, node.h);
             ctx.slide.addShape(shapeType, {
               x: pxToIn(node.x),
               y: pxToIn(node.y),

--- a/packages/pom/src/renderPptx/utils/backgroundBorder.ts
+++ b/packages/pom/src/renderPptx/utils/backgroundBorder.ts
@@ -1,19 +1,15 @@
-import type { PositionedNode, ShadowStyle } from "../../types.ts";
+import type { PositionedNode } from "../../types.ts";
 import { getImageData } from "../../shared/measureImage.ts";
 import { registerBackgroundGradient } from "../gradientFills.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn, pxToPt } from "../units.ts";
-
-function convertShadow(shadow: ShadowStyle) {
-  return {
-    type: shadow.type ?? ("outer" as const),
-    opacity: shadow.opacity,
-    blur: shadow.blur,
-    angle: shadow.angle,
-    offset: shadow.offset,
-    color: shadow.color,
-  };
-}
+import { pxToIn } from "../units.ts";
+import {
+  convertShadow,
+  convertBorderLine,
+  hasVisibleBorder,
+  resolveBackgroundFill,
+  resolveRectRadius,
+} from "./visualStyle.ts";
 
 /**
  * ノードの背景色・背景画像・ボーダー・影を描画する
@@ -47,12 +43,7 @@ export function renderBackgroundAndBorder(
 
   const hasBackground = Boolean(backgroundColor) || Boolean(gradientMarker);
   const hasBackgroundImage = Boolean(backgroundImage);
-  const hasBorder = Boolean(
-    border &&
-    (border.color !== undefined ||
-      border.width !== undefined ||
-      border.dashType !== undefined),
-  );
+  const hasBorder = hasVisibleBorder(border);
   const hasShadow = Boolean(shadow);
 
   if (!hasBackground && !hasBackgroundImage && !hasBorder && !hasShadow) {
@@ -64,29 +55,16 @@ export function renderBackgroundAndBorder(
     ? ctx.pptx.ShapeType.roundRect
     : ctx.pptx.ShapeType.rect;
 
-  // px を 0-1 の正規化値に変換
-  const rectRadius = borderRadius
-    ? Math.min((borderRadius / Math.min(node.w, node.h)) * 2, 1)
-    : undefined;
+  const rectRadius = resolveRectRadius(borderRadius, node.w, node.h);
 
   // backgroundImage がない場合は従来通り1回の addShape で処理
   if (!hasBackgroundImage) {
     const fill = hasBackground
-      ? gradientMarker
-        ? { color: gradientMarker }
-        : {
-            color: backgroundColor,
-            transparency:
-              node.opacity !== undefined ? (1 - node.opacity) * 100 : undefined,
-          }
+      ? resolveBackgroundFill(backgroundColor, node.opacity, gradientMarker)
       : { type: "none" as const };
 
     const line = hasBorder
-      ? {
-          color: border?.color ?? "000000",
-          width: border?.width !== undefined ? pxToPt(border.width) : undefined,
-          dashType: border?.dashType,
-        }
+      ? convertBorderLine(border, "000000")
       : { type: "none" as const };
 
     ctx.slide.addShape(shapeType, {
@@ -97,7 +75,7 @@ export function renderBackgroundAndBorder(
       fill,
       line,
       rectRadius,
-      shadow: shadow ? convertShadow(shadow) : undefined,
+      shadow: convertShadow(shadow),
     });
     return;
   }
@@ -111,13 +89,11 @@ export function renderBackgroundAndBorder(
       y: pxToIn(node.y),
       w: pxToIn(node.w),
       h: pxToIn(node.h),
-      fill: gradientMarker
-        ? { color: gradientMarker }
-        : {
-            color: backgroundColor,
-            transparency:
-              node.opacity !== undefined ? (1 - node.opacity) * 100 : undefined,
-          },
+      fill: resolveBackgroundFill(
+        backgroundColor,
+        node.opacity,
+        gradientMarker,
+      ),
       line: { type: "none" as const },
       rectRadius,
     });
@@ -158,15 +134,10 @@ export function renderBackgroundAndBorder(
       h: pxToIn(node.h),
       fill: { type: "none" as const },
       line: hasBorder
-        ? {
-            color: border?.color ?? "000000",
-            width:
-              border?.width !== undefined ? pxToPt(border.width) : undefined,
-            dashType: border?.dashType,
-          }
+        ? convertBorderLine(border, "000000")
         : { type: "none" as const },
       rectRadius,
-      shadow: shadow ? convertShadow(shadow) : undefined,
+      shadow: convertShadow(shadow),
     });
   }
 }

--- a/packages/pom/src/renderPptx/utils/visualStyle.test.ts
+++ b/packages/pom/src/renderPptx/utils/visualStyle.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertShadow,
+  hasVisibleBorder,
+  convertBorderLine,
+  opacityToTransparency,
+  resolveBackgroundFill,
+  resolveRectRadius,
+} from "./visualStyle.ts";
+
+describe("convertShadow", () => {
+  it("undefined はそのまま undefined を返す", () => {
+    expect(convertShadow(undefined)).toBeUndefined();
+  });
+
+  it("type 未指定時は outer をデフォルトとする", () => {
+    expect(convertShadow({})).toEqual({
+      type: "outer",
+      opacity: undefined,
+      blur: undefined,
+      angle: undefined,
+      offset: undefined,
+      color: undefined,
+    });
+  });
+
+  it("指定された属性をそのまま引き継ぐ", () => {
+    expect(
+      convertShadow({
+        type: "inner",
+        opacity: 0.5,
+        blur: 4,
+        angle: 90,
+        offset: 2,
+        color: "333333",
+      }),
+    ).toEqual({
+      type: "inner",
+      opacity: 0.5,
+      blur: 4,
+      angle: 90,
+      offset: 2,
+      color: "333333",
+    });
+  });
+});
+
+describe("hasVisibleBorder", () => {
+  it("undefined / 空オブジェクトは false", () => {
+    expect(hasVisibleBorder(undefined)).toBe(false);
+    expect(hasVisibleBorder({})).toBe(false);
+  });
+
+  it("color / width / dashType のいずれかがあれば true", () => {
+    expect(hasVisibleBorder({ color: "FF0000" })).toBe(true);
+    expect(hasVisibleBorder({ width: 2 })).toBe(true);
+    expect(hasVisibleBorder({ dashType: "dash" })).toBe(true);
+  });
+});
+
+describe("convertBorderLine", () => {
+  it("width を px から pt に変換する", () => {
+    expect(convertBorderLine({ color: "FF0000", width: 4, dashType: "dash" }))
+      .toEqual({ color: "FF0000", width: 3, dashType: "dash" });
+  });
+
+  it("color 未指定時は fallbackColor を使う", () => {
+    expect(convertBorderLine({ width: 2 }, "000000")).toEqual({
+      color: "000000",
+      width: 1.5,
+      dashType: undefined,
+    });
+  });
+
+  it("fallbackColor 省略時は color を undefined のままにする", () => {
+    expect(convertBorderLine({ width: 2 })).toEqual({
+      color: undefined,
+      width: 1.5,
+      dashType: undefined,
+    });
+  });
+});
+
+describe("opacityToTransparency", () => {
+  it("undefined はそのまま undefined を返す", () => {
+    expect(opacityToTransparency(undefined)).toBeUndefined();
+  });
+
+  it("0-1 の opacity を 0-100 の transparency に反転変換する", () => {
+    expect(opacityToTransparency(1)).toBe(0);
+    expect(opacityToTransparency(0.3)).toBeCloseTo(70);
+    expect(opacityToTransparency(0)).toBe(100);
+  });
+});
+
+describe("resolveBackgroundFill", () => {
+  it("gradientMarker があればマーカー色の単色塗りを返す (transparency なし)", () => {
+    expect(resolveBackgroundFill("FF0000", 0.5, "0F7A3D")).toEqual({
+      color: "0F7A3D",
+    });
+  });
+
+  it("backgroundColor と opacity から fill を解決する", () => {
+    expect(resolveBackgroundFill("FF0000", 0.5, undefined)).toEqual({
+      color: "FF0000",
+      transparency: 50,
+    });
+  });
+
+  it("opacity 未指定時は transparency を付与しない", () => {
+    expect(resolveBackgroundFill("FF0000", undefined, undefined)).toEqual({
+      color: "FF0000",
+      transparency: undefined,
+    });
+  });
+});
+
+describe("resolveRectRadius", () => {
+  it("borderRadius 未指定時は undefined を返す", () => {
+    expect(resolveRectRadius(undefined, 100, 50)).toBeUndefined();
+  });
+
+  it("短辺に対する比率の 2 倍を返す", () => {
+    expect(resolveRectRadius(10, 100, 50)).toBeCloseTo(0.4);
+  });
+
+  it("1 を超える場合は 1 にクランプする", () => {
+    expect(resolveRectRadius(100, 100, 50)).toBe(1);
+  });
+});

--- a/packages/pom/src/renderPptx/utils/visualStyle.test.ts
+++ b/packages/pom/src/renderPptx/utils/visualStyle.test.ts
@@ -60,8 +60,9 @@ describe("hasVisibleBorder", () => {
 
 describe("convertBorderLine", () => {
   it("width を px から pt に変換する", () => {
-    expect(convertBorderLine({ color: "FF0000", width: 4, dashType: "dash" }))
-      .toEqual({ color: "FF0000", width: 3, dashType: "dash" });
+    expect(
+      convertBorderLine({ color: "FF0000", width: 4, dashType: "dash" }),
+    ).toEqual({ color: "FF0000", width: 3, dashType: "dash" });
   });
 
   it("color 未指定時は fallbackColor を使う", () => {

--- a/packages/pom/src/renderPptx/utils/visualStyle.ts
+++ b/packages/pom/src/renderPptx/utils/visualStyle.ts
@@ -1,0 +1,127 @@
+/**
+ * 見た目属性 (fill / border / shadow / opacity / borderRadius) を
+ * pptxgenjs のオプションへ変換する共通 resolver 群。
+ *
+ * ノードごとに変換ロジックが重複・乖離すると、XML 上は同じ指定でも
+ * 描画結果が異なるリスクがあるため、属性値 → pptxgenjs オプションの
+ * 純粋変換をここに集約する。
+ *
+ * 共通化対象の属性カテゴリ:
+ * - fill (背景色 + opacity): resolveBackgroundFill / opacityToTransparency
+ * - border / line (枠線): hasVisibleBorder / convertBorderLine
+ * - shadow (影): convertShadow
+ * - borderRadius (角丸): resolveRectRadius
+ *
+ * 既存 helper との責務境界:
+ * - gradientFills.ts: backgroundGradient のマーカー登録と出力時の gradFill 置換。
+ *   グラデーションはマーカー色 1 色の単色塗りに帰着するため本モジュールでは
+ *   解釈せず、マーカー色を resolveBackgroundFill で単色 fill として扱う。
+ * - utils/backgroundBorder.ts: 背景色 → 背景画像 → ボーダーの描画順序の
+ *   オーケストレーション。個々の属性値の変換は本モジュールに委譲する。
+ * - textOptions.ts: テキスト系属性 (font / underline / strike など) の変換。
+ */
+import type { BorderStyle, ShadowStyle } from "../../types.ts";
+import { pxToPt } from "../units.ts";
+
+/**
+ * ShadowStyle を pptxgenjs の shadow オプションに変換する
+ * type 未指定時は outer をデフォルトとする
+ */
+export function convertShadow(shadow: ShadowStyle | undefined):
+  | {
+      type: "outer" | "inner";
+      opacity?: number;
+      blur?: number;
+      angle?: number;
+      offset?: number;
+      color?: string;
+    }
+  | undefined {
+  if (!shadow) return undefined;
+  return {
+    type: shadow.type ?? "outer",
+    opacity: shadow.opacity,
+    blur: shadow.blur,
+    angle: shadow.angle,
+    offset: shadow.offset,
+    color: shadow.color,
+  };
+}
+
+/**
+ * border が描画対象となる指定 (color / width / dashType のいずれか) を
+ * 持つかを判定する
+ */
+export function hasVisibleBorder(
+  border: BorderStyle | undefined,
+): border is BorderStyle {
+  return Boolean(
+    border &&
+    (border.color !== undefined ||
+      border.width !== undefined ||
+      border.dashType !== undefined),
+  );
+}
+
+/**
+ * BorderStyle を pptxgenjs の line オプションに変換する
+ * width はユーザー入力 px、pptxgenjs の line.width は pt
+ *
+ * @param fallbackColor color 未指定時に使う色。省略時は color を
+ *   undefined のまま渡し pptxgenjs のデフォルトに任せる
+ */
+export function convertBorderLine(
+  border: BorderStyle,
+  fallbackColor?: string,
+): { color?: string; width?: number; dashType?: BorderStyle["dashType"] } {
+  return {
+    color: border.color ?? fallbackColor,
+    width: border.width !== undefined ? pxToPt(border.width) : undefined,
+    dashType: border.dashType,
+  };
+}
+
+/**
+ * ノードの opacity (0-1、1 = 不透明) を pptxgenjs の
+ * transparency (0-100、100 = 透明) に変換する
+ */
+export function opacityToTransparency(
+  opacity: number | undefined,
+): number | undefined {
+  return opacity !== undefined ? (1 - opacity) * 100 : undefined;
+}
+
+/**
+ * backgroundColor / opacity / グラデーションマーカー色から
+ * pptxgenjs の fill オプションを解決する
+ *
+ * gradientMarker がある場合はマーカー色の単色塗りとして描画し、
+ * 出力時の後処理で gradFill に置換される (gradientFills.ts 参照)。
+ * opacity はマーカー側ではなく gradFill のカラーストップの alpha で
+ * 表現するため、マーカー fill には transparency を付与しない。
+ */
+export function resolveBackgroundFill(
+  backgroundColor: string | undefined,
+  opacity: number | undefined,
+  gradientMarker: string | undefined,
+): { color?: string; transparency?: number } {
+  if (gradientMarker) return { color: gradientMarker };
+  return {
+    color: backgroundColor,
+    transparency: opacityToTransparency(opacity),
+  };
+}
+
+/**
+ * borderRadius (px) をノードサイズに対する 0-1 の正規化値
+ * (pptxgenjs roundRect の rectRadius) に変換する
+ */
+export function resolveRectRadius(
+  borderRadius: number | undefined,
+  w: number,
+  h: number,
+): number | undefined {
+  return borderRadius
+    ? Math.min((borderRadius / Math.min(w, h)) * 2, 1)
+    : undefined;
+}

--- a/packages/pom/src/types.ts
+++ b/packages/pom/src/types.ts
@@ -295,6 +295,7 @@ const shapeTypeSchema = z.enum([
 
 // ===== TypeScript Types (defined early for recursive references) =====
 export type ShadowStyle = z.infer<typeof shadowStyleSchema>;
+export type BorderStyle = z.infer<typeof borderStyleSchema>;
 export type AlignItems = z.infer<typeof alignItemsSchema>;
 export type FlexWrap = z.infer<typeof flexWrapSchema>;
 export type JustifyContent = z.infer<typeof justifyContentSchema>;


### PR DESCRIPTION
close #811

## 目的

fill / border / shadow / opacity / borderRadius などの見た目属性の pptxgenjs オプション変換が、ノードごとにばらばらに実装されており、XML 上は同じ指定でも描画結果がズレるリスクがあった。これらの純粋変換を共通 resolver モジュール `renderPptx/utils/visualStyle.ts` に集約する。

## 変更内容

- `packages/pom/src/renderPptx/utils/visualStyle.ts` を新設し、以下の resolver を導入
  - `convertShadow` — ShadowStyle → pptxgenjs shadow(`type ?? "outer"` の既定値を一元化)
  - `hasVisibleBorder` / `convertBorderLine` — border 判定と pptxgenjs line への変換(px → pt)
  - `opacityToTransparency` / `resolveBackgroundFill` — opacity(0-1) → transparency(0-100)変換と背景 fill 解決
  - `resolveRectRadius` — borderRadius → roundRect の正規化値
- 重複していた呼び出し側 4 ファイルを resolver 利用に移行(挙動変更なし)
  - `utils/backgroundBorder.ts`(shadow / border / fill / rectRadius が内部で各 2 回重複)
  - `renderPptx.ts`(root ノードの border のみ描画パス)
  - `nodes/shape.ts`(line / shadow)
  - `nodes/image.ts`(shadow)
- 既存 helper との責務境界をモジュールヘッダに明記
  - `gradientFills.ts`: gradient のマーカー登録と出力後処理(マーカー色は単色 fill として本 resolver が扱う)
  - `utils/backgroundBorder.ts`: 描画順序のオーケストレーション(変換は本 resolver に委譲)
  - `textOptions.ts`: テキスト系属性の変換
- `types.ts` に `BorderStyle` 型エクスポートを追加(内部利用のみ、public API 変更なし)

## 影響パッケージ

- `packages/pom` のみ(`src/renderPptx/` 配下 + `src/types.ts` の型エクスポート追加)

## ローカル検証手順

```bash
cd packages/pom
pnpm run typecheck
pnpm run lint
pnpm run test:run   # 395 passed (visualStyle.test.ts の単体テスト 16 件を含む)
pnpm run knip
pnpm run build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
