### PR TITLE
feat(pom-cli): pom render サブコマンドを追加して PNG/SVG を直接出力する

### DIFF
--- a/.changeset/pom-render-subcommand.md
+++ b/.changeset/pom-render-subcommand.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+feat: `pom render <file> -o <dir>` サブコマンドを追加しました。pptx-glimpse を使って各スライドを LibreOffice なしで直接 PNG / SVG 画像として出力できます。`--format svg` で SVG 出力、`--slides 2,5` で対象スライドの指定が可能です。

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -114,7 +114,7 @@ pom render slides.pom.xml -o ./images --verbose
 
 ## Fonts
 
-This package bundles Carlito and Noto Sans CJK JP fonts for SVG rendering. These fonts are used when converting slides to SVG in the preview server. System fonts are not scanned.
+This package bundles Carlito and Noto Sans CJK JP fonts for image rendering. These fonts are used when converting slides to SVG in the preview server and to PNG / SVG in `pom render`. System fonts are not scanned.
 
 ## License
 

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -1,6 +1,6 @@
 # @hirokisakabe/pom-cli
 
-CLI tool for [pom](https://github.com/hirokisakabe/pom) — preview and build presentations from pom XML / Markdown.
+CLI tool for [pom](https://github.com/hirokisakabe/pom) — preview, build, and render presentations from pom XML / Markdown.
 
 ## Installation
 
@@ -81,6 +81,35 @@ To print per-step timing on stderr:
 
 ```bash
 pom build slides.pom.xml -o output.pptx --verbose
+```
+
+### Render
+
+Renders each slide to a PNG (default) or SVG image — no LibreOffice or other external tools required.
+
+```bash
+pom render slides.pom.xml -o ./images
+pom render slides.pom.md -o ./images
+```
+
+The images are written to the output directory as `slide-01.png`, `slide-02.png`, ... The directory is created if it does not exist. The rendering pipeline is the same as the preview server, so the images match what you see in `pom preview`.
+
+To output SVG instead of PNG:
+
+```bash
+pom render slides.pom.xml -o ./images --format svg
+```
+
+To render only specific slides (1-based, comma-separated) — useful when re-checking just the slides you edited:
+
+```bash
+pom render slides.pom.xml -o ./images --slides 2,5
+```
+
+To print per-step timing on stderr:
+
+```bash
+pom render slides.pom.xml -o ./images --verbose
 ```
 
 ## Fonts

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hirokisakabe/pom-cli",
   "version": "0.4.0",
-  "description": "CLI tool for pom — preview and build presentations",
+  "description": "CLI tool for pom — preview, build, and render presentations",
   "type": "module",
   "bin": {
     "pom": "./dist/cli.js"

--- a/packages/pom-cli/src/build.ts
+++ b/packages/pom-cli/src/build.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { buildPptx, DiagnosticsError } from "@hirokisakabe/pom";
-import { parseMd } from "@hirokisakabe/pom-md";
+import { loadInput } from "./input.ts";
 import { watchInputFile } from "./watch.ts";
 
 function makeLog(verbose: boolean) {
@@ -26,40 +26,10 @@ export async function runBuild(
   }
 
   log(`Reading file: ${absInput}`);
-  const content = fs.readFileSync(absInput, "utf-8");
-  const ext = path.extname(absInput);
-
-  let xml: string;
-  let slideWidth = 1280;
-  let slideHeight = 720;
-  let masterPptxData: Uint8Array | undefined;
-
-  if (ext === ".md") {
-    const t = Date.now();
-    const result = parseMd(content);
-    xml = result.xml;
-    slideWidth = result.meta.size.w;
-    slideHeight = result.meta.size.h;
-    log(`Parsing Markdown... done (${Date.now() - t}ms)`);
-
-    if (result.meta.masterPptx) {
-      const masterPath = path.resolve(
-        path.dirname(absInput),
-        result.meta.masterPptx,
-      );
-      try {
-        masterPptxData = new Uint8Array(fs.readFileSync(masterPath));
-      } catch (e: unknown) {
-        if (e instanceof Error && "code" in e && e.code === "ENOENT") {
-          console.warn(`Warning: masterPptx not found: ${masterPath}`);
-        } else {
-          throw e;
-        }
-      }
-    }
-  } else {
-    xml = content;
-  }
+  const { xml, slideWidth, slideHeight, masterPptxData } = loadInput(
+    absInput,
+    log,
+  );
 
   const t1 = Date.now();
   const { pptx } = await buildPptx(

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -4,11 +4,26 @@ import { Command } from "commander";
 import { DiagnosticsError } from "@hirokisakabe/pom";
 import { runBuild, runBuildWatch } from "./build.ts";
 import { runPreview } from "./preview.ts";
+import { runRender, type RenderFormat } from "./render.ts";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
 
 const program = new Command();
+
+function printBuildError(err: unknown): void {
+  if (err instanceof DiagnosticsError) {
+    const count = err.diagnostics.length;
+    console.error(
+      `✗ Build failed (${count} ${count === 1 ? "error" : "errors"})\n`,
+    );
+    for (const d of err.diagnostics) {
+      console.error(`  [${d.code}] ${d.message}`);
+    }
+  } else {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+}
 
 program
   .name("pom")
@@ -69,21 +84,63 @@ program
       } else {
         runBuild(input, options.o, { verbose: options.verbose }).catch(
           (err: unknown) => {
-            if (err instanceof DiagnosticsError) {
-              const count = err.diagnostics.length;
-              console.error(
-                `✗ Build failed (${count} ${count === 1 ? "error" : "errors"})\n`,
-              );
-              for (const d of err.diagnostics) {
-                console.error(`  [${d.code}] ${d.message}`);
-              }
-            } else {
-              console.error(err instanceof Error ? err.message : String(err));
-            }
+            printBuildError(err);
             process.exit(1);
           },
         );
       }
+    },
+  );
+
+program
+  .command("render")
+  .description("Render each slide to a PNG or SVG image")
+  .argument("<input>", "Input file (.pom.xml or .pom.md)")
+  .requiredOption("-o <dir>", "Output directory for rendered images")
+  .option("--format <format>", "Output format: png or svg", "png")
+  .option(
+    "--slides <numbers>",
+    "Comma-separated slide numbers to render (e.g. 2,5)",
+  )
+  .option("--verbose", "Show build step timing on stderr")
+  .action(
+    (
+      input: string,
+      options: {
+        o: string;
+        format: string;
+        slides?: string;
+        verbose?: boolean;
+      },
+    ) => {
+      if (options.format !== "png" && options.format !== "svg") {
+        console.error(
+          `Invalid format: ${options.format} (expected "png" or "svg")`,
+        );
+        process.exit(1);
+      }
+      const format: RenderFormat = options.format;
+      let slides: number[] | undefined;
+      if (options.slides !== undefined) {
+        slides = options.slides.split(",").map((s) => Number(s.trim()));
+        if (
+          slides.length === 0 ||
+          slides.some((n) => !Number.isInteger(n) || n <= 0)
+        ) {
+          console.error(
+            `Invalid slides: ${options.slides} (expected comma-separated slide numbers, e.g. 2,5)`,
+          );
+          process.exit(1);
+        }
+      }
+      runRender(input, options.o, {
+        format,
+        slides,
+        verbose: options.verbose,
+      }).catch((err: unknown) => {
+        printBuildError(err);
+        process.exit(1);
+      });
     },
   );
 

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -27,7 +27,7 @@ function printBuildError(err: unknown): void {
 
 program
   .name("pom")
-  .description("CLI tool for pom — preview and build presentations")
+  .description("CLI tool for pom — preview, build, and render presentations")
   .version(version);
 
 program

--- a/packages/pom-cli/src/glimpse.ts
+++ b/packages/pom-cli/src/glimpse.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const EXTRA_FONT_MAPPING: Record<string, string> = {
+  "游ゴシック Light": "Noto Sans CJK JP",
+  "Yu Gothic Light": "Noto Sans CJK JP",
+};
+
+export function resolveBundledFontsDir(): string {
+  const fontsDir = path.resolve(__dirname, "../fonts");
+  if (!fs.existsSync(fontsDir)) {
+    throw new Error(
+      `Bundled fonts directory not found: ${fontsDir}. The package may be corrupted.`,
+    );
+  }
+  return fontsDir;
+}

--- a/packages/pom-cli/src/input.ts
+++ b/packages/pom-cli/src/input.ts
@@ -1,0 +1,52 @@
+import fs from "fs";
+import path from "path";
+import { parseMd } from "@hirokisakabe/pom-md";
+
+export interface LoadedInput {
+  xml: string;
+  slideWidth: number;
+  slideHeight: number;
+  masterPptxData?: Uint8Array;
+}
+
+export function loadInput(
+  absInput: string,
+  log: (msg: string) => void = () => {},
+): LoadedInput {
+  const content = fs.readFileSync(absInput, "utf-8");
+  const ext = path.extname(absInput);
+
+  let xml: string;
+  let slideWidth = 1280;
+  let slideHeight = 720;
+  let masterPptxData: Uint8Array | undefined;
+
+  if (ext === ".md") {
+    const t = Date.now();
+    const result = parseMd(content);
+    xml = result.xml;
+    slideWidth = result.meta.size.w;
+    slideHeight = result.meta.size.h;
+    log(`Parsing Markdown... done (${Date.now() - t}ms)`);
+
+    if (result.meta.masterPptx) {
+      const masterPath = path.resolve(
+        path.dirname(absInput),
+        result.meta.masterPptx,
+      );
+      try {
+        masterPptxData = new Uint8Array(fs.readFileSync(masterPath));
+      } catch (e: unknown) {
+        if (e instanceof Error && "code" in e && e.code === "ENOENT") {
+          console.warn(`Warning: masterPptx not found: ${masterPath}`);
+        } else {
+          throw e;
+        }
+      }
+    }
+  } else {
+    xml = content;
+  }
+
+  return { xml, slideWidth, slideHeight, masterPptxData };
+}

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -1,14 +1,13 @@
 import { spawn } from "child_process";
 import fs from "fs";
 import http from "http";
-import { fileURLToPath } from "url";
 import path from "path";
 import { buildPptx } from "@hirokisakabe/pom";
-import { parseMd } from "@hirokisakabe/pom-md";
 import { convertPptxToSvg } from "pptx-glimpse";
+import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
+import { loadInput } from "./input.ts";
 import { watchInputFile } from "./watch.ts";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_PORT = 3000;
 
 function makeLog(verbose: boolean) {
@@ -37,11 +36,6 @@ function openBrowser(url: string): void {
   child.unref();
 }
 
-const EXTRA_FONT_MAPPING: Record<string, string> = {
-  "游ゴシック Light": "Noto Sans CJK JP",
-  "Yu Gothic Light": "Noto Sans CJK JP",
-};
-
 type SvgResult =
   | { type: "success"; svgs: string[]; slideWidth: number }
   | { type: "error"; message: string }
@@ -52,42 +46,10 @@ async function generateSvgs(
   verbose = false,
 ): Promise<SvgResult> {
   const log = makeLog(verbose);
-  const content = fs.readFileSync(inputFile, "utf-8");
-  const ext = path.extname(inputFile);
-
-  let xml: string;
-  let slideWidth = 1280;
-  let slideHeight = 720;
-  let masterPptxData: Uint8Array | undefined;
-
-  if (ext === ".md") {
-    const t = Date.now();
-    const result = parseMd(content);
-    xml = result.xml;
-    slideWidth = result.meta.size.w;
-    slideHeight = result.meta.size.h;
-    log(`Parsing Markdown... done (${Date.now() - t}ms)`);
-
-    if (result.meta.masterPptx) {
-      const masterPath = path.resolve(
-        path.dirname(inputFile),
-        result.meta.masterPptx,
-      );
-      try {
-        masterPptxData = new Uint8Array(fs.readFileSync(masterPath));
-      } catch (e: unknown) {
-        if (e instanceof Error && "code" in e && e.code === "ENOENT") {
-          process.stderr.write(
-            `Warning: masterPptx not found: ${masterPath}\n`,
-          );
-        } else {
-          throw e;
-        }
-      }
-    }
-  } else {
-    xml = content;
-  }
+  const { xml, slideWidth, slideHeight, masterPptxData } = loadInput(
+    inputFile,
+    log,
+  );
 
   if (!xml.trim()) {
     return { type: "empty" };
@@ -109,13 +71,7 @@ async function generateSvgs(
     throw new Error("Unexpected output type from pptx.write");
   }
 
-  const fontsDir = path.resolve(__dirname, "../fonts");
-  if (!fs.existsSync(fontsDir)) {
-    throw new Error(
-      `Bundled fonts directory not found: ${fontsDir}. The package may be corrupted.`,
-    );
-  }
-  const fontDirs = [fontsDir];
+  const fontDirs = [resolveBundledFontsDir()];
 
   const t2 = Date.now();
   const slides = await convertPptxToSvg(buffer, {

--- a/packages/pom-cli/src/render.ts
+++ b/packages/pom-cli/src/render.ts
@@ -90,10 +90,14 @@ export async function runRender(
   }
 
   fs.mkdirSync(absOutputDir, { recursive: true });
+  const padWidth = Math.max(
+    2,
+    ...outputs.map((o) => String(o.slideNumber).length),
+  );
   for (const { slideNumber, data } of outputs) {
     const file = path.join(
       absOutputDir,
-      `slide-${String(slideNumber).padStart(2, "0")}.${format}`,
+      `slide-${String(slideNumber).padStart(padWidth, "0")}.${format}`,
     );
     fs.writeFileSync(file, data);
     console.log(`Saved: ${file}`);

--- a/packages/pom-cli/src/render.ts
+++ b/packages/pom-cli/src/render.ts
@@ -1,0 +1,103 @@
+import fs from "fs";
+import path from "path";
+import { buildPptx } from "@hirokisakabe/pom";
+import { convertPptxToPng, convertPptxToSvg } from "pptx-glimpse";
+import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
+import { loadInput } from "./input.ts";
+
+export type RenderFormat = "png" | "svg";
+
+function makeLog(verbose: boolean) {
+  if (!verbose) return (_msg: string) => {};
+  return (msg: string) => process.stderr.write(`[pom] ${msg}\n`);
+}
+
+export async function runRender(
+  inputFile: string,
+  outputDir: string,
+  options: {
+    format?: RenderFormat;
+    slides?: number[];
+    verbose?: boolean;
+  } = {},
+): Promise<void> {
+  const verbose = options.verbose ?? false;
+  const format = options.format ?? "png";
+  const log = makeLog(verbose);
+  const totalStart = Date.now();
+
+  const absInput = path.resolve(inputFile);
+  const absOutputDir = path.resolve(outputDir);
+
+  if (!fs.existsSync(absInput)) {
+    throw new Error(`Input file not found: ${absInput}`);
+  }
+
+  log(`Reading file: ${absInput}`);
+  const { xml, slideWidth, slideHeight, masterPptxData } = loadInput(
+    absInput,
+    log,
+  );
+
+  const t1 = Date.now();
+  const { pptx } = await buildPptx(
+    xml,
+    { w: slideWidth, h: slideHeight },
+    {
+      textMeasurement: "fallback",
+      ...(masterPptxData ? { masterPptx: masterPptxData } : {}),
+      strict: true,
+    },
+  );
+  log(`Building PPTX... done (${Date.now() - t1}ms)`);
+
+  const buffer = await pptx.write({ outputType: "uint8array" });
+  if (!(buffer instanceof Uint8Array)) {
+    throw new Error("Unexpected output type from pptx.write");
+  }
+
+  const convertOptions = {
+    width: slideWidth,
+    fontDirs: [resolveBundledFontsDir()],
+    fontMapping: EXTRA_FONT_MAPPING,
+    skipSystemFonts: true,
+    ...(options.slides ? { slides: options.slides } : {}),
+  };
+
+  const t2 = Date.now();
+  let outputs: { slideNumber: number; data: string | Buffer }[];
+  if (format === "svg") {
+    const slides = await convertPptxToSvg(buffer, convertOptions);
+    outputs = slides.map((s) => ({ slideNumber: s.slideNumber, data: s.svg }));
+  } else {
+    const slides = await convertPptxToPng(buffer, convertOptions);
+    outputs = slides.map((s) => ({ slideNumber: s.slideNumber, data: s.png }));
+  }
+  log(`Rendering ${format.toUpperCase()}... done (${Date.now() - t2}ms)`);
+
+  if (options.slides) {
+    const rendered = new Set(outputs.map((o) => o.slideNumber));
+    const missing = options.slides.filter((n) => !rendered.has(n));
+    if (missing.length > 0) {
+      console.warn(
+        `Warning: slide ${missing.join(", ")} not found in the presentation`,
+      );
+    }
+  }
+
+  if (outputs.length === 0) {
+    throw new Error("No slides were rendered");
+  }
+
+  fs.mkdirSync(absOutputDir, { recursive: true });
+  for (const { slideNumber, data } of outputs) {
+    const file = path.join(
+      absOutputDir,
+      `slide-${String(slideNumber).padStart(2, "0")}.${format}`,
+    );
+    fs.writeFileSync(file, data);
+    console.log(`Saved: ${file}`);
+  }
+
+  log(`Total: ${Date.now() - totalStart}ms`);
+}

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -4,7 +4,7 @@ description: Generate pom presentation slides from natural language. Applies des
 license: MIT
 allowed-tools: Write,Edit,Read,Bash
 metadata:
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 自然言語の指示から pom XML スライドを生成し、ファイルに保存する。デザイン原則（配色・タイポグラフィ・余白・アーキタイプ）に基づいて初版の質を高め、`/pom-theme` skill が生成したテーマファイル（`pom-theme.json`）があればブランド配色・フォントを適用する。レンダリング結果を自分で見て修正するセルフレビューを行ったうえで、pom-cli がインストール済みの場合はプレビューサーバーを起動する。
@@ -736,17 +736,21 @@ When the same property is specified via both attributes (JSON string) and child 
 
 #### レンダリング手段の確認
 
-`pom`（pom-cli）に加えて LibreOffice（`soffice`）が必要。PNG 化には `pdftoppm`（poppler）か ImageMagick があれば高速だが、どちらも無くても `soffice` 単体で可能。`pom` または `soffice` が無い場合はこのステップをスキップし、完了報告で「レンダリング確認は未実施」と伝える。
+`pom`（pom-cli）があれば `pom render` で各スライドを直接 PNG 化できる（LibreOffice 等の外部ツールは不要）。`pom` が無い場合はこのステップをスキップし、完了報告で「レンダリング確認は未実施」と伝える。
 
 #### ループ手順
 
+1. **レンダリング**: `pom render <保存したファイル名> -o /tmp/pom-review` で全スライドの PNG（`slide-01.png` 形式）を出力する。2 周目以降は `--slides 2,5` のように修正したスライドだけを再レンダリングしてよい
+2. **批評**: 各 PNG を `Read` ツールで読み、下のチェックリストで全スライドを評価する
+3. **修正**: 問題があれば XML を修正して 1 に戻る
+
+#### fallback: soffice チェーン（render 未対応の古い pom-cli 用）
+
+`pom render` がエラーになる場合（render サブコマンド導入前の pom-cli）のみ、以下で代替する。LibreOffice（`soffice`）と、`pdftoppm`（poppler）または ImageMagick が必要。どちらも無い場合はセルフレビューをスキップし、完了報告でその旨を伝える。
+
 1. **ビルド**: `pom build <保存したファイル名> -o /tmp/pom-review/slides.pptx`
-2. **PNG 化**（使える経路を上から選ぶ）:
-   - `pdftoppm` がある場合: `soffice --headless --convert-to pdf --outdir /tmp/pom-review /tmp/pom-review/slides.pptx && pdftoppm -png -r 96 /tmp/pom-review/slides.pdf /tmp/pom-review/slide`
-   - ImageMagick がある場合: 上記の `pdftoppm` の代わりに `magick -density 96 /tmp/pom-review/slides.pdf /tmp/pom-review/slide-%02d.png`
-   - どちらも無い場合: `soffice` の PNG 直接変換は先頭スライドしか出力しないため、`<Slide>` ごとに一時 XML へ分割して個別に `pom build` し、それぞれを `soffice --headless --convert-to 'png:impress_png_Export:{"PixelWidth":{"type":"long","value":1280},"PixelHeight":{"type":"long","value":720}}' --outdir /tmp/pom-review <pptx>` で変換する
-3. **批評**: 各 PNG を `Read` ツールで読み、下のチェックリストで全スライドを評価する
-4. **修正**: 問題があれば XML を修正して 1 に戻る
+2. **PDF 化**: `soffice --headless --convert-to pdf --outdir /tmp/pom-review /tmp/pom-review/slides.pptx`
+3. **PNG 化**: `pdftoppm -png -r 96 /tmp/pom-review/slides.pdf /tmp/pom-review/slide`（ImageMagick の場合は `magick -density 96 /tmp/pom-review/slides.pdf /tmp/pom-review/slide-%02d.png`）
 
 #### 批評チェックリスト
 


### PR DESCRIPTION
close #816

## 目的

pom-cli に `pom render <file> -o <dir>` サブコマンドを追加し、pptx-glimpse を使って各スライドの画像（PNG / SVG）を LibreOffice なしで直接出力できるようにする。pom-slide skill のセルフレビューループのレンダリング経路を soffice → PDF → pdftoppm の外部依存チェーンからこれに置き換える。

## 変更内容

- **`pom render <input> -o <dir>`**: 全スライドを `slide-01.png` 形式で出力。出力先ディレクトリは自動作成
  - `--format svg` で SVG 出力に切り替え（デフォルト: png）
  - `--slides 2,5` で対象スライドのみレンダリング（1 始まり。存在しない番号は警告）
  - `--verbose` でステップ別タイミングを stderr に出力
  - フォント・幅・マッピングは preview と同一設定のため、`pom preview` と見た目が一致する
- **リファクタ**: build.ts / preview.ts に重複していた入力読み込み（md/xml 判定・masterPptx 解決）を `input.ts` に、pptx-glimpse 用フォント設定を `glimpse.ts` に抽出
- **pom-slide SKILL.md**: セルフレビュー手順を `pom render` 第一経路に書き換え。soffice チェーンは render 未対応の古い pom-cli 向け fallback に格下げし、`<Slide>` 分割の個別ビルド手順は削除
- **README / changeset**: Render セクションを追加し、`@hirokisakabe/pom-cli` の minor changeset を追加

## 影響パッケージ

- `packages/pom-cli/`（render.ts / cli.ts 追加・変更、input.ts / glimpse.ts 抽出）
- `skills/pom-slide/`（SKILL.md のセルフレビュー手順）

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom run build
pnpm --filter @hirokisakabe/pom-md run build
pnpm --filter @hirokisakabe/pom-cli run build
node packages/pom-cli/dist/cli.js render slides.pom.xml -o ./images
node packages/pom-cli/dist/cli.js render slides.pom.xml -o ./images --slides 2 --format svg
```

3 スライドのサンプル XML で PNG（1280×720）/ SVG 出力、`--slides` 指定、不正 format / 不正 slides / 範囲外 slides のエラーハンドリングを実行確認済み。typecheck / lint / fmt / knip すべて通過。

## cross-review (codex / gpt-5.4)

critical 0 / warning 3 / info 1。

- 対応済み: ゼロ埋め桁数の動的化（100 枚超デッキ対応）、README Fonts セクションの更新
- 見送り: dist/cli.js の同期漏れ指摘（dist は gitignore 済み・未追跡のため誤検知）、render のユニットテスト追加（pom-cli にはテスト基盤自体がなく、既存の build / preview とも未テスト。テスト基盤導入は別 issue が適当）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
