### PR TITLE
chore(eslint): @typescript-eslint/switch-exhaustiveness-check を error で有効化

### DIFF
--- a/apps/website/eslint.config.mjs
+++ b/apps/website/eslint.config.mjs
@@ -24,6 +24,10 @@ export default defineConfig([
     files: ["**/*.{ts,tsx,mts,cts}"],
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom-cli/eslint.config.mts
+++ b/packages/pom-cli/eslint.config.mts
@@ -25,6 +25,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom-editor/eslint.config.mts
+++ b/packages/pom-editor/eslint.config.mts
@@ -25,6 +25,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom-jsx/eslint.config.mts
+++ b/packages/pom-jsx/eslint.config.mts
@@ -33,6 +33,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom-md/eslint.config.mts
+++ b/packages/pom-md/eslint.config.mts
@@ -32,6 +32,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom-vscode/eslint.config.mts
+++ b/packages/pom-vscode/eslint.config.mts
@@ -36,6 +36,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom/eslint.config.mts
+++ b/packages/pom/eslint.config.mts
@@ -40,6 +40,10 @@ export default defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/packages/pom/src/autoFit/strategies/reduceFontSize.ts
+++ b/packages/pom/src/autoFit/strategies/reduceFontSize.ts
@@ -31,6 +31,8 @@ export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
         }
         break;
       }
+      default:
+        break;
     }
 
     // ul/ol の li 要素の fontSize も縮小

--- a/packages/pom/src/autoFit/strategies/reduceFontSize.ts
+++ b/packages/pom/src/autoFit/strategies/reduceFontSize.ts
@@ -14,25 +14,19 @@ export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
   let changed = false;
 
   walkPOMTree(node, (n) => {
-    switch (n.type) {
-      case "text":
-      case "shape":
-      case "ul":
-      case "ol": {
-        if (n.fontSize !== undefined) {
-          const newSize = Math.max(
-            MIN_FONT_SIZE,
-            Math.round(n.fontSize * ratio),
-          );
-          if (newSize !== n.fontSize) {
-            n.fontSize = newSize;
-            changed = true;
-          }
+    if (
+      n.type === "text" ||
+      n.type === "shape" ||
+      n.type === "ul" ||
+      n.type === "ol"
+    ) {
+      if (n.fontSize !== undefined) {
+        const newSize = Math.max(MIN_FONT_SIZE, Math.round(n.fontSize * ratio));
+        if (newSize !== n.fontSize) {
+          n.fontSize = newSize;
+          changed = true;
         }
-        break;
       }
-      default:
-        break;
     }
 
     // ul/ol の li 要素の fontSize も縮小

--- a/packages/pom/src/calcYogaLayout/calcYogaLayout.ts
+++ b/packages/pom/src/calcYogaLayout/calcYogaLayout.ts
@@ -100,6 +100,8 @@ function collectImageSources(node: POMNode): string[] {
         }
         break;
       }
+      default:
+        break;
     }
   }
 

--- a/packages/pom/src/calcYogaLayout/calcYogaLayout.ts
+++ b/packages/pom/src/calcYogaLayout/calcYogaLayout.ts
@@ -88,20 +88,14 @@ function collectImageSources(node: POMNode): string[] {
     }
 
     // 子要素の再帰
-    switch (def.category) {
-      case "multi-child":
-      case "absolute-child": {
-        const containerNode = n as Extract<
-          POMNode,
-          { type: "vstack" | "hstack" | "layer" }
-        >;
-        for (const child of containerNode.children) {
-          traverse(child);
-        }
-        break;
+    if (def.category === "multi-child" || def.category === "absolute-child") {
+      const containerNode = n as Extract<
+        POMNode,
+        { type: "vstack" | "hstack" | "layer" }
+      >;
+      for (const child of containerNode.children) {
+        traverse(child);
       }
-      default:
-        break;
     }
   }
 

--- a/packages/pom/src/shared/walkTree.ts
+++ b/packages/pom/src/shared/walkTree.ts
@@ -9,15 +9,13 @@ export function walkPOMTree(
 ): void {
   visitor(node);
 
-  switch (node.type) {
-    case "vstack":
-    case "hstack":
-    case "layer":
-      for (const child of node.children) {
-        walkPOMTree(child, visitor);
-      }
-      break;
-    default:
-      break;
+  if (
+    node.type === "vstack" ||
+    node.type === "hstack" ||
+    node.type === "layer"
+  ) {
+    for (const child of node.children) {
+      walkPOMTree(child, visitor);
+    }
   }
 }

--- a/packages/pom/src/shared/walkTree.ts
+++ b/packages/pom/src/shared/walkTree.ts
@@ -17,5 +17,7 @@ export function walkPOMTree(
         walkPOMTree(child, visitor);
       }
       break;
+    default:
+      break;
   }
 }


### PR DESCRIPTION
close #826

## 目的

`POMNode` のような大きな union 型に対する switch 分岐の網羅漏れを lint で機械的に検出する。新ノード種別追加時の 3 段パイプライン（calcYogaLayout → toPositioned → renderPptx）への波及確認の一部を自動化する。

## 変更内容

- 全パッケージ（`packages/pom`, `pom-jsx`, `pom-md`, `pom-cli`, `pom-editor`, `pom-vscode`）と `apps/website` の ESLint config に `@typescript-eslint/switch-exhaustiveness-check` を error で追加
- 既存違反（`packages/pom` の 7 件）を解消
  - 特定ノード種別のみを処理する意図の switch 3 箇所（`shared/walkTree.ts` / `calcYogaLayout/calcYogaLayout.ts` / `autoFit/strategies/reduceFontSize.ts`）は、cross-review の指摘を踏まえ明示的な `if` 条件に書き換え
  - yoga の MeasureMode を fallback 付きで分岐する 3 箇所と `parseMasterPptx.ts` の拡張子分岐は、意図的な `default` として下記の設定方針で許容

## 設定方針

`considerDefaultExhaustiveForUnions: true` を採用する。

- **`default` 節を持つ switch**: 意図的な部分処理 / fallback とみなし許容する
- **`default` 節を持たない switch**: union の全メンバーの列挙を強制する（網羅漏れが lint error になる）

これにより、パイプライン各段の `POMNode` 分岐のような「網羅が前提の switch」は default を持たないため引き続き保護され、新ノード種別追加時の分岐漏れが lint で検出される。意図的に subset のみ扱う分岐は `if` 条件または `default` 節で表現する。

なお ESLint 共有 config 統合（#825）は未完了のため、各パッケージの config へ個別に追加している。#825 実施時にはこのルールも共有 config へ集約される想定。

## 影響パッケージ

- `packages/pom`（src 3 ファイルの分岐書き換え。動作変更なし）
- `packages/pom-jsx` / `pom-md` / `pom-cli` / `pom-editor` / `pom-vscode` / `apps/website`（ESLint config のみ）

## ローカル検証手順

```bash
pnpm install
pnpm -r run build
pnpm -r run lint       # 全パッケージ pass
pnpm -r run typecheck  # 全パッケージ pass
pnpm --filter @hirokisakabe/pom run test:run  # 412 passed | 2 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
