### PR TITLE
pom-cli にユニットテストを追加し CI で実行する

### DIFF
--- a/.github/workflows/ci-pom-cli.yml
+++ b/.github/workflows/ci-pom-cli.yml
@@ -51,4 +51,5 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run knip
       - run: pnpm run typecheck
+      - run: pnpm run test:run
       - run: pnpm run build

--- a/packages/pom-cli/eslint.config.mts
+++ b/packages/pom-cli/eslint.config.mts
@@ -5,7 +5,13 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   {
-    ignores: ["dist/**", "node_modules/**", "eslint.config.mts"],
+    ignores: [
+      "dist/**",
+      "**/*.test.ts",
+      "node_modules/**",
+      "eslint.config.mts",
+      "vitest.config.ts",
+    ],
   },
   {
     files: ["**/*.{ts,mts,cts}"],

--- a/packages/pom-cli/knip.json
+++ b/packages/pom-cli/knip.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "project": ["src/**/*.ts"],
-  "ignoreBinaries": ["eslint", "knip", "prettier", "tsc"],
-  "ignoreDependencies": ["typescript-eslint"],
+  "ignoreBinaries": ["eslint", "knip", "prettier", "tsc", "vitest"],
+  "ignoreDependencies": ["typescript-eslint", "vitest"],
+  "vitest": {
+    "config": ["vitest.config.ts"]
+  },
   "rules": {
     "exports": "warn"
   }

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -36,7 +36,9 @@
     "fmt:check": "prettier --check .",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "knip": "knip"
+    "knip": "knip",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@hirokisakabe/pom": "workspace:*",

--- a/packages/pom-cli/src/build.test.ts
+++ b/packages/pom-cli/src/build.test.ts
@@ -1,0 +1,169 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiagnosticsError } from "@hirokisakabe/pom";
+import { runBuild, runBuildWatch } from "./build.ts";
+import { watchInputFile } from "./watch.ts";
+
+const buildPptxMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@hirokisakabe/pom", () => {
+  class DiagnosticsError extends Error {
+    diagnostics: { code: string; message: string }[];
+    constructor(diagnostics: { code: string; message: string }[]) {
+      super("diagnostics");
+      this.diagnostics = diagnostics;
+    }
+  }
+  return { buildPptx: buildPptxMock, DiagnosticsError };
+});
+
+vi.mock("./watch.ts", () => ({ watchInputFile: vi.fn() }));
+
+const watchInputFileMock = vi.mocked(watchInputFile);
+
+function makePptxResult() {
+  return { pptx: { write: async () => new Uint8Array([80, 75]) } };
+}
+
+describe("build", () => {
+  let tmpDir: string;
+  let inputFile: string;
+  let outputFile: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pom-cli-build-"));
+    inputFile = path.join(tmpDir, "deck.pom.xml");
+    outputFile = path.join(tmpDir, "deck.pptx");
+    fs.writeFileSync(inputFile, "<Slide><Text>hello</Text></Slide>");
+    buildPptxMock.mockReset();
+    buildPptxMock.mockImplementation(async () => makePptxResult());
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe("runBuild", () => {
+    it("PPTX を出力ファイルに書き込み、stdout に保存先を表示する", async () => {
+      await runBuild(inputFile, outputFile);
+
+      expect(Array.from(fs.readFileSync(outputFile))).toEqual([80, 75]);
+      expect(logSpy).toHaveBeenCalledWith(`PPTX saved: ${outputFile}`);
+    });
+
+    // 再発防止: 95b997e — --verbose 時も stdout は "PPTX saved:" の 1 行のみで
+    // 後方互換を維持し、進捗ログは stderr に出す
+    it("verbose 時も stdout は PPTX saved の 1 行のみで、進捗ログは stderr に出す", async () => {
+      await runBuild(inputFile, outputFile, { verbose: true });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(`PPTX saved: ${outputFile}`);
+      const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0]));
+      expect(stderrOutput.length).toBeGreaterThan(0);
+      for (const line of stderrOutput) {
+        expect(line).toMatch(/^\[pom\] /);
+      }
+    });
+
+    it("verbose でなければ stderr に進捗ログを出さない", async () => {
+      await runBuild(inputFile, outputFile);
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it("silent 時は stdout に何も表示しない", async () => {
+      await runBuild(inputFile, outputFile, { silent: true });
+
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it("入力ファイルが存在しない場合はエラーを投げる", async () => {
+      await expect(
+        runBuild(path.join(tmpDir, "missing.pom.xml"), outputFile),
+      ).rejects.toThrow("Input file not found");
+    });
+
+    it("strict オプション付きで buildPptx を呼ぶ", async () => {
+      await runBuild(inputFile, outputFile);
+
+      expect(buildPptxMock).toHaveBeenCalledWith(
+        "<Slide><Text>hello</Text></Slide>",
+        { w: 1280, h: 720 },
+        expect.objectContaining({ strict: true }),
+      );
+    });
+  });
+
+  describe("runBuildWatch", () => {
+    // 再発防止: c13343d — ビルド進行中に変更イベントが連続発火しても
+    // ビルドを並走させず、完了後の 1 回の再ビルドにまとめる
+    it("ビルド進行中の変更イベントは並走させず 1 回の再ビルドにまとめる", async () => {
+      let releaseSecondBuild!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseSecondBuild = resolve;
+      });
+      buildPptxMock
+        .mockImplementationOnce(async () => makePptxResult())
+        .mockImplementationOnce(async () => {
+          await gate;
+          return makePptxResult();
+        })
+        .mockImplementation(async () => makePptxResult());
+
+      let onChange!: () => void;
+      watchInputFileMock.mockImplementation((_absPath, cb) => {
+        onChange = cb;
+        return { close: vi.fn() } as unknown as fs.FSWatcher;
+      });
+
+      await runBuildWatch(inputFile, outputFile);
+      expect(buildPptxMock).toHaveBeenCalledTimes(1);
+
+      // 2 回目のビルドを開始 (gate で進行中のまま停止)
+      onChange();
+      await vi.waitFor(() => expect(buildPptxMock).toHaveBeenCalledTimes(2));
+
+      // 進行中にさらに 2 回発火しても新しいビルドは始まらない
+      onChange();
+      onChange();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(buildPptxMock).toHaveBeenCalledTimes(2);
+
+      // 進行中のビルドが完了すると、まとめられた 1 回だけ再ビルドされる
+      releaseSecondBuild();
+      await vi.waitFor(() => expect(buildPptxMock).toHaveBeenCalledTimes(3));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(buildPptxMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("DiagnosticsError は診断内容を stderr に出して継続する", async () => {
+      buildPptxMock.mockImplementationOnce(async () => {
+        throw new DiagnosticsError([
+          { code: "POM001", message: "invalid node" },
+        ] as never);
+      });
+      watchInputFileMock.mockImplementation(
+        () => ({ close: vi.fn() }) as unknown as fs.FSWatcher,
+      );
+
+      await runBuildWatch(inputFile, outputFile);
+
+      const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0]));
+      expect(stderrOutput).toContainEqual(
+        expect.stringContaining("Build failed (1 error)"),
+      );
+      expect(stderrOutput).toContainEqual(
+        expect.stringContaining("[POM001] invalid node"),
+      );
+    });
+  });
+});

--- a/packages/pom-cli/src/build.test.ts
+++ b/packages/pom-cli/src/build.test.ts
@@ -27,6 +27,14 @@ function makePptxResult() {
   return { pptx: { write: async () => new Uint8Array([80, 75]) } };
 }
 
+// 経過時間ではなくイベントループの消化を待つことで、CI の負荷に依存せず
+// 「保留中の doBuild が始まらないこと」を検証できるようにする
+async function flushEventLoop(rounds = 5) {
+  for (let i = 0; i < rounds; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
 describe("build", () => {
   let tmpDir: string;
   let inputFile: string;
@@ -135,25 +143,27 @@ describe("build", () => {
       // 進行中にさらに 2 回発火しても新しいビルドは始まらない
       onChange();
       onChange();
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushEventLoop();
       expect(buildPptxMock).toHaveBeenCalledTimes(2);
 
       // 進行中のビルドが完了すると、まとめられた 1 回だけ再ビルドされる
       releaseSecondBuild();
       await vi.waitFor(() => expect(buildPptxMock).toHaveBeenCalledTimes(3));
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await flushEventLoop();
       expect(buildPptxMock).toHaveBeenCalledTimes(3);
     });
 
-    it("DiagnosticsError は診断内容を stderr に出して継続する", async () => {
+    it("DiagnosticsError は診断内容を stderr に出し、監視を継続して再ビルドできる", async () => {
       buildPptxMock.mockImplementationOnce(async () => {
         throw new DiagnosticsError([
           { code: "POM001", message: "invalid node" },
         ] as never);
       });
-      watchInputFileMock.mockImplementation(
-        () => ({ close: vi.fn() }) as unknown as fs.FSWatcher,
-      );
+      let onChange!: () => void;
+      watchInputFileMock.mockImplementation((_absPath, cb) => {
+        onChange = cb;
+        return { close: vi.fn() } as unknown as fs.FSWatcher;
+      });
 
       await runBuildWatch(inputFile, outputFile);
 
@@ -164,6 +174,13 @@ describe("build", () => {
       expect(stderrOutput).toContainEqual(
         expect.stringContaining("[POM001] invalid node"),
       );
+
+      // ビルド失敗後も watch は継続し、次の変更イベントで再ビルドされる
+      onChange();
+      await vi.waitFor(() =>
+        expect(Array.from(fs.readFileSync(outputFile))).toEqual([80, 75]),
+      );
+      expect(buildPptxMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/pom-cli/src/input.test.ts
+++ b/packages/pom-cli/src/input.test.ts
@@ -1,0 +1,81 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadInput } from "./input.ts";
+
+describe("loadInput", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pom-cli-input-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("XML ファイルは内容をそのまま返し、デフォルトサイズ 1280x720 になる", () => {
+    const file = path.join(tmpDir, "deck.pom.xml");
+    fs.writeFileSync(file, "<Slide><Text>hello</Text></Slide>");
+
+    const result = loadInput(file);
+
+    expect(result.xml).toBe("<Slide><Text>hello</Text></Slide>");
+    expect(result.slideWidth).toBe(1280);
+    expect(result.slideHeight).toBe(720);
+    expect(result.masterPptxData).toBeUndefined();
+  });
+
+  it(".md ファイルは parseMd で XML に変換され、サイズは frontmatter に従う", () => {
+    const file = path.join(tmpDir, "deck.pom.md");
+    fs.writeFileSync(file, "---\nsize: 4:3\n---\n# タイトル\n");
+
+    const result = loadInput(file);
+
+    expect(result.xml).toContain("<Slide>");
+    expect(result.xml).toContain("タイトル");
+    expect(result.slideWidth).toBe(1024);
+    expect(result.slideHeight).toBe(768);
+  });
+
+  it(".md の masterPptx は入力ファイルからの相対パスで読み込まれる", () => {
+    fs.writeFileSync(path.join(tmpDir, "master.pptx"), Buffer.from([1, 2, 3]));
+    const file = path.join(tmpDir, "deck.pom.md");
+    fs.writeFileSync(file, "---\nmasterPptx: ./master.pptx\n---\n# タイトル\n");
+
+    const result = loadInput(file);
+
+    expect(result.masterPptxData).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result.masterPptxData ?? [])).toEqual([1, 2, 3]);
+  });
+
+  it("masterPptx が存在しない場合は警告を出して masterPptxData なしで続行する", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const file = path.join(tmpDir, "deck.pom.md");
+    fs.writeFileSync(
+      file,
+      "---\nmasterPptx: ./missing.pptx\n---\n# タイトル\n",
+    );
+
+    const result = loadInput(file);
+
+    expect(result.masterPptxData).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("masterPptx not found"),
+    );
+  });
+
+  it(".md の場合は log コールバックに進捗メッセージを渡す", () => {
+    const log = vi.fn();
+    const file = path.join(tmpDir, "deck.pom.md");
+    fs.writeFileSync(file, "# タイトル\n");
+
+    loadInput(file, log);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Parsing Markdown"),
+    );
+  });
+});

--- a/packages/pom-cli/src/render.test.ts
+++ b/packages/pom-cli/src/render.test.ts
@@ -1,0 +1,113 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { convertPptxToPng, convertPptxToSvg } from "pptx-glimpse";
+import { runRender } from "./render.ts";
+
+vi.mock("@hirokisakabe/pom", () => ({
+  buildPptx: vi.fn(async () => ({
+    pptx: { write: async () => new Uint8Array([80, 75]) },
+  })),
+}));
+
+vi.mock("pptx-glimpse", () => ({
+  convertPptxToPng: vi.fn(),
+  convertPptxToSvg: vi.fn(),
+}));
+
+const convertPptxToPngMock = vi.mocked(convertPptxToPng);
+const convertPptxToSvgMock = vi.mocked(convertPptxToSvg);
+
+function makePngSlides(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    slideNumber: i + 1,
+    png: Buffer.from(`png-${i + 1}`),
+  }));
+}
+
+describe("runRender", () => {
+  let tmpDir: string;
+  let inputFile: string;
+  let outputDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pom-cli-render-"));
+    inputFile = path.join(tmpDir, "deck.pom.xml");
+    outputDir = path.join(tmpDir, "out");
+    fs.writeFileSync(inputFile, "<Slide><Text>hello</Text></Slide>");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("各スライドを slide-NN.png として出力ディレクトリに保存する", async () => {
+    convertPptxToPngMock.mockResolvedValue(makePngSlides(3) as never);
+
+    await runRender(inputFile, outputDir);
+
+    expect(fs.readdirSync(outputDir).sort()).toEqual([
+      "slide-01.png",
+      "slide-02.png",
+      "slide-03.png",
+    ]);
+    expect(fs.readFileSync(path.join(outputDir, "slide-02.png"), "utf-8")).toBe(
+      "png-2",
+    );
+  });
+
+  // 再発防止: a0a1d8c — ゼロ埋め桁数を最大スライド番号に合わせて動的化し、
+  // 100 枚超のデッキでもファイル名の辞書順とスライド順が一致するようにする
+  it("100 枚超のデッキではゼロ埋めを 3 桁に広げ、辞書順がスライド順と一致する", async () => {
+    convertPptxToPngMock.mockResolvedValue(makePngSlides(120) as never);
+
+    await runRender(inputFile, outputDir);
+
+    const files = fs.readdirSync(outputDir).sort();
+    expect(files).toHaveLength(120);
+    expect(files[0]).toBe("slide-001.png");
+    expect(files[99]).toBe("slide-100.png");
+    expect(files[119]).toBe("slide-120.png");
+  });
+
+  it("format=svg では convertPptxToSvg を使い .svg として保存する", async () => {
+    convertPptxToSvgMock.mockResolvedValue([
+      { slideNumber: 1, svg: "<svg/>" },
+    ] as never);
+
+    await runRender(inputFile, outputDir, { format: "svg" });
+
+    expect(convertPptxToSvgMock).toHaveBeenCalled();
+    expect(convertPptxToPngMock).not.toHaveBeenCalled();
+    expect(fs.readdirSync(outputDir)).toEqual(["slide-01.svg"]);
+  });
+
+  it("slides 指定に存在しない番号があれば警告する", async () => {
+    convertPptxToPngMock.mockResolvedValue(makePngSlides(1) as never);
+
+    await runRender(inputFile, outputDir, { slides: [1, 5] });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("slide 5 not found"),
+    );
+  });
+
+  it("スライドが 1 枚も出力されなかった場合はエラーを投げる", async () => {
+    convertPptxToPngMock.mockResolvedValue([] as never);
+
+    await expect(runRender(inputFile, outputDir)).rejects.toThrow(
+      "No slides were rendered",
+    );
+  });
+
+  it("入力ファイルが存在しない場合はエラーを投げる", async () => {
+    await expect(
+      runRender(path.join(tmpDir, "missing.pom.xml"), outputDir),
+    ).rejects.toThrow("Input file not found");
+  });
+});

--- a/packages/pom-cli/src/watch.test.ts
+++ b/packages/pom-cli/src/watch.test.ts
@@ -1,0 +1,124 @@
+import fs from "fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { watchInputFile } from "./watch.ts";
+
+type WatchListener = (eventType: string, filename: string | null) => void;
+
+const DEBOUNCE_MS = 100;
+
+describe("watchInputFile", () => {
+  let listener: WatchListener;
+  let mtimeMs: number;
+  let statUnavailable: boolean;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mtimeMs = 1000;
+    statUnavailable = false;
+
+    vi.spyOn(fs, "watch").mockImplementation(((
+      _dir: string,
+      cb: WatchListener,
+    ) => {
+      listener = cb;
+      return { close: vi.fn() } as unknown as fs.FSWatcher;
+    }) as unknown as typeof fs.watch);
+
+    vi.spyOn(fs, "statSync").mockImplementation((() => {
+      if (statUnavailable) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return { mtimeMs } as fs.Stats;
+    }) as unknown as typeof fs.statSync);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("対象ファイルの mtime が変化したらデバウンス後に onChange を 1 回呼ぶ", () => {
+    const onChange = vi.fn();
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    mtimeMs = 2000;
+    listener("change", "deck.pom.xml");
+
+    expect(onChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("同一ディレクトリの別ファイルのイベントでは onChange を呼ばない", () => {
+    const onChange = vi.fn();
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    mtimeMs = 2000;
+    listener("change", "output.pptx");
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // 再発防止: 58a3926 — fs.watch の filename が null になる環境で、
+  // 同一ディレクトリの任意の変更 (build --watch の出力 PPTX 書き込み等) が
+  // 再ビルドを誘発しないよう mtime の実変化を確認する
+  it("filename が null でも対象ファイルの mtime が不変なら onChange を呼ばない", () => {
+    const onChange = vi.fn();
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    listener("change", null);
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("filename が null でも対象ファイルの mtime が変化していれば onChange を呼ぶ", () => {
+    const onChange = vi.fn();
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    mtimeMs = 2000;
+    listener("change", null);
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("デバウンス時間内の連続イベントは 1 回の onChange にまとめる", () => {
+    const onChange = vi.fn();
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    mtimeMs = 2000;
+    listener("change", "deck.pom.xml");
+    vi.advanceTimersByTime(DEBOUNCE_MS / 2);
+    mtimeMs = 3000;
+    listener("change", "deck.pom.xml");
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("イベント時に stat が失敗した場合 (ファイル一時消滅) は onChange を呼ばない", () => {
+    const onChange = vi.fn();
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    statUnavailable = true;
+    listener("rename", "deck.pom.xml");
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("監視開始時にファイルが無くても、作成イベントで onChange を呼ぶ", () => {
+    const onChange = vi.fn();
+    statUnavailable = true;
+    watchInputFile("/work/deck.pom.xml", onChange);
+
+    statUnavailable = false;
+    mtimeMs = 500;
+    listener("rename", "deck.pom.xml");
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/pom-cli/tsconfig.json
+++ b/packages/pom-cli/tsconfig.json
@@ -14,5 +14,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/pom-cli/vitest.config.ts
+++ b/packages/pom-cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
close #822

## 目的

`packages/pom-cli` は直近の fix 系コミットが集中する一方でテストが 0 件だったため、Vitest を導入してユニットテストを追加し、CI で実行するようにする。

## 変更内容

- **Vitest セットアップ**(pom-md と同構成: globals + node 環境、vitest は root devDependencies を利用)
  - `vitest.config.ts` 追加、`test` / `test:run` script 追加
  - `tsconfig.json` / `eslint.config.mts` / `knip.json` を既存パッケージ(pom / pom-md)と同じテスト除外規約に統一
- **ユニットテスト 4 ファイル・26 件を追加**(`input` / `watch` / `build` / `render`)
  - 既知バグの再発防止テストを含む:
    - watch: mtime ガード(58a3926)— filename が null の環境で無関係な変更が再ビルドを誘発しない
    - render: 出力ファイル名のゼロ埋め桁数の動的化(a0a1d8c)— 100 枚超で 3 桁
    - build: 並走ビルド防止(c13343d)— ビルド中の変更イベントを 1 回にまとめる
    - build: `--verbose` 時の stdout 後方互換(95b997e)— 進捗ログは stderr のみ
  - `buildPptx` / `pptx-glimpse` / `watchInputFile` はモック化し、fs は一時ディレクトリで実体を使用
- **CI**: `.github/workflows/ci-pom-cli.yml` に `pnpm run test:run` ステップを追加

## 影響パッケージ

- `packages/pom-cli`(テスト・開発設定のみ。公開物 `dist` / `fonts` に変更なし → changeset なし)
- `.github/workflows/ci-pom-cli.yml`

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom run build
pnpm --filter @hirokisakabe/pom-md run build
pnpm --filter @hirokisakabe/pom-cli run test:run   # 26 tests passed
```

fmt:check / lint / typecheck / knip / build もパス済み。

## cross-review (codex)

critical 0 / warning 3 / info 1。固定 sleep の排除とテスト名・検証範囲の一致は対応済み。テストファイルを tsc / ESLint の対象に含める提案は、pom / pom-md と共通のテスト除外規約のためリポジトリ横断の検討として見送り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
