### PR TITLE
refactor(pom): layout/render 用の box spacing 属性 resolver を内部共通化

### DIFF
--- a/packages/pom/src/autoFit/strategies/reduceGapAndPadding.ts
+++ b/packages/pom/src/autoFit/strategies/reduceGapAndPadding.ts
@@ -1,5 +1,6 @@
 import type { POMNode } from "../../types.ts";
 import { walkPOMTree } from "../../shared/walkTree.ts";
+import { mapBoxSpacing } from "../../shared/boxSpacing.ts";
 
 const MIN_GAP = 2;
 const MIN_PADDING = 2;
@@ -28,24 +29,12 @@ export function reduceGapAndPadding(
 
     // padding の縮小
     if (n.padding !== undefined) {
-      if (typeof n.padding === "number") {
-        const newPadding = Math.max(MIN_PADDING, Math.round(n.padding * ratio));
-        if (newPadding !== n.padding) {
-          n.padding = newPadding;
-          changed = true;
-        }
-      } else {
-        const dirs = ["top", "right", "bottom", "left"] as const;
-        for (const dir of dirs) {
-          const val = n.padding[dir];
-          if (val !== undefined) {
-            const newVal = Math.max(MIN_PADDING, Math.round(val * ratio));
-            if (newVal !== val) {
-              n.padding[dir] = newVal;
-              changed = true;
-            }
-          }
-        }
+      const result = mapBoxSpacing(n.padding, (v) =>
+        Math.max(MIN_PADDING, Math.round(v * ratio)),
+      );
+      if (result.changed) {
+        n.padding = result.value;
+        changed = true;
       }
     }
   });

--- a/packages/pom/src/autoFit/strategies/uniformScale.ts
+++ b/packages/pom/src/autoFit/strategies/uniformScale.ts
@@ -1,5 +1,6 @@
 import type { POMNode } from "../../types.ts";
 import { walkPOMTree } from "../../shared/walkTree.ts";
+import { mapBoxSpacing } from "../../shared/boxSpacing.ts";
 
 const MIN_SCALE = 0.5;
 
@@ -36,24 +37,10 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
 
     // padding
     if (n.padding !== undefined) {
-      if (typeof n.padding === "number") {
-        const newVal = scaleNumber(n.padding, ratio, 1);
-        if (newVal !== n.padding) {
-          n.padding = newVal;
-          changed = true;
-        }
-      } else {
-        const dirs = ["top", "right", "bottom", "left"] as const;
-        for (const dir of dirs) {
-          const val = n.padding[dir];
-          if (val !== undefined) {
-            const newVal = scaleNumber(val, ratio, 1);
-            if (newVal !== val) {
-              n.padding[dir] = newVal;
-              changed = true;
-            }
-          }
-        }
+      const result = mapBoxSpacing(n.padding, (v) => scaleNumber(v, ratio, 1));
+      if (result.changed) {
+        n.padding = result.value;
+        changed = true;
       }
     }
 

--- a/packages/pom/src/buildPptx.test.ts
+++ b/packages/pom/src/buildPptx.test.ts
@@ -133,3 +133,33 @@ describe("buildPptx diagnostics", () => {
     expect(result.pptx).toBeDefined();
   });
 });
+
+describe("buildPptx SlideMaster margin", () => {
+  const slideSize = { w: 1280, h: 720 };
+  const xml = `<Slide><VStack><Text fontSize="24">margin test</Text></VStack></Slide>`;
+
+  async function getMasterMargin(
+    margin:
+      | number
+      | { top?: number; right?: number; bottom?: number; left?: number },
+  ): Promise<unknown> {
+    const { pptx } = await buildPptx(xml, slideSize, {
+      master: { title: "M1", margin },
+    });
+    const layouts = (
+      pptx as unknown as { slideLayouts: { _name: string; _margin: unknown }[] }
+    ).slideLayouts;
+    return layouts.find((l) => l._name === "M1")?._margin;
+  }
+
+  it("number 指定は 4 辺等値の配列 (inch) として渡される", async () => {
+    // pptxgenjs では margin: n と [n, n, n, n] は同義 (全辺に適用)
+    expect(await getMasterMargin(96)).toEqual([1, 1, 1, 1]);
+  });
+
+  it("object 指定は未指定 edge を 0 として [top, right, bottom, left] で渡される", async () => {
+    expect(await getMasterMargin({ top: 96, left: 48 })).toEqual([
+      1, 0, 0, 0.5,
+    ]);
+  });
+});

--- a/packages/pom/src/calcYogaLayout/calcYogaLayout.ts
+++ b/packages/pom/src/calcYogaLayout/calcYogaLayout.ts
@@ -5,6 +5,7 @@ import { Node as YogaNode } from "yoga-layout";
 import { loadYoga } from "yoga-layout/load";
 import { prefetchImageSize } from "../shared/measureImage.ts";
 import { freeYogaTree } from "../shared/freeYogaTree.ts";
+import { resolveBoxSpacing } from "../shared/boxSpacing.ts";
 import { getNodeDef } from "../registry/index.ts";
 
 /**
@@ -280,50 +281,22 @@ async function applyStyleToYogaNode(
     yn.setMaxHeight(node.maxH);
   }
 
-  // padding
+  // padding（yoga の未設定 edge は 0 扱いのため、解決済みの 0 を明示設定しても等価）
   if (node.padding !== undefined) {
-    if (typeof node.padding === "number") {
-      yn.setPadding(yoga.EDGE_TOP, node.padding);
-      yn.setPadding(yoga.EDGE_RIGHT, node.padding);
-      yn.setPadding(yoga.EDGE_BOTTOM, node.padding);
-      yn.setPadding(yoga.EDGE_LEFT, node.padding);
-    } else {
-      if (node.padding.top !== undefined) {
-        yn.setPadding(yoga.EDGE_TOP, node.padding.top);
-      }
-      if (node.padding.right !== undefined) {
-        yn.setPadding(yoga.EDGE_RIGHT, node.padding.right);
-      }
-      if (node.padding.bottom !== undefined) {
-        yn.setPadding(yoga.EDGE_BOTTOM, node.padding.bottom);
-      }
-      if (node.padding.left !== undefined) {
-        yn.setPadding(yoga.EDGE_LEFT, node.padding.left);
-      }
-    }
+    const padding = resolveBoxSpacing(node.padding);
+    yn.setPadding(yoga.EDGE_TOP, padding.top);
+    yn.setPadding(yoga.EDGE_RIGHT, padding.right);
+    yn.setPadding(yoga.EDGE_BOTTOM, padding.bottom);
+    yn.setPadding(yoga.EDGE_LEFT, padding.left);
   }
 
   // margin
   if (node.margin !== undefined) {
-    if (typeof node.margin === "number") {
-      yn.setMargin(yoga.EDGE_TOP, node.margin);
-      yn.setMargin(yoga.EDGE_RIGHT, node.margin);
-      yn.setMargin(yoga.EDGE_BOTTOM, node.margin);
-      yn.setMargin(yoga.EDGE_LEFT, node.margin);
-    } else {
-      if (node.margin.top !== undefined) {
-        yn.setMargin(yoga.EDGE_TOP, node.margin.top);
-      }
-      if (node.margin.right !== undefined) {
-        yn.setMargin(yoga.EDGE_RIGHT, node.margin.right);
-      }
-      if (node.margin.bottom !== undefined) {
-        yn.setMargin(yoga.EDGE_BOTTOM, node.margin.bottom);
-      }
-      if (node.margin.left !== undefined) {
-        yn.setMargin(yoga.EDGE_LEFT, node.margin.left);
-      }
-    }
+    const margin = resolveBoxSpacing(node.margin);
+    yn.setMargin(yoga.EDGE_TOP, margin.top);
+    yn.setMargin(yoga.EDGE_RIGHT, margin.right);
+    yn.setMargin(yoga.EDGE_BOTTOM, margin.bottom);
+    yn.setMargin(yoga.EDGE_LEFT, margin.left);
   }
 
   // position

--- a/packages/pom/src/renderPptx/renderPptx.ts
+++ b/packages/pom/src/renderPptx/renderPptx.ts
@@ -29,6 +29,7 @@ import type { RenderContext, NodeBounds } from "./types.ts";
 import { pxToIn, pxToPt } from "./units.ts";
 import { convertUnderline, convertStrike } from "./textOptions.ts";
 import { getImageData } from "../shared/measureImage.ts";
+import { resolveBoxSpacing } from "../shared/boxSpacing.ts";
 import { renderBackgroundAndBorder } from "./utils/backgroundBorder.ts";
 import {
   convertBorderLine,
@@ -189,16 +190,13 @@ function defineSlideMasterFromOptions(
 
   // margin の変換 (px -> inches)
   if (master.margin !== undefined) {
-    if (typeof master.margin === "number") {
-      masterProps.margin = pxToIn(master.margin);
-    } else {
-      masterProps.margin = [
-        pxToIn(master.margin.top ?? 0),
-        pxToIn(master.margin.right ?? 0),
-        pxToIn(master.margin.bottom ?? 0),
-        pxToIn(master.margin.left ?? 0),
-      ];
-    }
+    const margin = resolveBoxSpacing(master.margin);
+    masterProps.margin = [
+      pxToIn(margin.top),
+      pxToIn(margin.right),
+      pxToIn(margin.bottom),
+      pxToIn(margin.left),
+    ];
   }
 
   // objects の変換

--- a/packages/pom/src/renderPptx/utils/contentArea.ts
+++ b/packages/pom/src/renderPptx/utils/contentArea.ts
@@ -1,11 +1,7 @@
-type Padding =
-  | number
-  | {
-      top?: number;
-      right?: number;
-      bottom?: number;
-      left?: number;
-    };
+import {
+  resolveBoxSpacing,
+  type BoxSpacingInput,
+} from "../../shared/boxSpacing.ts";
 
 interface ContentArea {
   x: number;
@@ -24,22 +20,13 @@ export function getContentArea(node: {
   y: number;
   w: number;
   h: number;
-  padding?: Padding;
+  padding?: BoxSpacingInput;
 }): ContentArea {
   if (node.padding === undefined) {
     return { x: node.x, y: node.y, w: node.w, h: node.h };
   }
 
-  let top: number, right: number, bottom: number, left: number;
-
-  if (typeof node.padding === "number") {
-    top = right = bottom = left = node.padding;
-  } else {
-    top = node.padding.top ?? 0;
-    right = node.padding.right ?? 0;
-    bottom = node.padding.bottom ?? 0;
-    left = node.padding.left ?? 0;
-  }
+  const { top, right, bottom, left } = resolveBoxSpacing(node.padding);
 
   return {
     x: node.x + left,

--- a/packages/pom/src/shared/boxSpacing.test.ts
+++ b/packages/pom/src/shared/boxSpacing.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { mapBoxSpacing, resolveBoxSpacing } from "./boxSpacing.ts";
+
+describe("resolveBoxSpacing", () => {
+  it("undefined は全 edge 0 に解決される", () => {
+    expect(resolveBoxSpacing(undefined)).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+  });
+
+  it("number は 4 辺すべてに展開される", () => {
+    expect(resolveBoxSpacing(16)).toEqual({
+      top: 16,
+      right: 16,
+      bottom: 16,
+      left: 16,
+    });
+  });
+
+  it("0 も number として 4 辺に展開される", () => {
+    expect(resolveBoxSpacing(0)).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+  });
+
+  it("object は未指定 edge を 0 として解決される", () => {
+    expect(resolveBoxSpacing({ top: 8, left: 24 })).toEqual({
+      top: 8,
+      right: 0,
+      bottom: 0,
+      left: 24,
+    });
+  });
+
+  it("全 edge 指定の object はそのまま解決される", () => {
+    expect(resolveBoxSpacing({ top: 1, right: 2, bottom: 3, left: 4 })).toEqual(
+      {
+        top: 1,
+        right: 2,
+        bottom: 3,
+        left: 4,
+      },
+    );
+  });
+});
+
+describe("mapBoxSpacing", () => {
+  it("number は number のまま変換される", () => {
+    expect(mapBoxSpacing(10, (v) => v * 2)).toEqual({
+      value: 20,
+      changed: true,
+    });
+  });
+
+  it("number で値が変わらない場合は changed が false になる", () => {
+    expect(mapBoxSpacing(10, (v) => v)).toEqual({
+      value: 10,
+      changed: false,
+    });
+  });
+
+  it("object は定義済み edge のみ変換され、未指定 edge は生えない", () => {
+    expect(mapBoxSpacing({ top: 10, left: 20 }, (v) => v * 2)).toEqual({
+      value: { top: 20, left: 40 },
+      changed: true,
+    });
+  });
+
+  it("object で全 edge の値が変わらない場合は changed が false になる", () => {
+    expect(mapBoxSpacing({ top: 10, bottom: 20 }, (v) => v)).toEqual({
+      value: { top: 10, bottom: 20 },
+      changed: false,
+    });
+  });
+
+  it("一部の edge だけ変化しても changed が true になる", () => {
+    expect(
+      mapBoxSpacing({ top: 10, bottom: 2 }, (v) => Math.max(2, v / 2)),
+    ).toEqual({
+      value: { top: 5, bottom: 2 },
+      changed: true,
+    });
+  });
+});

--- a/packages/pom/src/shared/boxSpacing.ts
+++ b/packages/pom/src/shared/boxSpacing.ts
@@ -15,6 +15,10 @@
  * 複合ノードのスケーリングは renderPptx/utils/scaleToFit.ts が担当する (本モジュールの対象外)。
  */
 
+/**
+ * types.ts の paddingSchema / slideMasterMarginSchema と同じ shape。
+ * schema 側を変更する場合は本型も同期すること。
+ */
 export type BoxSpacingInput =
   | number
   | {

--- a/packages/pom/src/shared/boxSpacing.ts
+++ b/packages/pom/src/shared/boxSpacing.ts
@@ -1,0 +1,85 @@
+/**
+ * box spacing 系属性 (padding / margin / SlideMaster margin) の内部共通 resolver。
+ *
+ * 対象属性群: `number | { top?, right?, bottom?, left? }` 形式で指定される余白系の
+ * layout/style 属性。pipeline の各段階が個別に形式分岐すると解釈ズレの温床になるため、
+ * 「入力 XML の値」から「layout/render が使う解決済み per-edge 値」への正規化を
+ * 本モジュールに集約する。
+ *
+ * 利用箇所:
+ * - calcYogaLayout: padding / margin の yoga への設定 (resolveBoxSpacing)
+ * - renderPptx: contentArea の padding 控除、SlideMaster margin の変換 (resolveBoxSpacing)
+ * - autoFit: padding 縮小・一律スケール時の shape 保持変換 (mapBoxSpacing)
+ *
+ * fill / border / shadow など見た目属性の変換は renderPptx/utils/visualStyle.ts、
+ * 複合ノードのスケーリングは renderPptx/utils/scaleToFit.ts が担当する (本モジュールの対象外)。
+ */
+
+export type BoxSpacingInput =
+  | number
+  | {
+      top?: number;
+      right?: number;
+      bottom?: number;
+      left?: number;
+    };
+
+export interface ResolvedBoxSpacing {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+const EDGES = ["top", "right", "bottom", "left"] as const;
+
+/**
+ * box spacing 値を解決済みの per-edge 値に正規化する。
+ * number は 4 辺すべて、object は未指定 edge を 0 として解決する。
+ */
+export function resolveBoxSpacing(
+  value: BoxSpacingInput | undefined,
+): ResolvedBoxSpacing {
+  if (value === undefined) {
+    return { top: 0, right: 0, bottom: 0, left: 0 };
+  }
+  if (typeof value === "number") {
+    return { top: value, right: value, bottom: value, left: value };
+  }
+  return {
+    top: value.top ?? 0,
+    right: value.right ?? 0,
+    bottom: value.bottom ?? 0,
+    left: value.left ?? 0,
+  };
+}
+
+/**
+ * box spacing 値の各 edge に fn を適用し、入力の shape を保持したまま返す。
+ * number は number のまま、object は定義済み edge のみ変換する
+ * (未指定 edge を 0 扱いで生やさない。autoFit の縮小処理が最小値クランプを
+ * 持つため、未指定 edge に最小値が混入するのを防ぐ)。
+ */
+export function mapBoxSpacing(
+  value: BoxSpacingInput,
+  fn: (edgeValue: number) => number,
+): { value: BoxSpacingInput; changed: boolean } {
+  if (typeof value === "number") {
+    const mapped = fn(value);
+    return { value: mapped, changed: mapped !== value };
+  }
+  const mappedValue: Exclude<BoxSpacingInput, number> = {};
+  let changed = false;
+  for (const edge of EDGES) {
+    const edgeValue = value[edge];
+    if (edgeValue === undefined) {
+      continue;
+    }
+    const mapped = fn(edgeValue);
+    mappedValue[edge] = mapped;
+    if (mapped !== edgeValue) {
+      changed = true;
+    }
+  }
+  return { value: mappedValue, changed };
+}


### PR DESCRIPTION
close #810

## 目的

padding / margin など `number | {top, right, bottom, left}` 形式の box spacing 系属性の解釈が pipeline 各段階 (calcYogaLayout / renderPptx / autoFit) に分散し、同じ形式分岐が 6 箇所で重複していた。これを `shared/boxSpacing.ts` の内部共通 resolver に集約し、属性解釈のズレが起きにくい構造にする (#807 の内部共通化シリーズ、PR #818 の visualStyle resolver と同パターン)。

## 変更内容

- **`shared/boxSpacing.ts` を新規追加**
  - `resolveBoxSpacing`: 入力値を解決済みの per-edge 値 `{top, right, bottom, left}` に正規化 (number → 4 辺展開、object → 未指定 edge は 0)
  - `mapBoxSpacing`: 各 edge へ変換関数を適用しつつ入力 shape を保持 (number は number のまま、object は定義済み edge のみ) + changed 判定。autoFit の最小値クランプが未指定 edge に混入しないようにするための API
  - モジュールヘッダに対象属性群・各段階での利用箇所・対象外 (visualStyle / scaleToFit) を明記
- **置き換え (挙動は不変)**
  - `calcYogaLayout.ts`: padding / margin の yoga 設定 (yoga は未設定 edge を 0 扱いのため等価)
  - `renderPptx/utils/contentArea.ts`: padding 控除のローカル分岐とローカル `Padding` 型を resolver に統一
  - `renderPptx/renderPptx.ts`: SlideMaster margin の px→in 変換 (pptxgenjs では number と等値 4 要素配列は同義)
  - `autoFit/strategies/reduceGapAndPadding.ts` / `uniformScale.ts`: padding 縮小を `mapBoxSpacing` に統一
- **テスト追加**: `boxSpacing.test.ts` (unit 10 件)、SlideMaster margin の回帰テスト 2 件 (cross-review 指摘対応)

## 影響パッケージ

- `packages/pom` のみ (内部 refactor。公開 API・XML 仕様の変更なし、changeset 不要)

## 検証

- `pnpm run lint` / `typecheck` / `test:run` (424 passed) / `knip` / `build` / `fmt` すべてパス
- **前後レイアウト差分なしの確認**: 分岐点 f321b23 と本ブランチで VRT 全 43 スライドの PositionedNode (autoFit 有効) を dump して diff → **完全一致**。生成 PPTX の zip 内容も比較し、差分は埋め込み xlsx の生成タイムスタンプ (docProps) のみ
- cross-review (codex / gpt-5.4): critical 0 / warning 1 / info 1 → 両指摘とも追加 commit で対応済み

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom run test:run
pnpm --filter @hirokisakabe/pom run typecheck
pnpm --filter @hirokisakabe/pom run lint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
