### PR TITLE
refactor(pom): renderPptx のノード renderer 共通 context / helper を整備

### DIFF
--- a/packages/pom/src/renderPptx/nodes/arrow.ts
+++ b/packages/pom/src/renderPptx/nodes/arrow.ts
@@ -1,7 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn, pxToPt } from "../units.ts";
-import { resolveArrowType } from "./line.ts";
+import { addStraightLine } from "../utils/straightLine.ts";
 
 type ArrowPositionedNode = Extract<PositionedNode, { type: "arrow" }>;
 
@@ -27,33 +26,15 @@ export function renderArrowNode(
     return;
   }
 
-  const x1 = fromBounds.x + fromBounds.w / 2;
-  const y1 = fromBounds.y + fromBounds.h / 2;
-  const x2 = toBounds.x + toBounds.w / 2;
-  const y2 = toBounds.y + toBounds.h / 2;
-
-  const minX = Math.min(x1, x2);
-  const minY = Math.min(y1, y2);
-  const lineW = Math.abs(x2 - x1);
-  const lineH = Math.abs(y2 - y1);
-  const flipH = x2 < x1;
-  const flipV = y2 < y1;
-
-  const { color, lineWidth, dashType, beginArrow, endArrow } = node;
-
-  ctx.slide.addShape(ctx.pptx.ShapeType.line, {
-    x: pxToIn(minX),
-    y: pxToIn(minY),
-    w: pxToIn(lineW),
-    h: pxToIn(lineH),
-    flipH,
-    flipV,
-    line: {
-      color: color ?? "000000",
-      width: lineWidth !== undefined ? pxToPt(lineWidth) : 1,
-      dashType,
-      beginArrowType: resolveArrowType(beginArrow),
-      endArrowType: resolveArrowType(endArrow),
+  // 参照ノードの中心同士を結ぶ
+  addStraightLine(
+    ctx,
+    {
+      x1: fromBounds.x + fromBounds.w / 2,
+      y1: fromBounds.y + fromBounds.h / 2,
+      x2: toBounds.x + toBounds.w / 2,
+      y2: toBounds.y + toBounds.h / 2,
     },
-  });
+    node,
+  );
 }

--- a/packages/pom/src/renderPptx/nodes/chart.ts
+++ b/packages/pom/src/renderPptx/nodes/chart.ts
@@ -1,7 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn } from "../units.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { getContentAreaIn } from "../utils/contentArea.ts";
 
 type ChartPositionedNode = Extract<PositionedNode, { type: "chart" }>;
 
@@ -15,12 +14,8 @@ export function renderChartNode(
     values: d.values,
   }));
 
-  const content = getContentArea(node);
   const chartOptions: Record<string, unknown> = {
-    x: pxToIn(content.x),
-    y: pxToIn(content.y),
-    w: pxToIn(content.w),
-    h: pxToIn(content.h),
+    ...getContentAreaIn(node),
     showLegend: node.showLegend ?? false,
     showTitle: node.showTitle ?? false,
     title: node.title,

--- a/packages/pom/src/renderPptx/nodes/flow.ts
+++ b/packages/pom/src/renderPptx/nodes/flow.ts
@@ -2,8 +2,8 @@ import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measureFlow } from "../../calcYogaLayout/measureCompositeNodes.ts";
-import { calcScaleFactor } from "../utils/scaleToFit.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
+import { withContentBounds } from "../utils/contentArea.ts";
 
 type FlowPositionedNode = Extract<PositionedNode, { type: "flow" }>;
 
@@ -28,15 +28,10 @@ export function renderFlowNode(
   const defaultColor = "1D4ED8";
 
   // スケール係数を計算（コンテンツ領域基準）
-  const content = getContentArea(node);
-  const intrinsic = measureFlow(node);
-  const scaleFactor = calcScaleFactor(
-    content.w,
-    content.h,
-    intrinsic.width,
-    intrinsic.height,
-    "flow",
-    ctx.buildContext.diagnostics,
+  const { content, scaleFactor } = resolveScaledContentArea(
+    node,
+    measureFlow(node),
+    ctx,
   );
 
   const scaledNodeWidth = nodeWidth * scaleFactor;
@@ -47,13 +42,7 @@ export function renderFlowNode(
   const nodeCount = node.nodes.length;
 
   // コンテンツ領域を使用するための仮想ノードを作成
-  const contentNode = {
-    ...node,
-    x: content.x,
-    y: content.y,
-    w: content.w,
-    h: content.h,
-  };
+  const contentNode = withContentBounds(node, content);
 
   // ノードのレイアウトを計算
   if (direction === "horizontal") {

--- a/packages/pom/src/renderPptx/nodes/flow.ts
+++ b/packages/pom/src/renderPptx/nodes/flow.ts
@@ -1,5 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { stripHash } from "../utils/visualStyle.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measureFlow } from "../../calcYogaLayout/measureCompositeNodes.ts";
 import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
@@ -114,8 +115,8 @@ export function renderFlowNode(
         fontSize: pxToPt(10 * scaleFactor),
         fontFace: "Noto Sans JP",
         color:
-          conn.labelColor?.replace("#", "") ??
-          connectorStyle.labelColor?.replace("#", "") ??
+          stripHash(conn.labelColor) ??
+          stripHash(connectorStyle.labelColor) ??
           "64748B",
         align: "center",
         valign: "middle",

--- a/packages/pom/src/renderPptx/nodes/image.ts
+++ b/packages/pom/src/renderPptx/nodes/image.ts
@@ -1,6 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn } from "../units.ts";
+import { pxToIn, rectPxToIn } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
 import { convertShadow } from "../utils/visualStyle.ts";
 
@@ -12,10 +12,7 @@ export function renderImageNode(
 ): void {
   const content = getContentArea(node);
   const imageOptions: Record<string, unknown> = {
-    x: pxToIn(content.x),
-    y: pxToIn(content.y),
-    w: pxToIn(content.w),
-    h: pxToIn(content.h),
+    ...rectPxToIn(content),
     shadow: convertShadow(node.shadow),
   };
 

--- a/packages/pom/src/renderPptx/nodes/line.ts
+++ b/packages/pom/src/renderPptx/nodes/line.ts
@@ -1,60 +1,13 @@
-import type { PositionedNode, LineArrow } from "../../types.ts";
+import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn, pxToPt } from "../units.ts";
+import { addStraightLine } from "../utils/straightLine.ts";
 
 type LinePositionedNode = Extract<PositionedNode, { type: "line" }>;
-
-/**
- * boolean | LineArrowOptions から pptxgenjs の arrow type を取得
- */
-export function resolveArrowType(
-  arrow: LineArrow | undefined,
-): "none" | "arrow" | "diamond" | "oval" | "stealth" | "triangle" | undefined {
-  if (arrow === undefined) {
-    return undefined;
-  }
-  if (arrow === false) {
-    return "none";
-  }
-  if (arrow === true) {
-    return "triangle"; // デフォルト
-  }
-  return arrow.type ?? "triangle";
-}
 
 export function renderLineNode(
   node: LinePositionedNode,
   ctx: RenderContext,
 ): void {
-  const { x1, y1, x2, y2, color, lineWidth, dashType, beginArrow, endArrow } =
-    node;
-
-  // pptxgenjs の line シェイプは x, y, w, h で描画
-  // x, y は左上座標、w, h で方向と長さを指定
-  const minX = Math.min(x1, x2);
-  const minY = Math.min(y1, y2);
-  const lineW = Math.abs(x2 - x1);
-  const lineH = Math.abs(y2 - y1);
-
-  // 線の方向を判定して flip を決定
-  // flipH: 右から左へ向かう線
-  // flipV: 下から上へ向かう線
-  const flipH = x2 < x1;
-  const flipV = y2 < y1;
-
-  ctx.slide.addShape(ctx.pptx.ShapeType.line, {
-    x: pxToIn(minX),
-    y: pxToIn(minY),
-    w: pxToIn(lineW),
-    h: pxToIn(lineH),
-    flipH,
-    flipV,
-    line: {
-      color: color ?? "000000",
-      width: lineWidth !== undefined ? pxToPt(lineWidth) : 1,
-      dashType: dashType,
-      beginArrowType: resolveArrowType(beginArrow),
-      endArrowType: resolveArrowType(endArrow),
-    },
-  });
+  const { x1, y1, x2, y2 } = node;
+  addStraightLine(ctx, { x1, y1, x2, y2 }, node);
 }

--- a/packages/pom/src/renderPptx/nodes/list.ts
+++ b/packages/pom/src/renderPptx/nodes/list.ts
@@ -1,8 +1,8 @@
 import type { PositionedNode, LiNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn, pxToPt } from "../units.ts";
+import { pxToPt } from "../units.ts";
 import { convertUnderline, convertStrike } from "../textOptions.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { getContentAreaIn } from "../utils/contentArea.ts";
 
 type UlPositionedNode = Extract<PositionedNode, { type: "ul" }>;
 type OlPositionedNode = Extract<PositionedNode, { type: "ol" }>;
@@ -95,17 +95,14 @@ export function renderUlNode(node: UlPositionedNode, ctx: RenderContext): void {
   const fontSizePx = node.fontSize ?? 24;
   const fontFamily = node.fontFamily ?? "Noto Sans JP";
   const lineHeight = node.lineHeight ?? 1.3;
-  const content = getContentArea(node);
+  const contentIn = getContentAreaIn(node);
 
   if (hasItemStyleOverride(node.items)) {
     // Li に個別スタイルがある場合は配列形式を使用
     const textItems = buildListTextItems(node.items, node, true);
 
     ctx.slide.addText(textItems, {
-      x: pxToIn(content.x),
-      y: pxToIn(content.y),
-      w: pxToIn(content.w),
-      h: pxToIn(content.h),
+      ...contentIn,
       align: node.textAlign ?? "left",
       valign: "top" as const,
       margin: 0,
@@ -116,10 +113,7 @@ export function renderUlNode(node: UlPositionedNode, ctx: RenderContext): void {
     const text = node.items.map((li) => li.text).join("\n");
 
     ctx.slide.addText(text, {
-      x: pxToIn(content.x),
-      y: pxToIn(content.y),
-      w: pxToIn(content.w),
-      h: pxToIn(content.h),
+      ...contentIn,
       fontSize: pxToPt(fontSizePx),
       fontFace: fontFamily,
       align: node.textAlign ?? "left",
@@ -141,7 +135,7 @@ export function renderOlNode(node: OlPositionedNode, ctx: RenderContext): void {
   const fontSizePx = node.fontSize ?? 24;
   const fontFamily = node.fontFamily ?? "Noto Sans JP";
   const lineHeight = node.lineHeight ?? 1.3;
-  const content = getContentArea(node);
+  const contentIn = getContentAreaIn(node);
 
   const bulletOptions: Record<string, unknown> = { type: "number" };
   if (node.numberType !== undefined) {
@@ -155,10 +149,7 @@ export function renderOlNode(node: OlPositionedNode, ctx: RenderContext): void {
     const textItems = buildListTextItems(node.items, node, bulletOptions);
 
     ctx.slide.addText(textItems, {
-      x: pxToIn(content.x),
-      y: pxToIn(content.y),
-      w: pxToIn(content.w),
-      h: pxToIn(content.h),
+      ...contentIn,
       align: node.textAlign ?? "left",
       valign: "top" as const,
       margin: 0,
@@ -168,10 +159,7 @@ export function renderOlNode(node: OlPositionedNode, ctx: RenderContext): void {
     const text = node.items.map((li) => li.text).join("\n");
 
     ctx.slide.addText(text, {
-      x: pxToIn(content.x),
-      y: pxToIn(content.y),
-      w: pxToIn(content.w),
-      h: pxToIn(content.h),
+      ...contentIn,
       fontSize: pxToPt(fontSizePx),
       fontFace: fontFamily,
       align: node.textAlign ?? "left",

--- a/packages/pom/src/renderPptx/nodes/matrix.ts
+++ b/packages/pom/src/renderPptx/nodes/matrix.ts
@@ -1,5 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { stripHash } from "../utils/visualStyle.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measureMatrix } from "../../calcYogaLayout/measureCompositeNodes.ts";
 import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
@@ -18,8 +19,8 @@ export function renderMatrixNode(
   const baseItemSize = 24; // px
   const baseLineWidth = 2; // px
   const axisColor = "E2E8F0";
-  const axisLabelColor = node.axisLabelColor?.replace("#", "") ?? "64748B";
-  const itemLabelColor = node.itemLabelColor?.replace("#", "") ?? "1E293B";
+  const axisLabelColor = stripHash(node.axisLabelColor) ?? "64748B";
+  const itemLabelColor = stripHash(node.itemLabelColor) ?? "1E293B";
 
   // スケール係数を計算（コンテンツ領域基準）
   const { content, scaleFactor } = resolveScaledContentArea(
@@ -106,7 +107,7 @@ export function renderMatrixNode(
       centerX,
       centerY,
       scaleFactor,
-      node.quadrantLabelColor?.replace("#", "") ?? "94A3B8",
+      stripHash(node.quadrantLabelColor) ?? "94A3B8",
     );
   }
 
@@ -140,7 +141,7 @@ export function renderMatrixNode(
       h: pxToIn(itemLabelH),
       fontSize: pxToPt(11 * scaleFactor),
       fontFace: "Noto Sans JP",
-      color: item.textColor?.replace("#", "") ?? itemLabelColor,
+      color: stripHash(item.textColor) ?? itemLabelColor,
       bold: true,
       align: "center",
       valign: "bottom",

--- a/packages/pom/src/renderPptx/nodes/matrix.ts
+++ b/packages/pom/src/renderPptx/nodes/matrix.ts
@@ -2,8 +2,7 @@ import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measureMatrix } from "../../calcYogaLayout/measureCompositeNodes.ts";
-import { calcScaleFactor } from "../utils/scaleToFit.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
 
 type MatrixPositionedNode = Extract<PositionedNode, { type: "matrix" }>;
 
@@ -23,15 +22,10 @@ export function renderMatrixNode(
   const itemLabelColor = node.itemLabelColor?.replace("#", "") ?? "1E293B";
 
   // スケール係数を計算（コンテンツ領域基準）
-  const content = getContentArea(node);
-  const intrinsic = measureMatrix(node);
-  const scaleFactor = calcScaleFactor(
-    content.w,
-    content.h,
-    intrinsic.width,
-    intrinsic.height,
-    "matrix",
-    ctx.buildContext.diagnostics,
+  const { content, scaleFactor } = resolveScaledContentArea(
+    node,
+    measureMatrix(node),
+    ctx,
   );
 
   const itemSize = baseItemSize * scaleFactor;

--- a/packages/pom/src/renderPptx/nodes/processArrow.ts
+++ b/packages/pom/src/renderPptx/nodes/processArrow.ts
@@ -1,5 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { stripHash } from "../utils/visualStyle.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { convertUnderline, convertStrike } from "../textOptions.ts";
 import { measureProcessArrow } from "../../calcYogaLayout/measureCompositeNodes.ts";
@@ -99,8 +100,8 @@ function renderHorizontalProcessArrow(
   steps.forEach((step, index) => {
     const stepX = startX + index * (itemWidth + gap);
     const stepY = centerY - itemHeight / 2;
-    const fillColor = step.color?.replace("#", "") ?? defaultColor;
-    const textColor = step.textColor?.replace("#", "") ?? defaultTextColor;
+    const fillColor = stripHash(step.color) ?? defaultColor;
+    const textColor = stripHash(step.textColor) ?? defaultTextColor;
 
     // custGeom でシェブロン形状を描画
     const isFirst = index === 0;
@@ -178,8 +179,8 @@ function renderVerticalProcessArrow(
   steps.forEach((step, index) => {
     const stepX = centerX - itemWidth / 2;
     const stepY = startY + index * (itemHeight + gap);
-    const fillColor = step.color?.replace("#", "") ?? defaultColor;
-    const textColor = step.textColor?.replace("#", "") ?? defaultTextColor;
+    const fillColor = stripHash(step.color) ?? defaultColor;
+    const textColor = stripHash(step.textColor) ?? defaultTextColor;
 
     const isFirst = index === 0;
     const points = isFirst

--- a/packages/pom/src/renderPptx/nodes/processArrow.ts
+++ b/packages/pom/src/renderPptx/nodes/processArrow.ts
@@ -3,13 +3,13 @@ import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { convertUnderline, convertStrike } from "../textOptions.ts";
 import { measureProcessArrow } from "../../calcYogaLayout/measureCompositeNodes.ts";
-import { calcScaleFactor } from "../utils/scaleToFit.ts";
+import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
 import {
   ARROW_DEPTH_RATIO,
   DEFAULT_PROCESS_ARROW_ITEM_WIDTH,
   DEFAULT_PROCESS_ARROW_ITEM_HEIGHT,
 } from "../../shared/processArrowConstants.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { withContentBounds } from "../utils/contentArea.ts";
 
 type ProcessArrowPositionedNode = Extract<
   PositionedNode,
@@ -34,15 +34,10 @@ export function renderProcessArrowNode(
   const gap = node.gap ?? -arrowDepth;
 
   // スケール係数を計算（コンテンツ領域基準）
-  const content = getContentArea(node);
-  const intrinsic = measureProcessArrow(node);
-  const scaleFactor = calcScaleFactor(
-    content.w,
-    content.h,
-    intrinsic.width,
-    intrinsic.height,
-    "processArrow",
-    ctx.buildContext.diagnostics,
+  const { content, scaleFactor } = resolveScaledContentArea(
+    node,
+    measureProcessArrow(node),
+    ctx,
   );
 
   const scaledItemWidth = itemWidth * scaleFactor;
@@ -51,13 +46,7 @@ export function renderProcessArrowNode(
   const scaledArrowDepth = arrowDepth * scaleFactor;
 
   // コンテンツ領域を使用するための仮想ノードを作成
-  const contentNode = {
-    ...node,
-    x: content.x,
-    y: content.y,
-    w: content.w,
-    h: content.h,
-  };
+  const contentNode = withContentBounds(node, content);
 
   if (direction === "horizontal") {
     renderHorizontalProcessArrow(

--- a/packages/pom/src/renderPptx/nodes/pyramid.ts
+++ b/packages/pom/src/renderPptx/nodes/pyramid.ts
@@ -2,8 +2,7 @@ import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measurePyramid } from "../../calcYogaLayout/measureCompositeNodes.ts";
-import { calcScaleFactor } from "../utils/scaleToFit.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
 
 type PyramidPositionedNode = Extract<PositionedNode, { type: "pyramid" }>;
 
@@ -21,15 +20,10 @@ export function renderPyramidNode(
   const defaultTextColor = "FFFFFF";
 
   // スケール係数を計算（コンテンツ領域基準）
-  const content = getContentArea(node);
-  const intrinsic = measurePyramid(node);
-  const scaleFactor = calcScaleFactor(
-    content.w,
-    content.h,
-    intrinsic.width,
-    intrinsic.height,
-    "pyramid",
-    ctx.buildContext.diagnostics,
+  const { content, scaleFactor } = resolveScaledContentArea(
+    node,
+    measurePyramid(node),
+    ctx,
   );
 
   const baseWidth = 400 * scaleFactor;

--- a/packages/pom/src/renderPptx/nodes/pyramid.ts
+++ b/packages/pom/src/renderPptx/nodes/pyramid.ts
@@ -1,5 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { stripHash } from "../utils/visualStyle.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measurePyramid } from "../../calcYogaLayout/measureCompositeNodes.ts";
 import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
@@ -36,8 +37,8 @@ export function renderPyramidNode(
 
   for (let i = 0; i < levelCount; i++) {
     const level = levels[i];
-    const fillColor = level.color?.replace("#", "") ?? defaultColor;
-    const textColor = level.textColor?.replace("#", "") ?? defaultTextColor;
+    const fillColor = stripHash(level.color) ?? defaultColor;
+    const textColor = stripHash(level.textColor) ?? defaultTextColor;
 
     const layerY = startY + i * (layerHeight + gap);
 

--- a/packages/pom/src/renderPptx/nodes/shape.ts
+++ b/packages/pom/src/renderPptx/nodes/shape.ts
@@ -1,8 +1,8 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn, pxToPt } from "../units.ts";
+import { pxToPt } from "../units.ts";
 import { convertUnderline, convertStrike } from "../textOptions.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { getContentAreaIn } from "../utils/contentArea.ts";
 import { convertBorderLine, convertShadow } from "../utils/visualStyle.ts";
 
 type ShapePositionedNode = Extract<PositionedNode, { type: "shape" }>;
@@ -11,12 +11,8 @@ export function renderShapeNode(
   node: ShapePositionedNode,
   ctx: RenderContext,
 ): void {
-  const content = getContentArea(node);
   const shapeOptions = {
-    x: pxToIn(content.x),
-    y: pxToIn(content.y),
-    w: pxToIn(content.w),
-    h: pxToIn(content.h),
+    ...getContentAreaIn(node),
     fill: node.fill
       ? {
           color: node.fill.color,

--- a/packages/pom/src/renderPptx/nodes/svg.ts
+++ b/packages/pom/src/renderPptx/nodes/svg.ts
@@ -1,6 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn } from "../units.ts";
+import { rectPxToIn } from "../units.ts";
 
 type SvgPositionedNode = Extract<PositionedNode, { type: "svg" }>;
 
@@ -10,9 +10,6 @@ export function renderSvgNode(
 ): void {
   ctx.slide.addImage({
     data: node.iconImageData,
-    x: pxToIn(node.x),
-    y: pxToIn(node.y),
-    w: pxToIn(node.w),
-    h: pxToIn(node.h),
+    ...rectPxToIn(node),
   });
 }

--- a/packages/pom/src/renderPptx/nodes/table.ts
+++ b/packages/pom/src/renderPptx/nodes/table.ts
@@ -4,7 +4,7 @@ import {
   resolveColumnWidths,
   resolveRowHeights,
 } from "../../shared/tableUtils.ts";
-import { pxToIn, pxToPt } from "../units.ts";
+import { pxToIn, pxToPt, rectPxToIn } from "../units.ts";
 import { convertUnderline, convertStrike } from "../textOptions.ts";
 import { getContentArea } from "../utils/contentArea.ts";
 
@@ -71,10 +71,7 @@ export function renderTableNode(
 
   const content = getContentArea(node);
   const tableOptions: Record<string, unknown> = {
-    x: pxToIn(content.x),
-    y: pxToIn(content.y),
-    w: pxToIn(content.w),
-    h: pxToIn(content.h),
+    ...rectPxToIn(content),
     colW: resolveColumnWidths(node, content.w).map((width) => pxToIn(width)),
     rowH: resolveRowHeights(node).map((height) => pxToIn(height)),
     margin: 0,

--- a/packages/pom/src/renderPptx/nodes/timeline.ts
+++ b/packages/pom/src/renderPptx/nodes/timeline.ts
@@ -2,8 +2,8 @@ import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measureTimeline } from "../../calcYogaLayout/measureCompositeNodes.ts";
-import { calcScaleFactor } from "../utils/scaleToFit.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
+import { withContentBounds } from "../utils/contentArea.ts";
 
 type TimelinePositionedNode = Extract<PositionedNode, { type: "timeline" }>;
 
@@ -34,28 +34,17 @@ export function renderTimelineNode(
   };
 
   // スケール係数を計算（コンテンツ領域基準）
-  const content = getContentArea(node);
-  const intrinsic = measureTimeline(node);
-  const scaleFactor = calcScaleFactor(
-    content.w,
-    content.h,
-    intrinsic.width,
-    intrinsic.height,
-    "timeline",
-    ctx.buildContext.diagnostics,
+  const { content, scaleFactor } = resolveScaledContentArea(
+    node,
+    measureTimeline(node),
+    ctx,
   );
 
   const nodeRadius = baseNodeRadius * scaleFactor;
   const lineWidth = baseLineWidth * scaleFactor;
 
   // コンテンツ領域を使用するための仮想ノードを作成
-  const contentNode = {
-    ...node,
-    x: content.x,
-    y: content.y,
-    w: content.w,
-    h: content.h,
-  };
+  const contentNode = withContentBounds(node, content);
 
   if (direction === "horizontal") {
     renderHorizontalTimeline(

--- a/packages/pom/src/renderPptx/nodes/timeline.ts
+++ b/packages/pom/src/renderPptx/nodes/timeline.ts
@@ -1,5 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { stripHash } from "../utils/visualStyle.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { measureTimeline } from "../../calcYogaLayout/measureCompositeNodes.ts";
 import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
@@ -28,9 +29,9 @@ export function renderTimelineNode(
   const baseLineWidth = 4; // px
 
   const textColors: TimelineTextColors = {
-    date: node.dateColor?.replace("#", "") ?? "64748B",
-    title: node.titleColor?.replace("#", "") ?? "1E293B",
-    description: node.descriptionColor?.replace("#", "") ?? "64748B",
+    date: stripHash(node.dateColor) ?? "64748B",
+    title: stripHash(node.titleColor) ?? "1E293B",
+    description: stripHash(node.descriptionColor) ?? "64748B",
   };
 
   // スケール係数を計算（コンテンツ領域基準）

--- a/packages/pom/src/renderPptx/nodes/tree.ts
+++ b/packages/pom/src/renderPptx/nodes/tree.ts
@@ -6,8 +6,7 @@ import type {
 } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToIn, pxToPt } from "../units.ts";
-import { calcScaleFactor } from "../utils/scaleToFit.ts";
-import { getContentArea } from "../utils/contentArea.ts";
+import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
 
 type TreePositionedNode = Extract<PositionedNode, { type: "tree" }>;
 
@@ -300,14 +299,10 @@ export function renderTreeNode(
   const treeSize = calculateSubtreeSize(node.data);
 
   // スケール係数を計算（コンテンツ領域基準）
-  const content = getContentArea(node);
-  const scaleFactor = calcScaleFactor(
-    content.w,
-    content.h,
-    treeSize.width,
-    treeSize.height,
-    "tree",
-    ctx.buildContext.diagnostics,
+  const { content, scaleFactor } = resolveScaledContentArea(
+    node,
+    treeSize,
+    ctx,
   );
 
   // スケール後のサイズで中央配置オフセットを計算

--- a/packages/pom/src/renderPptx/nodes/tree.ts
+++ b/packages/pom/src/renderPptx/nodes/tree.ts
@@ -5,6 +5,7 @@ import type {
   TreeConnectorStyle,
 } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { stripHash } from "../utils/visualStyle.ts";
 import { pxToIn, pxToPt } from "../units.ts";
 import { resolveScaledContentArea } from "../utils/scaleToFit.ts";
 
@@ -31,7 +32,7 @@ export function renderTreeNode(
   const siblingGap = node.siblingGap ?? 20;
   const connectorStyle = node.connectorStyle ?? {};
   const defaultColor = "1D4ED8";
-  const defaultTextColor = node.textColor?.replace("#", "") ?? "FFFFFF";
+  const defaultTextColor = stripHash(node.textColor) ?? "FFFFFF";
 
   // サブツリーの幅/高さを計算
   function calculateSubtreeSize(item: TreeDataItem): {
@@ -263,7 +264,7 @@ export function renderTreeNode(
       h: pxToIn(drawH),
       fontSize: pxToPt(12 * sf),
       fontFace: "Noto Sans JP",
-      color: layoutNode.item.textColor?.replace("#", "") ?? defaultTextColor,
+      color: stripHash(layoutNode.item.textColor) ?? defaultTextColor,
       align: "center",
       valign: "middle",
     });

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -137,14 +137,12 @@ describe("renderTimelineNode", () => {
 
   it("割り当てが固有サイズの半分未満なら SCALE_BELOW_THRESHOLD を記録して 0.5 にクランプする", async () => {
     const { objects, buildContext } = await renderPage(
-      vstackPage([
-        { type: "timeline", x: 0, y: 0, w: 100, h: 50, items },
-      ]),
+      vstackPage([{ type: "timeline", x: 0, y: 0, w: 100, h: 50, items }]),
     );
 
-    expect(
-      buildContext.diagnostics.items.map((d) => d.code),
-    ).toContain("SCALE_BELOW_THRESHOLD");
+    expect(buildContext.diagnostics.items.map((d) => d.code)).toContain(
+      "SCALE_BELOW_THRESHOLD",
+    );
 
     // nodeRadius 12px が scaleFactor 0.5 でスケールされる
     const ellipse = objects.find((o) => o.shape === "ellipse");

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -1,0 +1,266 @@
+/**
+ * ノード renderer の出力回帰テスト。
+ *
+ * renderPptx に PositionedNode を直接渡し、pptxgenjs 内部の
+ * _slideObjects (描画オブジェクトの位置・スタイル) を検証することで、
+ * renderer 内部のリファクタリングで public な出力挙動が変わっていない
+ * ことを保証する。
+ */
+import { describe, expect, it } from "vitest";
+import { renderPptx } from "./renderPptx.ts";
+import { createBuildContext } from "../buildContext.ts";
+import { pxToIn, pxToPt } from "./units.ts";
+import type { PositionedNode } from "../types.ts";
+
+type SlideObject = {
+  _type: string;
+  shape?: string;
+  options: Record<string, unknown>;
+  text?: unknown;
+};
+
+async function renderPage(page: PositionedNode) {
+  const buildContext = createBuildContext();
+  const pptx = await renderPptx([page], { w: 1280, h: 720 }, buildContext);
+  const slides = (
+    pptx as unknown as { _slides: { _slideObjects: SlideObject[] }[] }
+  )._slides;
+  return { objects: slides[0]._slideObjects, buildContext };
+}
+
+function vstackPage(children: PositionedNode[]): PositionedNode {
+  return { type: "vstack", x: 0, y: 0, w: 1280, h: 720, children };
+}
+
+describe("renderShapeNode", () => {
+  it("padding を除いたコンテンツ領域に inch 変換して描画される", async () => {
+    const { objects } = await renderPage(
+      vstackPage([
+        {
+          type: "shape",
+          shapeType: "rect",
+          x: 96,
+          y: 96,
+          w: 192,
+          h: 96,
+          padding: 24,
+          fill: { color: "FF0000" },
+        },
+      ]),
+    );
+
+    expect(objects).toHaveLength(1);
+    expect(objects[0].shape).toBe("rect");
+    expect(objects[0].options).toMatchObject({
+      x: pxToIn(96 + 24),
+      y: pxToIn(96 + 24),
+      w: pxToIn(192 - 48),
+      h: pxToIn(96 - 48),
+      fill: { color: "FF0000" },
+    });
+  });
+});
+
+describe("renderUlNode", () => {
+  it("padding を除いたコンテンツ領域にテキストが配置される", async () => {
+    const { objects } = await renderPage(
+      vstackPage([
+        {
+          type: "ul",
+          x: 0,
+          y: 480,
+          w: 384,
+          h: 192,
+          padding: { left: 48, top: 24 },
+          fontSize: 24,
+          items: [{ text: "a" }, { text: "b" }],
+        },
+      ]),
+    );
+
+    expect(objects).toHaveLength(1);
+    expect(objects[0]._type).toBe("text");
+    expect(objects[0].options).toMatchObject({
+      x: pxToIn(48),
+      y: pxToIn(480 + 24),
+      w: pxToIn(384 - 48),
+      h: pxToIn(192 - 24),
+      fontSize: pxToPt(24),
+      bullet: true,
+    });
+  });
+});
+
+describe("renderTimelineNode", () => {
+  const items = [
+    { date: "D1", title: "T1" },
+    { date: "D2", title: "T2" },
+  ];
+
+  it("padding 分オフセットしたコンテンツ領域基準で線とノード円を描画する", async () => {
+    // content = (148, 148, 704, 304)。intrinsic (240x128) より大きいため scaleFactor = 1
+    const { objects, buildContext } = await renderPage(
+      vstackPage([
+        {
+          type: "timeline",
+          x: 100,
+          y: 100,
+          w: 800,
+          h: 400,
+          padding: 48,
+          items,
+        },
+      ]),
+    );
+
+    expect(buildContext.diagnostics.items).toEqual([]);
+
+    // メイン線: 端点は labelW/2 = 60 インセット、lineY はコンテンツ領域の垂直中央
+    const lineY = 148 + 304 / 2;
+    expect(objects[0].shape).toBe("line");
+    expect(objects[0].options).toMatchObject({
+      x: pxToIn(148 + 60),
+      y: pxToIn(lineY),
+      w: pxToIn(704 - 120),
+      h: 0,
+    });
+
+    // 最初のアイテムのノード円 (半径 12px)
+    const ellipse = objects.find((o) => o.shape === "ellipse");
+    expect(ellipse?.options).toMatchObject({
+      x: pxToIn(148 + 60 - 12),
+      y: pxToIn(lineY - 12),
+      w: pxToIn(24),
+      h: pxToIn(24),
+    });
+  });
+
+  it("割り当てが固有サイズの半分未満なら SCALE_BELOW_THRESHOLD を記録して 0.5 にクランプする", async () => {
+    const { objects, buildContext } = await renderPage(
+      vstackPage([
+        { type: "timeline", x: 0, y: 0, w: 100, h: 50, items },
+      ]),
+    );
+
+    expect(
+      buildContext.diagnostics.items.map((d) => d.code),
+    ).toContain("SCALE_BELOW_THRESHOLD");
+
+    // nodeRadius 12px が scaleFactor 0.5 でスケールされる
+    const ellipse = objects.find((o) => o.shape === "ellipse");
+    expect(ellipse?.options).toMatchObject({ w: pxToIn(12), h: pxToIn(12) });
+  });
+});
+
+describe("renderPyramidNode", () => {
+  it('"#" 付きの色指定は "#" なしで pptxgenjs に渡される', async () => {
+    const { objects } = await renderPage(
+      vstackPage([
+        {
+          type: "pyramid",
+          x: 100,
+          y: 200,
+          w: 480,
+          h: 200,
+          levels: [
+            { label: "L1", color: "#112233" },
+            { label: "L2", textColor: "#445566" },
+          ],
+        },
+      ]),
+    );
+
+    const shapes = objects.filter((o) => o.shape === "custGeom");
+    expect(shapes[0].options.fill).toEqual({ color: "112233" });
+
+    const labels = objects.filter((o) => o.shape === "rect");
+    expect(labels[1].options.color).toBe("445566");
+  });
+});
+
+describe("renderLineNode / renderArrowNode", () => {
+  it("line: 逆向き座標は左上原点 + flip で表現される", async () => {
+    const { objects } = await renderPage(
+      vstackPage([
+        {
+          type: "line",
+          x: 0,
+          y: 0,
+          w: 0,
+          h: 0,
+          x1: 300,
+          y1: 100,
+          x2: 100,
+          y2: 50,
+          color: "00FF00",
+        },
+      ]),
+    );
+
+    expect(objects[0].shape).toBe("line");
+    expect(objects[0].options).toMatchObject({
+      x: pxToIn(100),
+      y: pxToIn(50),
+      w: pxToIn(200),
+      h: pxToIn(50),
+      flipH: true,
+      flipV: true,
+    });
+    expect(objects[0].options.line).toMatchObject({ color: "00FF00" });
+  });
+
+  it("arrow: 参照ノードの中心同士を結ぶ線を描画する", async () => {
+    const { objects } = await renderPage({
+      type: "layer",
+      x: 0,
+      y: 0,
+      w: 1280,
+      h: 720,
+      children: [
+        {
+          type: "shape",
+          shapeType: "rect",
+          id: "a",
+          x: 50,
+          y: 50,
+          w: 100,
+          h: 100,
+        },
+        {
+          type: "shape",
+          shapeType: "rect",
+          id: "b",
+          x: 250,
+          y: 150,
+          w: 100,
+          h: 100,
+        },
+        {
+          type: "arrow",
+          from: "a",
+          to: "b",
+          x: 0,
+          y: 0,
+          w: 0,
+          h: 0,
+          color: "0000FF",
+          endArrow: true,
+        },
+      ],
+    });
+
+    const line = objects.find((o) => o.shape === "line");
+    expect(line?.options).toMatchObject({
+      x: pxToIn(100),
+      y: pxToIn(100),
+      w: pxToIn(200),
+      h: pxToIn(100),
+      flipH: false,
+      flipV: false,
+    });
+    expect(line?.options.line).toMatchObject({
+      color: "0000FF",
+      endArrowType: "triangle",
+    });
+  });
+});

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -171,8 +171,34 @@ describe("renderPyramidNode", () => {
     const shapes = objects.filter((o) => o.shape === "custGeom");
     expect(shapes[0].options.fill).toEqual({ color: "112233" });
 
-    const labels = objects.filter((o) => o.shape === "rect");
+    // ラベルは text を持つオブジェクト (図形は text: null)
+    const labels = objects.filter((o) => Array.isArray(o.text));
     expect(labels[1].options.color).toBe("445566");
+  });
+});
+
+describe("ルートノードの background + border", () => {
+  it("backgroundColor は slide.background に逃がし、border のみノード全体に fill なしで描画する", async () => {
+    const { objects } = await renderPage({
+      type: "vstack",
+      x: 0,
+      y: 0,
+      w: 1280,
+      h: 720,
+      backgroundColor: "EEEEEE",
+      border: { color: "FF0000", width: 2 },
+      children: [],
+    });
+
+    expect(objects).toHaveLength(1);
+    expect(objects[0].options).toMatchObject({
+      x: 0,
+      y: 0,
+      w: pxToIn(1280),
+      h: pxToIn(720),
+      fill: { type: "none" },
+    });
+    expect(objects[0].options.line).toMatchObject({ color: "FF0000" });
   });
 });
 

--- a/packages/pom/src/renderPptx/renderPptx.ts
+++ b/packages/pom/src/renderPptx/renderPptx.ts
@@ -26,7 +26,7 @@ import type {
 } from "../types.ts";
 import type { BuildContext } from "../buildContext.ts";
 import type { RenderContext, NodeBounds } from "./types.ts";
-import { pxToIn, pxToPt } from "./units.ts";
+import { pxToIn, pxToPt, rectPxToIn } from "./units.ts";
 import { convertUnderline, convertStrike } from "./textOptions.ts";
 import { getImageData } from "../shared/measureImage.ts";
 import { resolveBoxSpacing } from "../shared/boxSpacing.ts";
@@ -322,10 +322,7 @@ export async function renderPptx(
               : ctx.pptx.ShapeType.rect;
             const rectRadius = resolveRectRadius(borderRadius, node.w, node.h);
             ctx.slide.addShape(shapeType, {
-              x: pxToIn(node.x),
-              y: pxToIn(node.y),
-              w: pxToIn(node.w),
-              h: pxToIn(node.h),
+              ...rectPxToIn(node),
               fill: { type: "none" },
               line,
               rectRadius,

--- a/packages/pom/src/renderPptx/textOptions.ts
+++ b/packages/pom/src/renderPptx/textOptions.ts
@@ -1,6 +1,6 @@
 import type { PositionedNode, Underline, UnderlineStyle } from "../types.ts";
-import { pxToIn, pxToPt } from "./units.ts";
-import { getContentArea } from "./utils/contentArea.ts";
+import { pxToPt } from "./units.ts";
+import { getContentAreaIn } from "./utils/contentArea.ts";
 
 type TextNode = Extract<PositionedNode, { type: "text" }>;
 
@@ -33,13 +33,9 @@ export function createTextOptions(node: TextNode) {
   const fontSizePx = node.fontSize ?? 24;
   const fontFamily = node.fontFamily ?? "Noto Sans JP";
   const lineHeight = node.lineHeight ?? 1.3;
-  const content = getContentArea(node);
 
   return {
-    x: pxToIn(content.x),
-    y: pxToIn(content.y),
-    w: pxToIn(content.w),
-    h: pxToIn(content.h),
+    ...getContentAreaIn(node),
     fontSize: pxToPt(fontSizePx),
     fontFace: fontFamily,
     align: node.textAlign ?? "left",

--- a/packages/pom/src/renderPptx/types.ts
+++ b/packages/pom/src/renderPptx/types.ts
@@ -6,9 +6,34 @@ export type PptxInstance = PptxGenJSClass;
 
 export type NodeBounds = { x: number; y: number; w: number; h: number };
 
+/**
+ * ノード renderer が共有する描画コンテキスト。
+ *
+ * renderer は `(node, ctx) => void` のシグネチャ (registry/types.ts の
+ * NodeDefinition.render) で registry に登録され、この context 経由で
+ * pptxgenjs と build 全体の状態にアクセスする。
+ *
+ * renderer 共通処理と helper の責務マップ:
+ * - 単位変換 (px → inch / pt): units.ts (pxToIn / pxToPt / rectPxToIn)
+ * - padding 解決済みコンテンツ領域: utils/contentArea.ts
+ *   (getContentArea / getContentAreaIn / withContentBounds)
+ * - scaleToFit 系 diagram の前処理 (コンテンツ領域 + スケール係数):
+ *   utils/scaleToFit.ts (resolveScaledContentArea)
+ * - 見た目属性 → pptxgenjs オプションの純粋変換: utils/visualStyle.ts
+ *   (fill / border / shadow / borderRadius / stripHash)
+ * - 背景色・背景画像・ボーダーの描画順序: utils/backgroundBorder.ts
+ *   (renderer の手前で renderPptx 本体から呼ばれる)
+ * - 2 点間直線の描画 (Line / Arrow): utils/straightLine.ts (addStraightLine)
+ * - テキスト系属性の変換: textOptions.ts
+ *   (createTextOptions / convertUnderline / convertStrike)
+ */
 export type RenderContext = {
+  /** 描画先のスライド */
   slide: SlideInstance;
+  /** ShapeType 等の定数参照に使う pptxgenjs インスタンス */
   pptx: PptxInstance;
+  /** diagnostics や画像・グラデーションのキャッシュなど build 全体の状態 */
   buildContext: BuildContext;
+  /** Arrow の from/to 参照解決に使う id → 絶対座標マップ */
   idPositionMap: Map<string, NodeBounds>;
 };

--- a/packages/pom/src/renderPptx/units.ts
+++ b/packages/pom/src/renderPptx/units.ts
@@ -3,3 +3,19 @@ export const PX_PER_IN = 96;
 export const pxToIn = (px: number) => px / PX_PER_IN;
 
 export const pxToPt = (px: number) => (px * 72) / PX_PER_IN;
+
+/**
+ * px 単位の矩形を pptxgenjs の位置オプション (inch 単位の x/y/w/h) に
+ * まとめて変換する。addShape / addText 等のオプションへ spread して使う。
+ */
+export const rectPxToIn = (rect: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}) => ({
+  x: pxToIn(rect.x),
+  y: pxToIn(rect.y),
+  w: pxToIn(rect.w),
+  h: pxToIn(rect.h),
+});

--- a/packages/pom/src/renderPptx/utils/backgroundBorder.ts
+++ b/packages/pom/src/renderPptx/utils/backgroundBorder.ts
@@ -2,7 +2,7 @@ import type { PositionedNode } from "../../types.ts";
 import { getImageData } from "../../shared/measureImage.ts";
 import { registerBackgroundGradient } from "../gradientFills.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn } from "../units.ts";
+import { pxToIn, rectPxToIn } from "../units.ts";
 import {
   convertShadow,
   convertBorderLine,
@@ -68,10 +68,7 @@ export function renderBackgroundAndBorder(
       : { type: "none" as const };
 
     ctx.slide.addShape(shapeType, {
-      x: pxToIn(node.x),
-      y: pxToIn(node.y),
-      w: pxToIn(node.w),
-      h: pxToIn(node.h),
+      ...rectPxToIn(node),
       fill,
       line,
       rectRadius,
@@ -85,10 +82,7 @@ export function renderBackgroundAndBorder(
   // 1. 背景色
   if (hasBackground) {
     ctx.slide.addShape(shapeType, {
-      x: pxToIn(node.x),
-      y: pxToIn(node.y),
-      w: pxToIn(node.w),
-      h: pxToIn(node.h),
+      ...rectPxToIn(node),
       fill: resolveBackgroundFill(
         backgroundColor,
         node.opacity,
@@ -103,10 +97,7 @@ export function renderBackgroundAndBorder(
   if (backgroundImage) {
     const sizing = backgroundImage.sizing ?? "cover";
     const imageOptions: Record<string, unknown> = {
-      x: pxToIn(node.x),
-      y: pxToIn(node.y),
-      w: pxToIn(node.w),
-      h: pxToIn(node.h),
+      ...rectPxToIn(node),
       sizing: {
         type: sizing,
         w: pxToIn(node.w),
@@ -128,10 +119,7 @@ export function renderBackgroundAndBorder(
   // 3. ボーダー
   if (hasBorder || hasShadow) {
     ctx.slide.addShape(shapeType, {
-      x: pxToIn(node.x),
-      y: pxToIn(node.y),
-      w: pxToIn(node.w),
-      h: pxToIn(node.h),
+      ...rectPxToIn(node),
       fill: { type: "none" as const },
       line: hasBorder
         ? convertBorderLine(border, "000000")

--- a/packages/pom/src/renderPptx/utils/contentArea.test.ts
+++ b/packages/pom/src/renderPptx/utils/contentArea.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { getContentArea, getContentAreaIn } from "./contentArea.ts";
+import { rectPxToIn } from "../units.ts";
+
+describe("getContentArea", () => {
+  it("padding 未指定ならノード領域をそのまま返す", () => {
+    expect(getContentArea({ x: 10, y: 20, w: 100, h: 50 })).toEqual({
+      x: 10,
+      y: 20,
+      w: 100,
+      h: 50,
+    });
+  });
+
+  it("number padding は 4 辺均等に差し引かれる", () => {
+    expect(getContentArea({ x: 10, y: 20, w: 100, h: 50, padding: 8 })).toEqual(
+      { x: 18, y: 28, w: 84, h: 34 },
+    );
+  });
+
+  it("object padding は指定 edge のみ差し引かれる", () => {
+    expect(
+      getContentArea({
+        x: 0,
+        y: 0,
+        w: 100,
+        h: 50,
+        padding: { left: 10, top: 4 },
+      }),
+    ).toEqual({ x: 10, y: 4, w: 90, h: 46 });
+  });
+
+  it("padding が大きすぎる場合は幅・高さを 0 にクランプする", () => {
+    expect(getContentArea({ x: 0, y: 0, w: 10, h: 10, padding: 20 })).toEqual({
+      x: 20,
+      y: 20,
+      w: 0,
+      h: 0,
+    });
+  });
+});
+
+describe("rectPxToIn", () => {
+  it("矩形の x/y/w/h を px から inch に変換する", () => {
+    expect(rectPxToIn({ x: 96, y: 48, w: 192, h: 144 })).toEqual({
+      x: 1,
+      y: 0.5,
+      w: 2,
+      h: 1.5,
+    });
+  });
+});
+
+describe("getContentAreaIn", () => {
+  it("padding を除いたコンテンツ領域を inch で返す", () => {
+    expect(
+      getContentAreaIn({ x: 96, y: 96, w: 192, h: 96, padding: 48 }),
+    ).toEqual({ x: 1.5, y: 1.5, w: 1, h: 0 });
+  });
+});

--- a/packages/pom/src/renderPptx/utils/contentArea.ts
+++ b/packages/pom/src/renderPptx/utils/contentArea.ts
@@ -44,7 +44,7 @@ export function getContentArea(node: {
  */
 export function getContentAreaIn(
   node: Parameters<typeof getContentArea>[0],
-): ContentArea {
+): ReturnType<typeof rectPxToIn> {
   return rectPxToIn(getContentArea(node));
 }
 

--- a/packages/pom/src/renderPptx/utils/contentArea.ts
+++ b/packages/pom/src/renderPptx/utils/contentArea.ts
@@ -2,6 +2,7 @@ import {
   resolveBoxSpacing,
   type BoxSpacingInput,
 } from "../../shared/boxSpacing.ts";
+import { rectPxToIn } from "../units.ts";
 
 interface ContentArea {
   x: number;
@@ -34,4 +35,15 @@ export function getContentArea(node: {
     w: Math.max(0, node.w - left - right),
     h: Math.max(0, node.h - top - bottom),
   };
+}
+
+/**
+ * コンテンツ描画領域を pptxgenjs の位置オプション (inch 単位の x/y/w/h)
+ * として返す。コンテンツを領域いっぱいに描画する renderer はこれを
+ * addShape / addText 等のオプションへ spread するだけでよい。
+ */
+export function getContentAreaIn(
+  node: Parameters<typeof getContentArea>[0],
+): ContentArea {
+  return rectPxToIn(getContentArea(node));
 }

--- a/packages/pom/src/renderPptx/utils/contentArea.ts
+++ b/packages/pom/src/renderPptx/utils/contentArea.ts
@@ -47,3 +47,14 @@ export function getContentAreaIn(
 ): ContentArea {
   return rectPxToIn(getContentArea(node));
 }
+
+/**
+ * ノードの x/y/w/h を指定領域 (通常はコンテンツ領域) で置き換えた
+ * 仮想ノードを返す。padding を解決済みの領域を基準に下位の描画関数へ
+ * ノードを渡すために使う。
+ */
+export function withContentBounds<
+  T extends { x: number; y: number; w: number; h: number },
+>(node: T, bounds: ContentArea): T {
+  return { ...node, x: bounds.x, y: bounds.y, w: bounds.w, h: bounds.h };
+}

--- a/packages/pom/src/renderPptx/utils/scaleToFit.test.ts
+++ b/packages/pom/src/renderPptx/utils/scaleToFit.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { calcScaleFactor } from "./scaleToFit.ts";
+import { calcScaleFactor, resolveScaledContentArea } from "./scaleToFit.ts";
 import { DiagnosticCollector } from "../../diagnostics.ts";
+import { createBuildContext } from "../../buildContext.ts";
+import type { RenderContext } from "../types.ts";
 
 describe("calcScaleFactor", () => {
   it("割り当てサイズ >= 固有サイズの場合、1.0を返す", () => {
@@ -46,5 +48,39 @@ describe("calcScaleFactor", () => {
   it("固有サイズが負の場合、1.0を返す", () => {
     const d = new DiagnosticCollector();
     expect(calcScaleFactor(100, 100, -10, 50, "tree", d)).toBe(1.0);
+  });
+});
+
+describe("resolveScaledContentArea", () => {
+  function makeCtx() {
+    const buildContext = createBuildContext();
+    // resolveScaledContentArea は buildContext.diagnostics のみ参照する
+    return { ctx: { buildContext } as RenderContext, buildContext };
+  }
+
+  it("padding を除いたコンテンツ領域基準でスケール係数を解決する", () => {
+    const { ctx, buildContext } = makeCtx();
+    const { content, scaleFactor } = resolveScaledContentArea(
+      { type: "tree", x: 0, y: 0, w: 300, h: 200, padding: 50 },
+      { width: 100, height: 100 },
+      ctx,
+    );
+    expect(content).toEqual({ x: 50, y: 50, w: 200, h: 100 });
+    expect(scaleFactor).toBe(1.0);
+    expect(buildContext.diagnostics.items).toEqual([]);
+  });
+
+  it("クランプ時の diagnostics には node.type がラベルとして使われる", () => {
+    const { ctx, buildContext } = makeCtx();
+    const { scaleFactor } = resolveScaledContentArea(
+      { type: "timeline", x: 0, y: 0, w: 100, h: 100 },
+      { width: 400, height: 200 },
+      ctx,
+    );
+    expect(scaleFactor).toBe(0.5);
+    expect(buildContext.diagnostics.items[0].code).toBe(
+      "SCALE_BELOW_THRESHOLD",
+    );
+    expect(buildContext.diagnostics.items[0].message).toContain("timeline");
   });
 });

--- a/packages/pom/src/renderPptx/utils/scaleToFit.ts
+++ b/packages/pom/src/renderPptx/utils/scaleToFit.ts
@@ -1,4 +1,6 @@
 import type { DiagnosticCollector } from "../../diagnostics.ts";
+import type { RenderContext } from "../types.ts";
+import { getContentArea } from "./contentArea.ts";
 
 const MIN_SCALE_THRESHOLD = 0.5;
 
@@ -31,4 +33,29 @@ export function calcScaleFactor(
   }
 
   return scaleFactor;
+}
+
+/**
+ * scaleToFit 系 diagram renderer (timeline / matrix / flow / processArrow /
+ * pyramid / tree) の共通前処理。padding を除いたコンテンツ領域と、
+ * 固有サイズに対するスケール係数をまとめて解決する。
+ *
+ * diagnostics のラベルには node.type を使うため、renderer ごとに
+ * ノードタイプ文字列を手書きする必要がない。
+ */
+export function resolveScaledContentArea(
+  node: Parameters<typeof getContentArea>[0] & { type: string },
+  intrinsic: { width: number; height: number },
+  ctx: RenderContext,
+): { content: ReturnType<typeof getContentArea>; scaleFactor: number } {
+  const content = getContentArea(node);
+  const scaleFactor = calcScaleFactor(
+    content.w,
+    content.h,
+    intrinsic.width,
+    intrinsic.height,
+    node.type,
+    ctx.buildContext.diagnostics,
+  );
+  return { content, scaleFactor };
 }

--- a/packages/pom/src/renderPptx/utils/straightLine.ts
+++ b/packages/pom/src/renderPptx/utils/straightLine.ts
@@ -1,0 +1,71 @@
+/**
+ * 2 点間の直線を pptxgenjs の line shape に変換する共通描画処理。
+ *
+ * pptxgenjs の line shape は左上座標 (x, y) + サイズ (w, h) で表現され、
+ * 線の向き (始点→終点) は flipH / flipV で表すため、端点座標からの
+ * 変換ロジックを Line / Arrow ノードで共有する。
+ */
+import type { LineArrow, LineNode } from "../../types.ts";
+import type { RenderContext } from "../types.ts";
+import { pxToIn, pxToPt } from "../units.ts";
+
+/**
+ * boolean | LineArrowOptions から pptxgenjs の arrow type を取得
+ */
+export function resolveArrowType(
+  arrow: LineArrow | undefined,
+): "none" | "arrow" | "diamond" | "oval" | "stealth" | "triangle" | undefined {
+  if (arrow === undefined) {
+    return undefined;
+  }
+  if (arrow === false) {
+    return "none";
+  }
+  if (arrow === true) {
+    return "triangle"; // デフォルト
+  }
+  return arrow.type ?? "triangle";
+}
+
+type StraightLinePoints = { x1: number; y1: number; x2: number; y2: number };
+
+type StraightLineStyle = Pick<
+  LineNode,
+  "color" | "lineWidth" | "dashType" | "beginArrow" | "endArrow"
+>;
+
+/**
+ * 始点 (x1, y1) から終点 (x2, y2) への直線を描画する
+ */
+export function addStraightLine(
+  ctx: RenderContext,
+  { x1, y1, x2, y2 }: StraightLinePoints,
+  { color, lineWidth, dashType, beginArrow, endArrow }: StraightLineStyle,
+): void {
+  const minX = Math.min(x1, x2);
+  const minY = Math.min(y1, y2);
+  const lineW = Math.abs(x2 - x1);
+  const lineH = Math.abs(y2 - y1);
+
+  // 線の方向を判定して flip を決定
+  // flipH: 右から左へ向かう線
+  // flipV: 下から上へ向かう線
+  const flipH = x2 < x1;
+  const flipV = y2 < y1;
+
+  ctx.slide.addShape(ctx.pptx.ShapeType.line, {
+    x: pxToIn(minX),
+    y: pxToIn(minY),
+    w: pxToIn(lineW),
+    h: pxToIn(lineH),
+    flipH,
+    flipV,
+    line: {
+      color: color ?? "000000",
+      width: lineWidth !== undefined ? pxToPt(lineWidth) : 1,
+      dashType,
+      beginArrowType: resolveArrowType(beginArrow),
+      endArrowType: resolveArrowType(endArrow),
+    },
+  });
+}

--- a/packages/pom/src/renderPptx/utils/visualStyle.test.ts
+++ b/packages/pom/src/renderPptx/utils/visualStyle.test.ts
@@ -6,7 +6,22 @@ import {
   opacityToTransparency,
   resolveBackgroundFill,
   resolveRectRadius,
+  stripHash,
 } from "./visualStyle.ts";
+
+describe("stripHash", () => {
+  it('"#" prefix を取り除く', () => {
+    expect(stripHash("#FF0000")).toBe("FF0000");
+  });
+
+  it('"#" なしの色はそのまま返す', () => {
+    expect(stripHash("FF0000")).toBe("FF0000");
+  });
+
+  it("undefined はそのまま undefined を返す", () => {
+    expect(stripHash(undefined)).toBeUndefined();
+  });
+});
 
 describe("convertShadow", () => {
   it("undefined はそのまま undefined を返す", () => {

--- a/packages/pom/src/renderPptx/utils/visualStyle.ts
+++ b/packages/pom/src/renderPptx/utils/visualStyle.ts
@@ -24,7 +24,7 @@ import type { BorderStyle, ShadowStyle } from "../../types.ts";
 import { pxToPt } from "../units.ts";
 
 /**
- * 色指定の "#" prefix を取り除き、pptxgenjs が受け付ける HEX 文字列にする。
+ * 色文字列から "#" を 1 つ取り除き、pptxgenjs が受け付ける HEX 文字列にする。
  * undefined はそのまま返すため `stripHash(color) ?? fallback` の形で使える。
  */
 export function stripHash(color: string | undefined): string | undefined {

--- a/packages/pom/src/renderPptx/utils/visualStyle.ts
+++ b/packages/pom/src/renderPptx/utils/visualStyle.ts
@@ -24,6 +24,14 @@ import type { BorderStyle, ShadowStyle } from "../../types.ts";
 import { pxToPt } from "../units.ts";
 
 /**
+ * 色指定の "#" prefix を取り除き、pptxgenjs が受け付ける HEX 文字列にする。
+ * undefined はそのまま返すため `stripHash(color) ?? fallback` の形で使える。
+ */
+export function stripHash(color: string | undefined): string | undefined {
+  return color?.replace("#", "");
+}
+
+/**
  * ShadowStyle を pptxgenjs の shadow オプションに変換する
  * type 未指定時は outer をデフォルトとする
  */


### PR DESCRIPTION
close #809

## 目的

`renderPptx/nodes/*` のノード別 renderer に分散していた重複処理を共通 helper に寄せ、renderer が共有する context / helper の責務を明確にする。親 issue #807 の段階的共通化の一環。

## 変更内容

### 共通化した重複（4 種類）

| helper | 配置 | 置き換え対象 |
| --- | --- | --- |
| `rectPxToIn` / `getContentAreaIn` | `units.ts` / `utils/contentArea.ts` | px 矩形 → inch の x/y/w/h 変換 4 行が 9 ファイルで反復していた箇所 |
| `resolveScaledContentArea` / `withContentBounds` | `utils/scaleToFit.ts` / `utils/contentArea.ts` | timeline / matrix / flow / processArrow / pyramid / tree の「コンテンツ領域 + calcScaleFactor + ノードタイプ文字列手書き + 仮想 contentNode 生成」前処理 |
| `stripHash` | `utils/visualStyle.ts` | 6 renderer に散在していた `?.replace("#", "")` 17 箇所 |
| `addStraightLine` | `utils/straightLine.ts` | line / arrow でほぼ同一だった端点座標 → pptxgenjs line shape (左上座標 + flipH/flipV) 変換 |

### 責務の明確化

- `renderPptx/types.ts` の `RenderContext` に各フィールドの doc comment と、units / contentArea / scaleToFit / visualStyle / backgroundBorder / straightLine / textOptions 各 helper の責務マップを記載

### 出力挙動の回帰保護

- refactor **前**に回帰テスト `renderPptx.renderers.test.ts` を追加（pptxgenjs 内部の `_slideObjects` の位置・色・flip を検証）し、refactor 後も green であることを確認
- 新 helper の unit test を `contentArea.test.ts` / `scaleToFit.test.ts` / `visualStyle.test.ts` に追加

## スコープ外（issue 通り）

- 全 renderer の handler class 化
- pptxgenjs 依存の抽象化

## 影響パッケージ

- `packages/pom` のみ（`renderPptx/` 配下に閉じた internal refactor。public API への変更なし）

## ローカル検証手順

```bash
cd packages/pom
pnpm run lint && pnpm run typecheck && pnpm run test:run
```

- 全 22 ファイル 443 テスト pass（回帰テスト 8 件 + helper unit test 14 件を含む）
- cross-review (codex backend, 3 分割) 実施済み: critical 0 / warning 1 / info 3 → すべて追加 commit で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)
