### PR TITLE
feat(pom): AutoFit strategy の共通 result 型を整備する

### DIFF
--- a/packages/pom/src/autoFit/autoFit.test.ts
+++ b/packages/pom/src/autoFit/autoFit.test.ts
@@ -88,7 +88,7 @@ describe("reduceTableRowHeight", () => {
     expect(result).toEqual({ changed: false, reason: "no-target" });
   });
 
-  it("すべて下限値の場合は already-at-minimum を返す", () => {
+  it("すべて下限値の場合は no-effective-change を返す", () => {
     const node: POMNode = {
       type: "table",
       columns: [{}],
@@ -96,7 +96,7 @@ describe("reduceTableRowHeight", () => {
       defaultRowHeight: 20,
     };
     const result = reduceTableRowHeight(node, 0.5);
-    expect(result).toEqual({ changed: false, reason: "already-at-minimum" });
+    expect(result).toEqual({ changed: false, reason: "no-effective-change" });
     expect(node.defaultRowHeight).toBe(20);
   });
 });
@@ -145,11 +145,19 @@ describe("reduceFontSize", () => {
     expect(result).toEqual({ changed: false, reason: "no-target" });
   });
 
-  it("すべて下限値の場合は already-at-minimum を返す", () => {
+  it("すべて下限値の場合は no-effective-change を返す", () => {
     const node: POMNode = { type: "text", text: "hello", fontSize: 10 };
     const result = reduceFontSize(node, 0.6);
-    expect(result).toEqual({ changed: false, reason: "already-at-minimum" });
+    expect(result).toEqual({ changed: false, reason: "no-effective-change" });
     expect(node.fontSize).toBe(10);
+  });
+
+  it("丸めにより値が変化しない場合も no-effective-change を返す", () => {
+    // Math.round(21 * 0.99) === 21: 下限未到達でも値が変化しない
+    const node: POMNode = { type: "text", text: "hello", fontSize: 21 };
+    const result = reduceFontSize(node, 0.99);
+    expect(result).toEqual({ changed: false, reason: "no-effective-change" });
+    expect(node.fontSize).toBe(21);
   });
 });
 

--- a/packages/pom/src/autoFit/autoFit.test.ts
+++ b/packages/pom/src/autoFit/autoFit.test.ts
@@ -55,8 +55,8 @@ describe("reduceTableRowHeight", () => {
       rows: [{ cells: [{ text: "a" }] }],
       defaultRowHeight: 40,
     };
-    const changed = reduceTableRowHeight(node, 0.7);
-    expect(changed).toBe(true);
+    const result = reduceTableRowHeight(node, 0.7);
+    expect(result.changed).toBe(true);
     expect(node.defaultRowHeight).toBe(28);
   });
 
@@ -66,8 +66,8 @@ describe("reduceTableRowHeight", () => {
       columns: [{}],
       rows: [{ cells: [{ text: "a" }], height: 50 }],
     };
-    const changed = reduceTableRowHeight(node, 0.8);
-    expect(changed).toBe(true);
+    const result = reduceTableRowHeight(node, 0.8);
+    expect(result.changed).toBe(true);
     expect(node.rows[0].height).toBe(40);
   });
 
@@ -82,10 +82,22 @@ describe("reduceTableRowHeight", () => {
     expect(node.defaultRowHeight).toBe(20);
   });
 
-  it("テーブルがない場合は false を返す", () => {
+  it("テーブルがない場合は no-target を返す", () => {
     const node: POMNode = { type: "text", text: "hello" };
-    const changed = reduceTableRowHeight(node, 0.7);
-    expect(changed).toBe(false);
+    const result = reduceTableRowHeight(node, 0.7);
+    expect(result).toEqual({ changed: false, reason: "no-target" });
+  });
+
+  it("すべて下限値の場合は already-at-minimum を返す", () => {
+    const node: POMNode = {
+      type: "table",
+      columns: [{}],
+      rows: [{ cells: [{ text: "a" }] }],
+      defaultRowHeight: 20,
+    };
+    const result = reduceTableRowHeight(node, 0.5);
+    expect(result).toEqual({ changed: false, reason: "already-at-minimum" });
+    expect(node.defaultRowHeight).toBe(20);
   });
 });
 
@@ -93,8 +105,8 @@ describe("reduceTableRowHeight", () => {
 describe("reduceFontSize", () => {
   it("テキストの fontSize を縮小する", () => {
     const node: POMNode = { type: "text", text: "hello", fontSize: 24 };
-    const changed = reduceFontSize(node, 0.8);
-    expect(changed).toBe(true);
+    const result = reduceFontSize(node, 0.8);
+    expect(result.changed).toBe(true);
     expect(node.fontSize).toBe(19);
   });
 
@@ -110,8 +122,8 @@ describe("reduceFontSize", () => {
       items: [{ text: "item", fontSize: 20 }],
       fontSize: 20,
     };
-    const changed = reduceFontSize(node, 0.8);
-    expect(changed).toBe(true);
+    const result = reduceFontSize(node, 0.8);
+    expect(result.changed).toBe(true);
     expect(node.items[0].fontSize).toBe(16);
     expect(node.fontSize).toBe(16);
   });
@@ -122,15 +134,22 @@ describe("reduceFontSize", () => {
       columns: [{}],
       rows: [{ cells: [{ text: "a", fontSize: 14 }] }],
     };
-    const changed = reduceFontSize(node, 0.8);
-    expect(changed).toBe(true);
+    const result = reduceFontSize(node, 0.8);
+    expect(result.changed).toBe(true);
     expect(node.rows[0].cells[0].fontSize).toBe(11);
   });
 
-  it("fontSize が未設定のノードは変更しない", () => {
+  it("fontSize が未設定のノードは no-target を返す", () => {
     const node: POMNode = { type: "text", text: "hello" };
-    const changed = reduceFontSize(node, 0.8);
-    expect(changed).toBe(false);
+    const result = reduceFontSize(node, 0.8);
+    expect(result).toEqual({ changed: false, reason: "no-target" });
+  });
+
+  it("すべて下限値の場合は already-at-minimum を返す", () => {
+    const node: POMNode = { type: "text", text: "hello", fontSize: 10 };
+    const result = reduceFontSize(node, 0.6);
+    expect(result).toEqual({ changed: false, reason: "already-at-minimum" });
+    expect(node.fontSize).toBe(10);
   });
 });
 
@@ -142,8 +161,8 @@ describe("reduceGapAndPadding", () => {
       children: [{ type: "text", text: "a" }],
       gap: 16,
     };
-    const changed = reduceGapAndPadding(node, 0.7);
-    expect(changed).toBe(true);
+    const result = reduceGapAndPadding(node, 0.7);
+    expect(result.changed).toBe(true);
     expect(node.gap).toBe(11);
   });
 
@@ -178,6 +197,15 @@ describe("reduceGapAndPadding", () => {
     expect(node.gap).toBe(2);
     expect(node.padding).toBe(2);
   });
+
+  it("gap も padding もない場合は no-target を返す", () => {
+    const node: POMNode = {
+      type: "vstack",
+      children: [{ type: "text", text: "a" }],
+    };
+    const result = reduceGapAndPadding(node, 0.7);
+    expect(result).toEqual({ changed: false, reason: "no-target" });
+  });
 });
 
 // ===== uniformScale =====
@@ -189,8 +217,8 @@ describe("uniformScale", () => {
       gap: 10,
       padding: 16,
     };
-    const changed = uniformScale(node, 0.7);
-    expect(changed).toBe(true);
+    const result = uniformScale(node, 0.7);
+    expect(result.changed).toBe(true);
     expect(node.gap).toBe(7);
     expect(node.padding).toBe(11);
     const text = node.children[0];
@@ -230,8 +258,8 @@ describe("uniformScale", () => {
       name: "star",
       size: 48,
     };
-    const changed = uniformScale(node, 0.7);
-    expect(changed).toBe(true);
+    const result = uniformScale(node, 0.7);
+    expect(result.changed).toBe(true);
     expect(node.size).toBe(34);
   });
 });

--- a/packages/pom/src/autoFit/autoFit.ts
+++ b/packages/pom/src/autoFit/autoFit.ts
@@ -7,11 +7,12 @@ import { reduceTableRowHeight } from "./strategies/reduceTableRowHeight.ts";
 import { reduceFontSize } from "./strategies/reduceFontSize.ts";
 import { reduceGapAndPadding } from "./strategies/reduceGapAndPadding.ts";
 import { uniformScale } from "./strategies/uniformScale.ts";
+import type { AutoFitStrategyResult } from "./strategyResult.ts";
 
 /** オーバーフロー判定の許容マージン（0.5%） */
 const OVERFLOW_TOLERANCE = 1.005;
 
-type Strategy = (node: POMNode, targetRatio: number) => boolean;
+type Strategy = (node: POMNode, targetRatio: number) => AutoFitStrategyResult;
 
 const strategies: Strategy[] = [
   reduceTableRowHeight,
@@ -100,8 +101,8 @@ export async function autoFitSlide(
       break;
     }
 
-    const changed = strategy(node, result.targetRatio);
-    if (!changed) {
+    const strategyResult = strategy(node, result.targetRatio);
+    if (!strategyResult.changed) {
       continue;
     }
   }

--- a/packages/pom/src/autoFit/strategies/reduceFontSize.ts
+++ b/packages/pom/src/autoFit/strategies/reduceFontSize.ts
@@ -1,5 +1,7 @@
 import type { POMNode } from "../../types.ts";
 import { walkPOMTree } from "../../shared/walkTree.ts";
+import type { AutoFitStrategyResult } from "../strategyResult.ts";
+import { toStrategyResult } from "../strategyResult.ts";
 
 const MIN_FONT_SIZE = 10;
 const MIN_SCALE = 0.6;
@@ -7,11 +9,14 @@ const MIN_SCALE = 0.6;
 /**
  * テキスト系ノードの fontSize を縮小する。
  * 対象: text, ul, ol, shape
- * @returns 変更があった場合 true
  */
-export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
+export function reduceFontSize(
+  node: POMNode,
+  targetRatio: number,
+): AutoFitStrategyResult {
   const ratio = Math.max(targetRatio, MIN_SCALE);
   let changed = false;
+  let sawTarget = false;
 
   walkPOMTree(node, (n) => {
     if (
@@ -21,6 +26,7 @@ export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
       n.type === "ol"
     ) {
       if (n.fontSize !== undefined) {
+        sawTarget = true;
         const newSize = Math.max(MIN_FONT_SIZE, Math.round(n.fontSize * ratio));
         if (newSize !== n.fontSize) {
           n.fontSize = newSize;
@@ -33,6 +39,7 @@ export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
     if (n.type === "ul" || n.type === "ol") {
       for (const item of n.items) {
         if (item.fontSize !== undefined) {
+          sawTarget = true;
           const newSize = Math.max(
             MIN_FONT_SIZE,
             Math.round(item.fontSize * ratio),
@@ -50,6 +57,7 @@ export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
       for (const row of n.rows) {
         for (const cell of row.cells) {
           if (cell.fontSize !== undefined) {
+            sawTarget = true;
             const newSize = Math.max(
               MIN_FONT_SIZE,
               Math.round(cell.fontSize * ratio),
@@ -64,5 +72,5 @@ export function reduceFontSize(node: POMNode, targetRatio: number): boolean {
     }
   });
 
-  return changed;
+  return toStrategyResult({ changed, sawTarget });
 }

--- a/packages/pom/src/autoFit/strategies/reduceGapAndPadding.ts
+++ b/packages/pom/src/autoFit/strategies/reduceGapAndPadding.ts
@@ -1,6 +1,8 @@
 import type { POMNode } from "../../types.ts";
 import { walkPOMTree } from "../../shared/walkTree.ts";
 import { mapBoxSpacing } from "../../shared/boxSpacing.ts";
+import type { AutoFitStrategyResult } from "../strategyResult.ts";
+import { toStrategyResult } from "../strategyResult.ts";
 
 const MIN_GAP = 2;
 const MIN_PADDING = 2;
@@ -8,18 +10,19 @@ const MIN_SCALE = 0.25;
 
 /**
  * gap と padding を縮小する。
- * @returns 変更があった場合 true
  */
 export function reduceGapAndPadding(
   node: POMNode,
   targetRatio: number,
-): boolean {
+): AutoFitStrategyResult {
   const ratio = Math.max(targetRatio, MIN_SCALE);
   let changed = false;
+  let sawTarget = false;
 
   walkPOMTree(node, (n) => {
     // gap の縮小（vstack, hstack）
     if ((n.type === "vstack" || n.type === "hstack") && n.gap !== undefined) {
+      sawTarget = true;
       const newGap = Math.max(MIN_GAP, Math.round(n.gap * ratio));
       if (newGap !== n.gap) {
         n.gap = newGap;
@@ -29,6 +32,7 @@ export function reduceGapAndPadding(
 
     // padding の縮小
     if (n.padding !== undefined) {
+      sawTarget = true;
       const result = mapBoxSpacing(n.padding, (v) =>
         Math.max(MIN_PADDING, Math.round(v * ratio)),
       );
@@ -39,5 +43,5 @@ export function reduceGapAndPadding(
     }
   });
 
-  return changed;
+  return toStrategyResult({ changed, sawTarget });
 }

--- a/packages/pom/src/autoFit/strategies/reduceTableRowHeight.ts
+++ b/packages/pom/src/autoFit/strategies/reduceTableRowHeight.ts
@@ -1,24 +1,27 @@
 import type { POMNode } from "../../types.ts";
 import { walkPOMTree } from "../../shared/walkTree.ts";
+import type { AutoFitStrategyResult } from "../strategyResult.ts";
+import { toStrategyResult } from "../strategyResult.ts";
 
 const MIN_ROW_HEIGHT = 20;
 const MIN_SCALE = 0.5;
 
 /**
  * テーブルの defaultRowHeight と各行の height を縮小する。
- * @returns 変更があった場合 true
  */
 export function reduceTableRowHeight(
   node: POMNode,
   targetRatio: number,
-): boolean {
+): AutoFitStrategyResult {
   const ratio = Math.max(targetRatio, MIN_SCALE);
   let changed = false;
+  let sawTarget = false;
 
   walkPOMTree(node, (n) => {
     if (n.type !== "table") return;
 
     if (n.defaultRowHeight !== undefined) {
+      sawTarget = true;
       const newHeight = Math.max(
         MIN_ROW_HEIGHT,
         Math.round(n.defaultRowHeight * ratio),
@@ -31,6 +34,7 @@ export function reduceTableRowHeight(
 
     for (const row of n.rows) {
       if (row.height !== undefined) {
+        sawTarget = true;
         const newHeight = Math.max(
           MIN_ROW_HEIGHT,
           Math.round(row.height * ratio),
@@ -43,5 +47,5 @@ export function reduceTableRowHeight(
     }
   });
 
-  return changed;
+  return toStrategyResult({ changed, sawTarget });
 }

--- a/packages/pom/src/autoFit/strategies/uniformScale.ts
+++ b/packages/pom/src/autoFit/strategies/uniformScale.ts
@@ -1,6 +1,8 @@
 import type { POMNode } from "../../types.ts";
 import { walkPOMTree } from "../../shared/walkTree.ts";
 import { mapBoxSpacing } from "../../shared/boxSpacing.ts";
+import type { AutoFitStrategyResult } from "../strategyResult.ts";
+import { toStrategyResult } from "../strategyResult.ts";
 
 const MIN_SCALE = 0.5;
 
@@ -10,15 +12,19 @@ function scaleNumber(value: number, ratio: number, min: number): number {
 
 /**
  * 全サイズ関連プロパティを一律スケーリングする（フォールバック）。
- * @returns 変更があった場合 true
  */
-export function uniformScale(node: POMNode, targetRatio: number): boolean {
+export function uniformScale(
+  node: POMNode,
+  targetRatio: number,
+): AutoFitStrategyResult {
   const ratio = Math.max(targetRatio, MIN_SCALE);
   let changed = false;
+  let sawTarget = false;
 
   walkPOMTree(node, (n) => {
     // fontSize
     if ("fontSize" in n && typeof n.fontSize === "number") {
+      sawTarget = true;
       const newVal = scaleNumber(n.fontSize, ratio, 8);
       if (newVal !== n.fontSize) {
         (n as { fontSize: number }).fontSize = newVal;
@@ -28,6 +34,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
 
     // gap (vstack/hstack)
     if ((n.type === "vstack" || n.type === "hstack") && n.gap !== undefined) {
+      sawTarget = true;
       const newVal = scaleNumber(n.gap, ratio, 1);
       if (newVal !== n.gap) {
         n.gap = newVal;
@@ -37,6 +44,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
 
     // padding
     if (n.padding !== undefined) {
+      sawTarget = true;
       const result = mapBoxSpacing(n.padding, (v) => scaleNumber(v, ratio, 1));
       if (result.changed) {
         n.padding = result.value;
@@ -47,6 +55,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
     // table: defaultRowHeight, row.height
     if (n.type === "table") {
       if (n.defaultRowHeight !== undefined) {
+        sawTarget = true;
         const newVal = scaleNumber(n.defaultRowHeight, ratio, 16);
         if (newVal !== n.defaultRowHeight) {
           n.defaultRowHeight = newVal;
@@ -55,6 +64,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
       }
       for (const row of n.rows) {
         if (row.height !== undefined) {
+          sawTarget = true;
           const newVal = scaleNumber(row.height, ratio, 16);
           if (newVal !== row.height) {
             row.height = newVal;
@@ -68,6 +78,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
     if (n.type === "ul" || n.type === "ol") {
       for (const item of n.items) {
         if (item.fontSize !== undefined) {
+          sawTarget = true;
           const newVal = scaleNumber(item.fontSize, ratio, 8);
           if (newVal !== item.fontSize) {
             item.fontSize = newVal;
@@ -79,6 +90,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
 
     // icon size
     if (n.type === "icon" && n.size !== undefined) {
+      sawTarget = true;
       const newVal = scaleNumber(n.size, ratio, 8);
       if (newVal !== n.size) {
         n.size = newVal;
@@ -91,6 +103,7 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
       for (const row of n.rows) {
         for (const cell of row.cells) {
           if (cell.fontSize !== undefined) {
+            sawTarget = true;
             const newVal = scaleNumber(cell.fontSize, ratio, 8);
             if (newVal !== cell.fontSize) {
               cell.fontSize = newVal;
@@ -102,5 +115,5 @@ export function uniformScale(node: POMNode, targetRatio: number): boolean {
     }
   });
 
-  return changed;
+  return toStrategyResult({ changed, sawTarget });
 }

--- a/packages/pom/src/autoFit/strategyResult.ts
+++ b/packages/pom/src/autoFit/strategyResult.ts
@@ -1,0 +1,27 @@
+/** AutoFit strategy が変更を適用できなかった理由 */
+export type AutoFitSkipReason =
+  /** 調整対象となる属性を持つノードが存在しない */
+  | "no-target"
+  /** 調整対象はあるが、すべて下限値に達していて縮小余地がない */
+  | "already-at-minimum";
+
+/** AutoFit strategy の適用結果 */
+export type AutoFitStrategyResult =
+  | { changed: true }
+  | { changed: false; reason: AutoFitSkipReason };
+
+/**
+ * strategy 内部で集計した「変更有無」「調整対象の有無」から共通 result を組み立てる。
+ */
+export function toStrategyResult(params: {
+  changed: boolean;
+  sawTarget: boolean;
+}): AutoFitStrategyResult {
+  if (params.changed) {
+    return { changed: true };
+  }
+  return {
+    changed: false,
+    reason: params.sawTarget ? "already-at-minimum" : "no-target",
+  };
+}

--- a/packages/pom/src/autoFit/strategyResult.ts
+++ b/packages/pom/src/autoFit/strategyResult.ts
@@ -2,8 +2,8 @@
 export type AutoFitSkipReason =
   /** 調整対象となる属性を持つノードが存在しない */
   | "no-target"
-  /** 調整対象はあるが、すべて下限値に達していて縮小余地がない */
-  | "already-at-minimum";
+  /** 調整対象はあるが、下限値への到達や丸めにより値が変化しなかった */
+  | "no-effective-change";
 
 /** AutoFit strategy の適用結果 */
 export type AutoFitStrategyResult =
@@ -22,6 +22,6 @@ export function toStrategyResult(params: {
   }
   return {
     changed: false,
-    reason: params.sawTarget ? "already-at-minimum" : "no-target",
+    reason: params.sawTarget ? "no-effective-change" : "no-target",
   };
 }


### PR DESCRIPTION
close #813

## 概要

`autoFit/strategies/*` の戻り値を boolean から共通 result 型 `AutoFitStrategyResult` に整理し、「変更有無」と「適用できなかった理由」を表現できるようにする。親 issue #807 の内部共通化の一環。

## 変更内容

- `packages/pom/src/autoFit/strategyResult.ts` を新規追加
  - `AutoFitStrategyResult` — `{ changed: true } | { changed: false; reason: AutoFitSkipReason }` の判別共用体
  - `AutoFitSkipReason` — `"no-target"`(調整対象なし)/ `"no-effective-change"`(下限到達・丸めにより値が変化しなかった)
  - `toStrategyResult` — strategy 内部で集計した `changed` / `sawTarget` から result を組み立てる helper
- 4 つの strategy(`reduceTableRowHeight` / `reduceFontSize` / `reduceGapAndPadding` / `uniformScale`)を共通 result 型へ移行
- orchestrator(`autoFit.ts`)の `Strategy` 型と判定を更新(挙動は変更なし)
- テストに `no-target` / `no-effective-change`(下限到達・丸め同値の両ケース)の検証を追加

## 影響パッケージ

- `packages/pom`(`src/autoFit/` 配下のみ。public API への変更なし)

## ローカル検証手順

```bash
cd packages/pom
pnpm run typecheck
pnpm run lint
pnpm run lint:deps
pnpm exec vitest run src/autoFit/autoFit.test.ts
```

typecheck / lint / lint:deps / テスト(autoFit 27 件、全体 477 件)がすべて通ることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
