### PR TITLE
refactor: XML child parsing / serialization ルールを registry の xmlChildRule として内部共通化

### DIFF
--- a/.changeset/xml-child-rules-internal-unify.md
+++ b/.changeset/xml-child-rules-internal-unify.md
@@ -1,0 +1,7 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+refactor: XML child parsing / serialization ルールを registry 側の `xmlChildRule` として内部共通化
+
+parseXml に分散していた child element の受け入れルール（許容タグ・変換先 property・インライン装飾タグの対応）を registry の宣言的なデータとして整理し、parseXml / serializeXml の双方から共有するようにしました。公開 API・XML 構文・エラーメッセージに変更はありません。

--- a/.changeset/xml-child-rules-internal-unify.md
+++ b/.changeset/xml-child-rules-internal-unify.md
@@ -4,4 +4,4 @@
 
 refactor: XML child parsing / serialization ルールを registry 側の `xmlChildRule` として内部共通化
 
-parseXml に分散していた child element の受け入れルール（許容タグ・変換先 property・インライン装飾タグの対応）を registry の宣言的なデータとして整理し、parseXml / serializeXml の双方から共有するようにしました。公開 API・XML 構文・エラーメッセージに変更はありません。
+parseXml に分散していた child element の受け入れルール（許容タグ・変換先 property）を registry の宣言的なデータ `xmlChildRule` として整理しました。インライン装飾タグ（B/I/A/U/S/Mark/Span）と `TextRun` の対応ルールは parseXml / serializeXml の双方から共有されます。公開 API・XML 構文・エラーメッセージに変更はありません。

--- a/packages/pom/src/parseXml/parseXml.ts
+++ b/packages/pom/src/parseXml/parseXml.ts
@@ -595,7 +595,9 @@ function convertFlowChildren(
     const tag = getTagName(child);
     switch (tag) {
       case "FlowNode":
-        nodes.push(coerceChildAttrs(tagName, tag, getAttributes(child), errors));
+        nodes.push(
+          coerceChildAttrs(tagName, tag, getAttributes(child), errors),
+        );
         break;
       case "FlowConnection":
         connections.push(

--- a/packages/pom/src/parseXml/parseXml.ts
+++ b/packages/pom/src/parseXml/parseXml.ts
@@ -7,6 +7,20 @@ import {
   NODE_METADATA,
 } from "../registry/nodeMetadata.ts";
 import {
+  INLINE_BOOLEAN_FORMATS,
+  INLINE_FORMAT_TAG_LIST,
+  INLINE_FORMAT_TAGS,
+  INLINE_LINK_TAG,
+  INLINE_MARK_TAG,
+  INLINE_SPAN_TAG,
+  MARK_DEFAULT_HIGHLIGHT_COLOR,
+  formatExpectedTags,
+  type NodeSpecificChildRule,
+  type RepeatedChildRule,
+  type TextRun,
+  type XmlChildRule,
+} from "../registry/xmlChildRules.ts";
+import {
   type CoercionRule,
   NODE_COERCION_MAP,
   CHILD_ELEMENT_COERCION_MAP,
@@ -310,8 +324,6 @@ function getRawChildren(node: XmlElement): XmlNode[] {
   return (node[tagName] as XmlNode[] | undefined) ?? [];
 }
 
-const INLINE_FORMAT_TAGS = new Set(["B", "I", "A", "U", "S", "Mark", "Span"]);
-
 function hasInlineFormatChildren(childElements: XmlElement[]): boolean {
   return (
     childElements.length > 0 &&
@@ -319,172 +331,56 @@ function hasInlineFormatChildren(childElements: XmlElement[]): boolean {
   );
 }
 
-type TextRunResult = {
-  text: string;
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strike?: boolean;
-  highlight?: string;
-  color?: string;
-  href?: string;
-  fontFamily?: string;
-  letterSpacing?: number;
-};
-
 function extractTextRuns(
   children: XmlNode[],
-  inheritBold?: boolean,
-  inheritItalic?: boolean,
-  inheritHref?: string,
-  inheritUnderline?: boolean,
-  inheritStrike?: boolean,
-  inheritHighlight?: string,
-  inheritColor?: string,
-  inheritFontFamily?: string,
-  inheritLetterSpacing?: number,
-): TextRunResult[] {
-  const runs: TextRunResult[] = [];
+  inherited: Partial<Omit<TextRun, "text">> = {},
+): TextRun[] {
+  const runs: TextRun[] = [];
   for (const child of children) {
     if (isTextNode(child)) {
-      const run: TextRunResult = { text: child["#text"] };
-      if (inheritBold) run.bold = true;
-      if (inheritItalic) run.italic = true;
-      if (inheritUnderline) run.underline = true;
-      if (inheritStrike) run.strike = true;
-      if (inheritHighlight) run.highlight = inheritHighlight;
-      if (inheritColor) run.color = inheritColor;
-      if (inheritHref) run.href = inheritHref;
-      if (inheritFontFamily) run.fontFamily = inheritFontFamily;
-      if (inheritLetterSpacing !== undefined)
-        run.letterSpacing = inheritLetterSpacing;
-      runs.push(run);
-    } else {
-      const tag = getTagName(child);
-      const innerChildren = getRawChildren(child);
-      if (tag === "B") {
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            true,
-            inheritItalic,
-            inheritHref,
-            inheritUnderline,
-            inheritStrike,
-            inheritHighlight,
-            inheritColor,
-            inheritFontFamily,
-            inheritLetterSpacing,
-          ),
-        );
-      } else if (tag === "I") {
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            inheritBold,
-            true,
-            inheritHref,
-            inheritUnderline,
-            inheritStrike,
-            inheritHighlight,
-            inheritColor,
-            inheritFontFamily,
-            inheritLetterSpacing,
-          ),
-        );
-      } else if (tag === "A") {
-        const href = getAttributes(child).href ?? "";
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            inheritBold,
-            inheritItalic,
-            href,
-            inheritUnderline,
-            inheritStrike,
-            inheritHighlight,
-            inheritColor,
-            inheritFontFamily,
-            inheritLetterSpacing,
-          ),
-        );
-      } else if (tag === "U") {
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            inheritBold,
-            inheritItalic,
-            inheritHref,
-            true,
-            inheritStrike,
-            inheritHighlight,
-            inheritColor,
-            inheritFontFamily,
-            inheritLetterSpacing,
-          ),
-        );
-      } else if (tag === "S") {
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            inheritBold,
-            inheritItalic,
-            inheritHref,
-            inheritUnderline,
-            true,
-            inheritHighlight,
-            inheritColor,
-            inheritFontFamily,
-            inheritLetterSpacing,
-          ),
-        );
-      } else if (tag === "Mark") {
-        const rawColor = getAttributes(child).color;
-        const color = rawColor && rawColor.trim() ? rawColor : "FFFF00";
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            inheritBold,
-            inheritItalic,
-            inheritHref,
-            inheritUnderline,
-            inheritStrike,
-            color,
-            inheritColor,
-            inheritFontFamily,
-            inheritLetterSpacing,
-          ),
-        );
-      } else if (tag === "Span") {
-        const spanAttrs = getAttributes(child);
-        const rawSpanColor = spanAttrs.color;
-        const spanColor =
-          rawSpanColor && rawSpanColor.trim() ? rawSpanColor : inheritColor;
-        const rawSpanFontFamily = spanAttrs.fontFamily;
-        const spanFontFamily =
-          rawSpanFontFamily && rawSpanFontFamily.trim()
-            ? rawSpanFontFamily
-            : inheritFontFamily;
-        const rawSpanLetterSpacing = spanAttrs.letterSpacing;
-        const spanLetterSpacing =
-          rawSpanLetterSpacing && rawSpanLetterSpacing.trim()
-            ? Number(rawSpanLetterSpacing)
-            : inheritLetterSpacing;
-        runs.push(
-          ...extractTextRuns(
-            innerChildren,
-            inheritBold,
-            inheritItalic,
-            inheritHref,
-            inheritUnderline,
-            inheritStrike,
-            inheritHighlight,
-            spanColor,
-            spanFontFamily,
-            spanLetterSpacing,
-          ),
-        );
+      runs.push({ text: child["#text"], ...inherited });
+      continue;
+    }
+    const tag = getTagName(child);
+    const innerChildren = getRawChildren(child);
+    const booleanFormat = INLINE_BOOLEAN_FORMATS.find(
+      (format) => format.tag === tag,
+    );
+    if (booleanFormat) {
+      runs.push(
+        ...extractTextRuns(innerChildren, {
+          ...inherited,
+          [booleanFormat.property]: true,
+        }),
+      );
+    } else if (tag === INLINE_LINK_TAG) {
+      // href なしの <A> は外側の href を引き継がない（リンク解除として扱う）
+      const next = { ...inherited };
+      const href = getAttributes(child).href;
+      if (href) {
+        next.href = href;
+      } else {
+        delete next.href;
       }
+      runs.push(...extractTextRuns(innerChildren, next));
+    } else if (tag === INLINE_MARK_TAG) {
+      const rawColor = getAttributes(child).color;
+      const highlight =
+        rawColor && rawColor.trim() ? rawColor : MARK_DEFAULT_HIGHLIGHT_COLOR;
+      runs.push(...extractTextRuns(innerChildren, { ...inherited, highlight }));
+    } else if (tag === INLINE_SPAN_TAG) {
+      const spanAttrs = getAttributes(child);
+      const next = { ...inherited };
+      if (spanAttrs.color && spanAttrs.color.trim()) {
+        next.color = spanAttrs.color;
+      }
+      if (spanAttrs.fontFamily && spanAttrs.fontFamily.trim()) {
+        next.fontFamily = spanAttrs.fontFamily;
+      }
+      if (spanAttrs.letterSpacing && spanAttrs.letterSpacing.trim()) {
+        next.letterSpacing = Number(spanAttrs.letterSpacing);
+      }
+      runs.push(...extractTextRuns(innerChildren, next));
     }
   }
   return runs;
@@ -492,7 +388,7 @@ function extractTextRuns(
 
 function buildRunsAndText(
   node: XmlElement,
-): { runs: TextRunResult[]; text: string } | null {
+): { runs: TextRun[]; text: string } | null {
   const rawChildren = getRawChildren(node);
   const childElements = rawChildren.filter(
     (c): c is XmlElement => !isTextNode(c),
@@ -581,54 +477,36 @@ function coerceChildAttrs(
 }
 
 // ===== Child element converters =====
-type ChildElementConverter = (
-  childElements: XmlElement[],
-  result: Record<string, unknown>,
-  errors: string[],
-  node?: XmlElement,
-) => void;
 
-function convertProcessArrowChildren(
-  childElements: XmlElement[],
-  result: Record<string, unknown>,
-  errors: string[],
-): void {
-  const steps: Record<string, unknown>[] = [];
-  for (const child of childElements) {
-    const tag = getTagName(child);
-    if (tag !== "ProcessArrowStep") {
-      errors.push(
-        `Unknown child element <${tag}> inside <ProcessArrow>. Expected: <ProcessArrowStep>`,
-      );
-      continue;
-    }
-    steps.push(
-      coerceChildAttrs("ProcessArrow", tag, getAttributes(child), errors),
-    );
-  }
-  result.steps = steps;
+function unknownChildError(
+  childTag: string,
+  parentTag: string,
+  expectedTags: readonly string[],
+): string {
+  return `Unknown child element <${childTag}> inside <${parentTag}>. Expected: ${formatExpectedTags(expectedTags)}`;
 }
 
-function convertPyramidChildren(
-  childElements: XmlElement[],
-  result: Record<string, unknown>,
-  errors: string[],
+/** element の text content / インライン装飾を attrs の text / runs へ反映する */
+function applyTextAndRuns(
+  element: XmlElement,
+  attrs: Record<string, unknown>,
 ): void {
-  const levels: Record<string, unknown>[] = [];
-  for (const child of childElements) {
-    const tag = getTagName(child);
-    if (tag !== "PyramidLevel") {
-      errors.push(
-        `Unknown child element <${tag}> inside <Pyramid>. Expected: <PyramidLevel>`,
-      );
-      continue;
+  const runsResult = buildRunsAndText(element);
+  if (runsResult) {
+    attrs.runs = runsResult.runs;
+    attrs.text = runsResult.text;
+  } else {
+    const textContent = getTextContent(element);
+    if (textContent !== undefined && !("text" in attrs)) {
+      attrs.text = textContent;
     }
-    levels.push(coerceChildAttrs("Pyramid", tag, getAttributes(child), errors));
   }
-  result.levels = levels;
 }
 
-function convertTimelineChildren(
+/** RepeatedChildRule (単一種類の child tag の繰り返し → 配列 property) の汎用 converter */
+function convertRepeatedChildren(
+  rule: RepeatedChildRule,
+  parentTag: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -636,18 +514,36 @@ function convertTimelineChildren(
   const items: Record<string, unknown>[] = [];
   for (const child of childElements) {
     const tag = getTagName(child);
-    if (tag !== "TimelineItem") {
-      errors.push(
-        `Unknown child element <${tag}> inside <Timeline>. Expected: <TimelineItem>`,
-      );
+    if (tag !== rule.childTag) {
+      errors.push(unknownChildError(tag, parentTag, [rule.childTag]));
       continue;
     }
-    items.push(coerceChildAttrs("Timeline", tag, getAttributes(child), errors));
+    const attrs = coerceChildAttrs(
+      parentTag,
+      tag,
+      getAttributes(child),
+      errors,
+    );
+    if (rule.allowsItemText) {
+      applyTextAndRuns(child, attrs);
+    }
+    items.push(attrs);
   }
-  result.items = items;
+  result[rule.property] = items;
 }
 
+/** NodeSpecificChildRule を処理する専用 converter のシグネチャ */
+type NodeSpecificChildConverter = (
+  rule: NodeSpecificChildRule,
+  tagName: string,
+  childElements: XmlElement[],
+  result: Record<string, unknown>,
+  errors: string[],
+) => void;
+
 function convertMatrixChildren(
+  rule: NodeSpecificChildRule,
+  tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -658,7 +554,7 @@ function convertMatrixChildren(
     switch (tag) {
       case "MatrixAxes":
         result.axes = coerceChildAttrs(
-          "Matrix",
+          tagName,
           tag,
           getAttributes(child),
           errors,
@@ -666,7 +562,7 @@ function convertMatrixChildren(
         break;
       case "MatrixQuadrants":
         result.quadrants = coerceChildAttrs(
-          "Matrix",
+          tagName,
           tag,
           getAttributes(child),
           errors,
@@ -674,13 +570,11 @@ function convertMatrixChildren(
         break;
       case "MatrixItem":
         items.push(
-          coerceChildAttrs("Matrix", tag, getAttributes(child), errors),
+          coerceChildAttrs(tagName, tag, getAttributes(child), errors),
         );
         break;
       default:
-        errors.push(
-          `Unknown child element <${tag}> inside <Matrix>. Expected: <MatrixAxes>, <MatrixQuadrants>, or <MatrixItem>`,
-        );
+        errors.push(unknownChildError(tag, tagName, rule.expectedTags));
     }
   }
   if (items.length > 0) {
@@ -689,6 +583,8 @@ function convertMatrixChildren(
 }
 
 function convertFlowChildren(
+  rule: NodeSpecificChildRule,
+  tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -699,17 +595,15 @@ function convertFlowChildren(
     const tag = getTagName(child);
     switch (tag) {
       case "FlowNode":
-        nodes.push(coerceChildAttrs("Flow", tag, getAttributes(child), errors));
+        nodes.push(coerceChildAttrs(tagName, tag, getAttributes(child), errors));
         break;
       case "FlowConnection":
         connections.push(
-          coerceChildAttrs("Flow", tag, getAttributes(child), errors),
+          coerceChildAttrs(tagName, tag, getAttributes(child), errors),
         );
         break;
       default:
-        errors.push(
-          `Unknown child element <${tag}> inside <Flow>. Expected: <FlowNode> or <FlowConnection>`,
-        );
+        errors.push(unknownChildError(tag, tagName, rule.expectedTags));
     }
   }
   if (nodes.length > 0) {
@@ -721,6 +615,8 @@ function convertFlowChildren(
 }
 
 function convertChartChildren(
+  rule: NodeSpecificChildRule,
+  tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -729,9 +625,7 @@ function convertChartChildren(
   for (const child of childElements) {
     const tag = getTagName(child);
     if (tag !== "ChartSeries") {
-      errors.push(
-        `Unknown child element <${tag}> inside <Chart>. Expected: <ChartSeries>`,
-      );
+      errors.push(unknownChildError(tag, tagName, rule.expectedTags));
       continue;
     }
     const attrs = getAttributes(child);
@@ -748,7 +642,7 @@ function convertChartChildren(
       const dpTag = getTagName(dp);
       if (dpTag !== "ChartDataPoint") {
         errors.push(
-          `Unknown child element <${dpTag}> inside <ChartSeries>. Expected: <ChartDataPoint>`,
+          unknownChildError(dpTag, "ChartSeries", ["ChartDataPoint"]),
         );
         continue;
       }
@@ -778,6 +672,8 @@ function convertChartChildren(
 }
 
 function convertTableChildren(
+  rule: NodeSpecificChildRule,
+  tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -789,7 +685,7 @@ function convertTableChildren(
     switch (tag) {
       case "Col":
         columns.push(
-          coerceChildAttrs("Table", tag, getAttributes(child), errors),
+          coerceChildAttrs(tagName, tag, getAttributes(child), errors),
         );
         break;
       case "Tr": {
@@ -798,9 +694,7 @@ function convertTableChildren(
         for (const cellEl of getChildElements(child)) {
           const cellTag = getTagName(cellEl);
           if (cellTag !== "Td") {
-            errors.push(
-              `Unknown child element <${cellTag}> inside <Tr>. Expected: <Td>`,
-            );
+            errors.push(unknownChildError(cellTag, "Tr", ["Td"]));
             continue;
           }
           const cellAttrs = coerceChildAttrs(
@@ -809,16 +703,7 @@ function convertTableChildren(
             getAttributes(cellEl),
             errors,
           );
-          const runsResult = buildRunsAndText(cellEl);
-          if (runsResult) {
-            cellAttrs.runs = runsResult.runs;
-            cellAttrs.text = runsResult.text;
-          } else {
-            const cellText = getTextContent(cellEl);
-            if (cellText !== undefined && !("text" in cellAttrs)) {
-              cellAttrs.text = cellText;
-            }
-          }
+          applyTextAndRuns(cellEl, cellAttrs);
           cells.push(cellAttrs);
         }
         const row: Record<string, unknown> = { cells };
@@ -836,9 +721,7 @@ function convertTableChildren(
         break;
       }
       default:
-        errors.push(
-          `Unknown child element <${tag}> inside <Table>. Expected: <Col> or <Tr>`,
-        );
+        errors.push(unknownChildError(tag, tagName, rule.expectedTags));
     }
   }
   if (columns.length > 0) {
@@ -884,9 +767,7 @@ function convertTreeItem(
       .map((child) => {
         const tag = getTagName(child);
         if (tag !== "TreeItem") {
-          errors.push(
-            `Unknown child element <${tag}> inside <TreeItem>. Expected: <TreeItem>`,
-          );
+          errors.push(unknownChildError(tag, "TreeItem", ["TreeItem"]));
           return null;
         }
         return convertTreeItem(child, errors);
@@ -897,6 +778,8 @@ function convertTreeItem(
 }
 
 function convertTreeChildren(
+  rule: NodeSpecificChildRule,
+  tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -910,48 +793,10 @@ function convertTreeChildren(
   const child = childElements[0];
   const tag = getTagName(child);
   if (tag !== "TreeItem") {
-    errors.push(
-      `Unknown child element <${tag}> inside <Tree>. Expected: <TreeItem>`,
-    );
+    errors.push(unknownChildError(tag, tagName, rule.expectedTags));
     return;
   }
   result.data = convertTreeItem(child, errors);
-}
-
-function convertListChildren(
-  parentTag: string,
-  childElements: XmlElement[],
-  result: Record<string, unknown>,
-  errors: string[],
-): void {
-  const items: Record<string, unknown>[] = [];
-  for (const child of childElements) {
-    const tag = getTagName(child);
-    if (tag !== "Li") {
-      errors.push(
-        `Unknown child element <${tag}> inside <${parentTag}>. Expected: <Li>`,
-      );
-      continue;
-    }
-    const attrs = coerceChildAttrs(
-      parentTag,
-      tag,
-      getAttributes(child),
-      errors,
-    );
-    const runsResult = buildRunsAndText(child);
-    if (runsResult) {
-      attrs.runs = runsResult.runs;
-      attrs.text = runsResult.text;
-    } else {
-      const textContent = getTextContent(child);
-      if (textContent !== undefined && !("text" in attrs)) {
-        attrs.text = textContent;
-      }
-    }
-    items.push(attrs);
-  }
-  result.items = items;
 }
 
 // SVG 要素を XML 文字列に再構築する
@@ -966,6 +811,8 @@ function serializeSvgElement(svgElement: XmlElement): string {
 }
 
 function convertSvgChildren(
+  _rule: NodeSpecificChildRule,
+  _tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -987,7 +834,8 @@ function convertSvgChildren(
   result.svgContent = serializeSvgElement(child);
 }
 
-function convertTextInlineChildren(
+function convertInlineRunsChildren(
+  tagName: string,
   childElements: XmlElement[],
   result: Record<string, unknown>,
   errors: string[],
@@ -997,8 +845,10 @@ function convertTextInlineChildren(
   for (const el of childElements) {
     const tag = getTagName(el);
     if (!INLINE_FORMAT_TAGS.has(tag)) {
+      const allowedTags = INLINE_FORMAT_TAG_LIST.map((t) => `<${t}>`);
+      const allowedList = `${allowedTags.slice(0, -1).join(", ")}, and ${allowedTags[allowedTags.length - 1]}`;
       errors.push(
-        `<Text>: Unexpected child element <${tag}>. Only <B>, <I>, <A>, <U>, <S>, <Mark>, and <Span> are allowed inside <Text>`,
+        `<${tagName}>: Unexpected child element <${tag}>. Only ${allowedList} are allowed inside <${tagName}>`,
       );
       return;
     }
@@ -1011,15 +861,11 @@ function convertTextInlineChildren(
   }
 }
 
-const CHILD_ELEMENT_CONVERTERS: Record<string, ChildElementConverter> = {
-  text: convertTextInlineChildren,
-  ul: (childElements, result, errors) =>
-    convertListChildren("Ul", childElements, result, errors),
-  ol: (childElements, result, errors) =>
-    convertListChildren("Ol", childElements, result, errors),
-  processArrow: convertProcessArrowChildren,
-  pyramid: convertPyramidChildren,
-  timeline: convertTimelineChildren,
+/** NodeSpecificChildRule を持つノードの専用 converter テーブル */
+const NODE_SPECIFIC_CHILD_CONVERTERS: Record<
+  string,
+  NodeSpecificChildConverter
+> = {
   matrix: convertMatrixChildren,
   flow: convertFlowChildren,
   chart: convertChartChildren,
@@ -1027,6 +873,33 @@ const CHILD_ELEMENT_CONVERTERS: Record<string, ChildElementConverter> = {
   tree: convertTreeChildren,
   svg: convertSvgChildren,
 };
+
+/** NodeMetadata の xmlChildRule に従って child element を変換する */
+function applyXmlChildRule(
+  rule: XmlChildRule,
+  nodeType: string,
+  tagName: string,
+  childElements: XmlElement[],
+  result: Record<string, unknown>,
+  errors: string[],
+  node?: XmlElement,
+): void {
+  if (rule.kind === "inline-runs") {
+    convertInlineRunsChildren(tagName, childElements, result, errors, node);
+    return;
+  }
+  if (rule.kind === "repeated") {
+    convertRepeatedChildren(rule, tagName, childElements, result, errors);
+    return;
+  }
+  const converter = NODE_SPECIFIC_CHILD_CONVERTERS[nodeType];
+  if (!converter) {
+    throw new Error(
+      `No node-specific child converter registered for node type: ${nodeType}`,
+    );
+  }
+  converter(rule, tagName, childElements, result, errors);
+}
 
 // ===== Theme tokens =====
 const THEME_TOKEN_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*$/;
@@ -1279,9 +1152,17 @@ function convertPomNode(
   }
 
   // Child element notation for complex properties
-  const childConverter = CHILD_ELEMENT_CONVERTERS[nodeType];
-  if (childConverter && childElements.length > 0) {
-    childConverter(childElements, result, errors, xmlNode);
+  const childRule = def.xmlChildRule;
+  if (childRule && childElements.length > 0) {
+    applyXmlChildRule(
+      childRule,
+      nodeType,
+      tagName,
+      childElements,
+      result,
+      errors,
+      xmlNode,
+    );
   }
   // Children for container nodes
   else if (
@@ -1296,7 +1177,7 @@ function convertPomNode(
   // Leaf nodes that shouldn't have child elements
   else if (
     def.childPolicy.kind !== "pom-children" &&
-    !childConverter &&
+    !childRule &&
     childElements.length > 0
   ) {
     errors.push(

--- a/packages/pom/src/parseXml/serializeXml.test.ts
+++ b/packages/pom/src/parseXml/serializeXml.test.ts
@@ -117,6 +117,15 @@ describe("serializeXml", () => {
       expect(result).toEqual(original);
     });
 
+    it("boolean 装飾のネスト順は B > I > U > S で直列化される", () => {
+      const nodes = parseXml(
+        `<Slide><Text><B><I><U><S>全装飾</S></U></I></B></Text></Slide>`,
+      );
+      const serialized = serializeXml(nodes);
+      expect(serialized).toContain("<B><I><U><S>全装飾</S></U></I></B>");
+      expect(parseXml(serialized)).toEqual(nodes);
+    });
+
     it("Span の letterSpacing を runs として往復変換する", () => {
       const original = parseXml(
         `<Slide><Text>通常 <Span letterSpacing="6">字間広め</Span></Text></Slide>`,
@@ -157,6 +166,9 @@ describe("serializeXml", () => {
         `<Slide><Ul><Li><B>太字</B>の項目</Li><Li>通常の項目</Li></Ul></Slide>`,
       );
       const serialized = serializeXml(original);
+      // serialize 側は child element notation ではなく JSON 属性として出力する (現状仕様の固定)
+      expect(serialized).toContain('items="');
+      expect(serialized).not.toContain("<Li");
       const result = parseXml(serialized);
       expect(result).toEqual(original);
     });

--- a/packages/pom/src/parseXml/serializeXml.test.ts
+++ b/packages/pom/src/parseXml/serializeXml.test.ts
@@ -151,6 +151,44 @@ describe("serializeXml", () => {
     });
   });
 
+  describe("child element notation ノードの往復変換", () => {
+    it("Ul (Li + インライン装飾) を往復変換する", () => {
+      const original = parseXml(
+        `<Slide><Ul><Li><B>太字</B>の項目</Li><Li>通常の項目</Li></Ul></Slide>`,
+      );
+      const serialized = serializeXml(original);
+      const result = parseXml(serialized);
+      expect(result).toEqual(original);
+    });
+
+    it("Timeline を往復変換する", () => {
+      const original = parseXml(
+        `<Slide><Timeline><TimelineItem date="2026-01" title="開始" /><TimelineItem date="2026-06" title="完了" color="FF0000" /></Timeline></Slide>`,
+      );
+      const serialized = serializeXml(original);
+      const result = parseXml(serialized);
+      expect(result).toEqual(original);
+    });
+
+    it("ProcessArrow を往復変換する", () => {
+      const original = parseXml(
+        `<Slide><ProcessArrow><ProcessArrowStep label="調査" /><ProcessArrowStep label="実装" /></ProcessArrow></Slide>`,
+      );
+      const serialized = serializeXml(original);
+      const result = parseXml(serialized);
+      expect(result).toEqual(original);
+    });
+
+    it("Table (Td + インライン装飾) を往復変換する", () => {
+      const original = parseXml(
+        `<Slide><Table><Tr><Td><B>見出し</B></Td><Td>値</Td></Tr></Table></Slide>`,
+      );
+      const serialized = serializeXml(original);
+      const result = parseXml(serialized);
+      expect(result).toEqual(original);
+    });
+  });
+
   describe("特殊文字のエスケープ", () => {
     it("属性値の特殊文字をエスケープする", () => {
       const xml = `<Text text="a &amp; b" />`;

--- a/packages/pom/src/parseXml/serializeXml.ts
+++ b/packages/pom/src/parseXml/serializeXml.ts
@@ -1,21 +1,15 @@
 import type { POMNode } from "../types.ts";
 import { getNodeMetadata } from "../registry/nodeMetadata.ts";
+import {
+  INLINE_BOOLEAN_FORMATS,
+  INLINE_LINK_TAG,
+  INLINE_MARK_TAG,
+  INLINE_SPAN_TAG,
+  type TextRun,
+} from "../registry/xmlChildRules.ts";
 
 // runs と svgContent は専用の直列化パスで処理する
 const SKIP_KEYS = new Set(["type", "children", "runs", "svgContent"]);
-
-interface TextRun {
-  text: string;
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strike?: boolean;
-  highlight?: string;
-  color?: string;
-  href?: string;
-  fontFamily?: string;
-  letterSpacing?: number;
-}
 
 function escapeAttrValue(value: string): string {
   return value
@@ -69,10 +63,10 @@ function serializeRun(run: TextRun): string {
   let content = escapeXmlContent(run.text);
 
   if (run.href) {
-    content = `<A href="${escapeAttrValue(run.href)}">${content}</A>`;
+    content = `<${INLINE_LINK_TAG} href="${escapeAttrValue(run.href)}">${content}</${INLINE_LINK_TAG}>`;
   }
   if (run.highlight) {
-    content = `<Mark color="${escapeAttrValue(run.highlight)}">${content}</Mark>`;
+    content = `<${INLINE_MARK_TAG} color="${escapeAttrValue(run.highlight)}">${content}</${INLINE_MARK_TAG}>`;
   }
   const spanAttrs: string[] = [];
   if (run.color) spanAttrs.push(`color="${escapeAttrValue(run.color)}"`);
@@ -81,12 +75,13 @@ function serializeRun(run: TextRun): string {
   if (run.letterSpacing !== undefined)
     spanAttrs.push(`letterSpacing="${run.letterSpacing}"`);
   if (spanAttrs.length > 0) {
-    content = `<Span ${spanAttrs.join(" ")}>${content}</Span>`;
+    content = `<${INLINE_SPAN_TAG} ${spanAttrs.join(" ")}>${content}</${INLINE_SPAN_TAG}>`;
   }
-  if (run.strike) content = `<S>${content}</S>`;
-  if (run.underline) content = `<U>${content}</U>`;
-  if (run.italic) content = `<I>${content}</I>`;
-  if (run.bold) content = `<B>${content}</B>`;
+  // INLINE_BOOLEAN_FORMATS は外側→内側のネスト順なので、内側から順に包む
+  for (let i = INLINE_BOOLEAN_FORMATS.length - 1; i >= 0; i--) {
+    const { tag, property } = INLINE_BOOLEAN_FORMATS[i];
+    if (run[property]) content = `<${tag}>${content}</${tag}>`;
+  }
   return content;
 }
 

--- a/packages/pom/src/registry/nodeMetadata.ts
+++ b/packages/pom/src/registry/nodeMetadata.ts
@@ -31,6 +31,7 @@ export type NodeMetadata = Pick<
   | "schema"
   | "defaults"
   | "childPolicy"
+  | "xmlChildRule"
   | "textContentProperty"
   | "supportsInlineRuns"
 >;
@@ -45,7 +46,11 @@ function leaf(
   options: Partial<
     Pick<
       NodeMetadata,
-      "defaults" | "childPolicy" | "textContentProperty" | "supportsInlineRuns"
+      | "defaults"
+      | "childPolicy"
+      | "xmlChildRule"
+      | "textContentProperty"
+      | "supportsInlineRuns"
     >
   > = {},
 ): NodeMetadata {
@@ -82,6 +87,7 @@ export const NODE_METADATA = [
       lineHeight: 1.3,
     },
     childPolicy: { kind: "custom" },
+    xmlChildRule: { kind: "inline-runs" },
     textContentProperty: "text",
     supportsInlineRuns: true,
   }),
@@ -92,6 +98,12 @@ export const NODE_METADATA = [
       lineHeight: 1.3,
     },
     childPolicy: { kind: "custom", optionalProperties: ["items"] },
+    xmlChildRule: {
+      kind: "repeated",
+      childTag: "Li",
+      property: "items",
+      allowsItemText: true,
+    },
   }),
   leaf("ol", "Ol", olNodeSchema, {
     defaults: {
@@ -100,6 +112,12 @@ export const NODE_METADATA = [
       lineHeight: 1.3,
     },
     childPolicy: { kind: "custom", optionalProperties: ["items"] },
+    xmlChildRule: {
+      kind: "repeated",
+      childTag: "Li",
+      property: "items",
+      allowsItemText: true,
+    },
   }),
   leaf("image", "Image", imageNodeSchema),
   leaf("table", "Table", tableNodeSchema, {
@@ -107,6 +125,7 @@ export const NODE_METADATA = [
       kind: "custom",
       optionalProperties: ["columns", "rows"],
     },
+    xmlChildRule: { kind: "node-specific", expectedTags: ["Col", "Tr"] },
   }),
   container("vstack", "VStack", "multi-child", vStackNodeSchema),
   container("hstack", "HStack", "multi-child", hStackNodeSchema),
@@ -121,30 +140,55 @@ export const NODE_METADATA = [
   }),
   leaf("chart", "Chart", chartNodeSchema, {
     childPolicy: { kind: "custom", optionalProperties: ["data"] },
+    xmlChildRule: { kind: "node-specific", expectedTags: ["ChartSeries"] },
   }),
   leaf("timeline", "Timeline", timelineNodeSchema, {
     childPolicy: { kind: "custom", optionalProperties: ["items"] },
+    xmlChildRule: {
+      kind: "repeated",
+      childTag: "TimelineItem",
+      property: "items",
+    },
   }),
   leaf("matrix", "Matrix", matrixNodeSchema, {
     childPolicy: {
       kind: "custom",
       optionalProperties: ["axes", "items", "quadrants"],
     },
+    xmlChildRule: {
+      kind: "node-specific",
+      expectedTags: ["MatrixAxes", "MatrixQuadrants", "MatrixItem"],
+    },
   }),
   leaf("tree", "Tree", treeNodeSchema, {
     childPolicy: { kind: "custom", optionalProperties: ["data"] },
+    xmlChildRule: { kind: "node-specific", expectedTags: ["TreeItem"] },
   }),
   leaf("flow", "Flow", flowNodeSchema, {
     childPolicy: {
       kind: "custom",
       optionalProperties: ["nodes", "connections"],
     },
+    xmlChildRule: {
+      kind: "node-specific",
+      expectedTags: ["FlowNode", "FlowConnection"],
+    },
   }),
   leaf("processArrow", "ProcessArrow", processArrowNodeSchema, {
     childPolicy: { kind: "custom", optionalProperties: ["steps"] },
+    xmlChildRule: {
+      kind: "repeated",
+      childTag: "ProcessArrowStep",
+      property: "steps",
+    },
   }),
   leaf("pyramid", "Pyramid", pyramidNodeSchema, {
     childPolicy: { kind: "custom", optionalProperties: ["levels"] },
+    xmlChildRule: {
+      kind: "repeated",
+      childTag: "PyramidLevel",
+      property: "levels",
+    },
   }),
   leaf("line", "Line", lineNodeSchema),
   leaf("arrow", "Arrow", arrowNodeSchema),
@@ -164,6 +208,7 @@ export const NODE_METADATA = [
       kind: "custom",
       optionalProperties: ["svgContent"],
     },
+    xmlChildRule: { kind: "node-specific", expectedTags: ["svg"] },
   }),
 ] as const satisfies readonly NodeMetadata[];
 

--- a/packages/pom/src/registry/nodeRegistry.test.ts
+++ b/packages/pom/src/registry/nodeRegistry.test.ts
@@ -105,6 +105,7 @@ describe("NodeRegistry", () => {
         schema: def.schema,
         defaults: def.defaults,
         childPolicy: def.childPolicy,
+        xmlChildRule: def.xmlChildRule,
         textContentProperty: def.textContentProperty,
         supportsInlineRuns: def.supportsInlineRuns,
       }).toEqual(metadata);

--- a/packages/pom/src/registry/types.ts
+++ b/packages/pom/src/registry/types.ts
@@ -5,6 +5,7 @@ import type { loadYoga } from "yoga-layout/load";
 import type { BuildContext } from "../buildContext.ts";
 import type { LayoutResultMap } from "../calcYogaLayout/types.ts";
 import type { z } from "zod";
+import type { XmlChildRule } from "./xmlChildRules.ts";
 
 export type Yoga = Awaited<ReturnType<typeof loadYoga>>;
 
@@ -50,6 +51,13 @@ export interface NodeDefinition {
 
   /** XML child element の受け入れルール */
   childPolicy: ChildPolicy;
+
+  /**
+   * XML child element notation の変換ルール。
+   * childPolicy.kind === "custom" のノードは必ずこのルールを持つ
+   * （対応関係は xmlChildRules.test.ts で検証される）
+   */
+  xmlChildRule?: XmlChildRule;
 
   /** テキスト content を流し込む属性名 */
   textContentProperty?: string;

--- a/packages/pom/src/registry/xmlChildRules.test.ts
+++ b/packages/pom/src/registry/xmlChildRules.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { NODE_METADATA } from "./nodeMetadata.ts";
+import {
+  INLINE_BOOLEAN_FORMATS,
+  INLINE_FORMAT_TAG_LIST,
+  INLINE_FORMAT_TAGS,
+  INLINE_LINK_TAG,
+  INLINE_MARK_TAG,
+  INLINE_SPAN_TAG,
+  formatExpectedTags,
+} from "./xmlChildRules.ts";
+
+describe("xmlChildRules", () => {
+  describe("NODE_METADATA との整合性", () => {
+    it("childPolicy.kind === 'custom' のノードは必ず xmlChildRule を持つ", () => {
+      for (const metadata of NODE_METADATA) {
+        if (metadata.childPolicy.kind === "custom") {
+          expect(
+            metadata.xmlChildRule,
+            `${metadata.type} は childPolicy.kind === "custom" なのに xmlChildRule が未定義`,
+          ).toBeDefined();
+        } else {
+          expect(
+            metadata.xmlChildRule,
+            `${metadata.type} は childPolicy.kind === "${metadata.childPolicy.kind}" なのに xmlChildRule が定義されている`,
+          ).toBeUndefined();
+        }
+      }
+    });
+
+    it("repeated ルールの property は childPolicy.optionalProperties に含まれる", () => {
+      for (const metadata of NODE_METADATA) {
+        if (metadata.xmlChildRule?.kind !== "repeated") continue;
+        if (metadata.childPolicy.kind !== "custom") continue;
+        const optionalProperties = metadata.childPolicy.optionalProperties;
+        if (!optionalProperties) continue;
+        expect(
+          optionalProperties,
+          `${metadata.type} の repeated ルール property "${metadata.xmlChildRule.property}" が optionalProperties に含まれていない`,
+        ).toContain(metadata.xmlChildRule.property);
+      }
+    });
+  });
+
+  describe("インライン装飾タグ定義", () => {
+    it("INLINE_FORMAT_TAG_LIST は boolean 装飾 + A/Mark/Span と一致する", () => {
+      const derived = new Set([
+        ...INLINE_BOOLEAN_FORMATS.map((format) => format.tag),
+        INLINE_LINK_TAG,
+        INLINE_MARK_TAG,
+        INLINE_SPAN_TAG,
+      ]);
+      expect(new Set(INLINE_FORMAT_TAG_LIST)).toEqual(derived);
+      expect(INLINE_FORMAT_TAGS).toEqual(new Set(INLINE_FORMAT_TAG_LIST));
+    });
+  });
+
+  describe("formatExpectedTags", () => {
+    it("タグ数に応じて列挙を整形する", () => {
+      expect(formatExpectedTags(["TreeItem"])).toBe("<TreeItem>");
+      expect(formatExpectedTags(["Col", "Tr"])).toBe("<Col> or <Tr>");
+      expect(
+        formatExpectedTags(["MatrixAxes", "MatrixQuadrants", "MatrixItem"]),
+      ).toBe("<MatrixAxes>, <MatrixQuadrants>, or <MatrixItem>");
+    });
+  });
+});

--- a/packages/pom/src/registry/xmlChildRules.ts
+++ b/packages/pom/src/registry/xmlChildRules.ts
@@ -1,0 +1,116 @@
+/**
+ * parseXml / serializeXml が共有する XML child handling のルール定義。
+ *
+ * - インライン装飾タグ (B/I/A/U/S/Mark/Span) と TextRun property の対応
+ * - ノードごとの XML child element 受け入れルール (XmlChildRule)
+ *
+ * parse 側 (parseXml.ts) と serialize 側 (serializeXml.ts) の双方がこの
+ * モジュールを参照することで、タグ名・対応 property・許容 child のズレを防ぐ。
+ * 依存方向は parseXml / serializeXml → registry の一方向に保つ（このモジュール
+ * からは parseXml / serializeXml を import しない）。
+ */
+
+// ===== インライン装飾 (B/I/A/U/S/Mark/Span) =====
+
+/** Text / Shape / Li / Td 内のインライン装飾を表すテキスト run */
+export interface TextRun {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  color?: string;
+  href?: string;
+  fontFamily?: string;
+  letterSpacing?: number;
+}
+
+/**
+ * boolean 装飾タグ ↔ TextRun property の対応。
+ * 配列の順序は serialize 時のネスト順（先頭が最も外側）。
+ */
+export const INLINE_BOOLEAN_FORMATS: readonly {
+  readonly tag: string;
+  readonly property: "bold" | "italic" | "underline" | "strike";
+}[] = [
+  { tag: "B", property: "bold" },
+  { tag: "I", property: "italic" },
+  { tag: "U", property: "underline" },
+  { tag: "S", property: "strike" },
+];
+
+/** ハイパーリンクタグ。href 属性 → TextRun.href */
+export const INLINE_LINK_TAG = "A";
+
+/** ハイライトタグ。color 属性 → TextRun.highlight（省略時は既定色） */
+export const INLINE_MARK_TAG = "Mark";
+
+/** Mark の color 属性省略時に適用される既定のハイライト色 */
+export const MARK_DEFAULT_HIGHLIGHT_COLOR = "FFFF00";
+
+/** 文字スタイルタグ。color / fontFamily / letterSpacing 属性 → TextRun の同名 property */
+export const INLINE_SPAN_TAG = "Span";
+
+/** インライン装飾として許容されるタグの一覧（エラーメッセージの列挙順） */
+export const INLINE_FORMAT_TAG_LIST: readonly string[] = [
+  "B",
+  "I",
+  "A",
+  "U",
+  "S",
+  "Mark",
+  "Span",
+];
+
+/** インライン装飾タグの集合（child element 判定用） */
+export const INLINE_FORMAT_TAGS: ReadonlySet<string> = new Set(
+  INLINE_FORMAT_TAG_LIST,
+);
+
+// ===== XML child element 受け入れルール =====
+
+/**
+ * インライン装飾タグ (B/I/A/U/S/Mark/Span) のみを child として受け付け、
+ * runs / text property へ変換するルール（Text 用）
+ */
+export interface InlineRunsChildRule {
+  kind: "inline-runs";
+}
+
+/** 単一種類の child tag の繰り返しを受け取り、配列 property へ変換するルール */
+export interface RepeatedChildRule {
+  kind: "repeated";
+  /** 受け付ける child tag 名 */
+  childTag: string;
+  /** 変換結果を格納する property 名 */
+  property: string;
+  /** 各 item が text content / インライン装飾タグを受け付けるか（Li 用） */
+  allowsItemText?: boolean;
+}
+
+/**
+ * parseXml 側の専用 converter で処理する複雑な child 構造
+ * （ネスト構造や複数 property への振り分けを伴うもの）
+ */
+export interface NodeSpecificChildRule {
+  kind: "node-specific";
+  /** 直下で受け付ける child tag 名の一覧（unknown child エラーメッセージに使用） */
+  expectedTags: readonly string[];
+}
+
+export type XmlChildRule =
+  | InlineRunsChildRule
+  | RepeatedChildRule
+  | NodeSpecificChildRule;
+
+/**
+ * unknown child エラーメッセージ用に期待タグ一覧を整形する。
+ * 例: ["A"] → "<A>" / ["A","B"] → "<A> or <B>" / ["A","B","C"] → "<A>, <B>, or <C>"
+ */
+export function formatExpectedTags(tags: readonly string[]): string {
+  const wrapped = tags.map((tag) => `<${tag}>`);
+  if (wrapped.length === 1) return wrapped[0];
+  if (wrapped.length === 2) return `${wrapped[0]} or ${wrapped[1]}`;
+  return `${wrapped.slice(0, -1).join(", ")}, or ${wrapped[wrapped.length - 1]}`;
+}


### PR DESCRIPTION
close #812

## 目的

`parseXml` にハードコードされていた XML child element の受け入れルール（許容タグ・変換先 property・インライン装飾タグの対応）を registry 側の宣言的なデータとして整理し、parseXml / serializeXml の双方から参照できるようにする。新ノード追加時に parse だけ通る / serialize だけ崩れる、といった同期漏れを減らすための内部共通化（親 issue #807 の一環）。

## 変更内容

- **`registry/xmlChildRules.ts` を新設**
  - インライン装飾タグ (B/I/A/U/S/Mark/Span) ↔ `TextRun` property の対応 (`INLINE_BOOLEAN_FORMATS` 等) と `TextRun` 型を定義。parseXml / serializeXml の双方がここを参照する
  - ノードごとの child element 受け入れルール `XmlChildRule`（`inline-runs` / `repeated` / `node-specific`）を型として定義
- **`NodeDefinition` / `NODE_METADATA` に `xmlChildRule` を追加**
  - 12 ノード分の child ルールを registry 側で宣言。`childPolicy.kind === "custom"` ⇔ `xmlChildRule` あり、の整合は invariant テストで担保
- **parseXml**: ノードタイプ別 converter テーブルを `xmlChildRule` 駆動の dispatch に置き換え
  - ProcessArrow / Pyramid / Timeline / Ul / Ol の重複 converter を `RepeatedChildRule` の汎用 converter に統合
  - unknown child エラーメッセージは rule の `expectedTags` から生成（文言は既存と同一、既存テストで固定済み）
  - `extractTextRuns` の位置引数 9 個の継承処理を、共有定義駆動の inherited オブジェクト方式に簡素化
- **serializeXml**: 重複定義していた `TextRun` 型とインライン装飾タグ名を共有定義に置き換え
- **テスト追加**: registry の invariant テスト、child element notation ノード (Ul / Timeline / ProcessArrow / Table) の round-trip テスト、boolean 装飾のネスト順を固定するテスト

公開 API・XML 構文・エラーメッセージに変更はありません。

## 影響パッケージ

- `packages/pom` のみ（`src/registry/`、`src/parseXml/`）。他パッケージへの影響なし

## ローカル検証手順

```bash
cd packages/pom
pnpm run typecheck && pnpm run lint && pnpm run lint:deps && pnpm run knip
pnpm run test:run   # 482 passed / 2 skipped
```

## cross-review (codex / gpt-5.4) 対応

- critical 0 件 / warning 1 件 / info 1 件
- warning「serialize 側は repeated 系ルールを参照しておらず changeset の表現が過大」→ changeset 文言を正確化し、Ul の直列化が JSON 属性出力である現状仕様を固定するアサーションを追加
- info「boolean 装飾のネスト順を固定するテストがない」→ `<B><I><U><S>` の出力順を文字列比較で固定するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
