### PR TITLE
fix(release): prepublishOnly を削除して changeset publish の並列ビルド競合を解消

### DIFF
--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -31,7 +31,6 @@
   },
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('dist/cli.js', '755')\"",
-    "prepublishOnly": "pnpm run build",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "lint": "eslint",

--- a/packages/pom/package.json
+++ b/packages/pom/package.json
@@ -47,7 +47,6 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepublishOnly": "pnpm run build && pnpm run lint && pnpm run fmt:check && pnpm run typecheck && pnpm run test:run",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "knip": "knip",


### PR DESCRIPTION
## 背景

release CI ([run 27424216407](https://github.com/hirokisakabe/pom/actions/runs/27424216407)) で `@hirokisakabe/pom-cli@0.5.1` の publish だけが失敗した（pom 8.4.0 / pom-editor 0.2.3 / pom-jsx 0.3.0 は publish 済み）。

```
error src/build.ts(92,23): error TS18046: 'err' is of type 'unknown'.
error src/build.ts(96,25): error TS18046: 'err' is of type 'unknown'.
error src/cli.ts(16,19): error TS18046: 'err' is of type 'unknown'.
error src/cli.ts(20,21): error TS18046: 'err' is of type 'unknown'.
```

## 原因

`changeset publish` は未公開パッケージを**並列**に publish し、各パッケージの `prepublishOnly` も並列に走る。

- pom の `prepublishOnly` → `tsdown` が `dist/` を clean してから再生成
- pom-cli の `prepublishOnly` → `tsc` が pom の `dist/*.d.ts` を参照

このため pom-cli の `tsc` が、pom の `dist/diagnostics.d.ts` が消えている瞬間に型解決を行うレース条件が存在した。`skipLibCheck: true` により d.ts 内の import 解決失敗は黙殺されて `DiagnosticsError` が `any` になり、`err instanceof DiagnosticsError` で narrowing されず TS18046 が発生する。

ローカルで `packages/pom/dist/diagnostics.d.ts` のみを退避して pom-cli の `tsc` を実行したところ、CI と完全に同一の 4 エラー（同一行番号）が再現することを確認済み。

release.yml の事前 build step（`pnpm --filter @hirokisakabe/pom-cli run build`）が成功していたのは、その時点では pom の dist が揃っていたため。

## 対応

pom / pom-cli の `prepublishOnly` を削除する。

- publish 前の build / lint / typecheck / test は release.yml の各 step が既に実施しており、prepublishOnly での再ビルドは冗長
- npm へは OIDC trusted publishing のため CI 以外からの手動 publish は元々不可で、安全網としての役割も CI が担っている

## changeset について

公開物の動作に変更はないため changeset は追加していない。意図的なもので、本 PR の merge による main への push で release.yml が再実行され、未公開のままの `pom-cli@0.5.1` がそのまま publish される（changeset を追加すると Release PR 作成フローに入ってしまい 0.5.1 が公開されない）。

## 検証

- [x] worktree で `pnpm install --frozen-lockfile` → pom / pom-md / pom-cli の build と pom-cli の typecheck が成功
- [x] `diagnostics.d.ts` 退避による CI エラーの完全再現を確認
- [x] `fmt:check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)