### PR TITLE
docs(pom-slide): 高さの異なる要素とテキストの縦揃え指針を追加

### DIFF
--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -4,7 +4,7 @@ description: Generate pom presentation slides from natural language. Applies des
 license: MIT
 allowed-tools: Write,Edit,Read,Bash
 metadata:
-  version: "1.3.0"
+  version: "1.3.1"
 ---
 
 自然言語の指示から pom XML スライドを生成し、ファイルに保存する。デザイン原則（配色・タイポグラフィ・余白・アーキタイプ）に基づいて初版の質を高め、`/pom-theme` skill が生成したテーマファイル（`pom-theme.json`）があればブランド配色・フォントを適用する。レンダリング結果を自分で見て修正するセルフレビューを行ったうえで、pom-cli がインストール済みの場合はプレビューサーバーを起動する。
@@ -100,6 +100,8 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
 | KPI | display サイズの数字 2〜4 個 + caption のラベル |
 | まとめ / CTA | キーメッセージの再掲 + 次のアクション |
 
+**縦方向の揃え**: アクセントバー・番号・アイコンなど高さの異なる要素をテキストと HStack で並べるときは `alignItems="end"` を基本にする。`Text` のレイアウトボックスは `fontSize × lineHeight` の高さを持ち行送り分の余白を含むため、グリフはボックス内で下寄りに描かれる。`center` で揃えると隣の要素が文字より上に浮いて見える。
+
 代表例（パレット: コーポレート）:
 
 ```xml
@@ -117,11 +119,11 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
   <VStack w="100%" h="max" padding="64" backgroundColor="F8F9FB" gap="32">
     <Text fontSize="32" bold="true" color="1F2937">アジェンダ</Text>
     <VStack gap="16">
-      <HStack gap="16" alignItems="center">
+      <HStack gap="16" alignItems="end">
         <Text fontSize="20" bold="true" color="1E3A8A">01</Text>
         <Text fontSize="16" color="1F2937">背景と課題</Text>
       </HStack>
-      <HStack gap="16" alignItems="center">
+      <HStack gap="16" alignItems="end">
         <Text fontSize="20" bold="true" color="1E3A8A">02</Text>
         <Text fontSize="16" color="1F2937">提案内容</Text>
       </HStack>
@@ -151,6 +153,12 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
     </HStack>
   </VStack>
 </Slide>
+
+<!-- 本編スライド共通の見出し（アクセントバー + タイトル）。center だとバーが文字より上に浮く -->
+<HStack gap="16" alignItems="end">
+  <Shape shapeType="rect" w="6" h="32" fill.color="1E3A8A" />
+  <Text fontSize="32" bold="true" color="1F2937">スライドタイトル</Text>
+</HStack>
 ```
 
 ### 3. pom XML の生成
@@ -800,7 +808,7 @@ When the same property is specified via both attributes (JSON string) and child 
 
 - **はみ出し・重なり**: テキストの見切れ、要素同士の重なり、スライド外へのはみ出し（最優先で修正する）
 - **余白**: 外周 padding が確保されているか。要素が窮屈になっていないか、一部だけ不自然に空いていないか
-- **整列**: 揃うべき左端・上端が揃っているか。並べたカードの幅が均等か
+- **整列**: 揃うべき左端・上端が揃っているか。並べたカードの幅が均等か。アクセントバー・番号・アイコンが隣のテキストの文字より上に浮いていないか（`alignItems="center"` 起因のズレは `end` に変える）
 - **階層**: タイトルが一目で本文と区別できるか。視線の流れ（左上 → 右下）が自然か
 - **配色**: Step 2 で決めたパレットから逸脱した色が混入していないか。テキストと背景のコントラストが十分か
 - **密度**: 詰め込みすぎのスライドがないか（あれば 2 枚に分割する）


### PR DESCRIPTION
## 目的

pom-slide skill が生成するスライドで、見出し脇のアクセントバーや番号がテキストより上に浮いて見えるズレを防ぐ。

実際に skill で生成したデッキで、全ヘッダー（アクセントバー + タイトルの HStack）にこのズレが再現した。原因は `Text` のレイアウトボックスが `fontSize × lineHeight` の高さを持ち行送り分の余白を含むため、グリフがボックス内で下寄りに描かれること。`alignItems="center"` ではバーがボックス中央（＝文字より上）に揃ってしまう。

## 変更内容

`skills/pom-slide/SKILL.md` のみ:

- **スライドアーキタイプ節に縦揃えの原則を追記**: 高さの異なる要素（アクセントバー・番号・アイコン）をテキストと HStack で並べるときは `alignItems="end"` を基本にする
- **アジェンダ例の `alignItems="center"` を `end` に修正**(2 箇所)
- **本編スライド共通ヘッダー(アクセントバー + タイトル)の例を代表例に追加**: 生成デッキで頻出するパターンなので正しい形をアンカーする
- **セルフレビューの「整列」チェック項目に検出観点を追加**: バー・番号・アイコンの浮きを画像確認で検出し `end` に直す
- skill version を 1.3.0 → 1.3.1 に bump

## 検証

- `bash scripts/check-skill-llm-sync.sh` 通過(llm.txt 埋め込みブロックは未変更)
- `alignItems="end"` 適用版を `pom render` で実機レンダリングし、バーと文字の揃いを画像で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
