### PR TITLE
feat(pom-cli): pptx-glimpse 1.1.0 に更新し SVG ネイティブテキスト出力を取り込み

### DIFF
--- a/.changeset/swift-llamas-shake.md
+++ b/.changeset/swift-llamas-shake.md
@@ -1,0 +1,8 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+pptx-glimpse を 1.1.0 に更新し、SVG のネイティブテキスト出力 (`textOutput: "text"`) を取り込み
+
+- `pom render --format svg` に `--text-output <path|text>` オプションを追加。`text` を指定すると、グリフのアウトライン `<path>` ではなくネイティブ `<text>` 要素 + サブセット化フォントの `@font-face` (data URI) 埋め込みで出力する (デフォルトは従来どおり `path`)
+- `pom preview` はインライン SVG 表示のため常に `textOutput: "text"` で変換するように変更。ブラウザのネイティブテキスト描画 (ヒンティング等) が効き、テキスト選択も可能になる

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -100,6 +100,12 @@ To output SVG instead of PNG:
 pom render slides.pom.xml -o ./images --format svg
 ```
 
+By default, SVG output converts text to `<path>` outlines so it renders identically in any environment. Pass `--text-output text` to emit native `<text>` elements with subsetted fonts embedded as `@font-face` data URIs instead — text becomes selectable and renders with browser font hinting, but may not display correctly when the SVG is referenced via `<img src="...">` or sanitized:
+
+```bash
+pom render slides.pom.xml -o ./images --format svg --text-output text
+```
+
 To render only specific slides (1-based, comma-separated) — useful when re-checking just the slides you edited:
 
 ```bash

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -43,7 +43,7 @@
     "@hirokisakabe/pom": "workspace:*",
     "@hirokisakabe/pom-md": "workspace:*",
     "commander": "^15.0.0",
-    "pptx-glimpse": "^1.0.1"
+    "pptx-glimpse": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.2"

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import { DiagnosticsError } from "@hirokisakabe/pom";
 import { runBuild, runBuildWatch } from "./build.ts";
 import { runPreview } from "./preview.ts";
-import { runRender, type RenderFormat } from "./render.ts";
+import { runRender, type RenderFormat, type TextOutput } from "./render.ts";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -102,6 +102,10 @@ program
     "--slides <numbers>",
     "Comma-separated slide numbers to render (e.g. 2,5)",
   )
+  .option(
+    "--text-output <mode>",
+    'SVG text output mode: "path" (glyph outlines) or "text" (native <text> with embedded subset fonts). Only valid with --format svg',
+  )
   .option("--verbose", "Show build step timing on stderr")
   .action(
     (
@@ -110,6 +114,7 @@ program
         o: string;
         format: string;
         slides?: string;
+        textOutput?: string;
         verbose?: boolean;
       },
     ) => {
@@ -120,6 +125,19 @@ program
         process.exit(1);
       }
       const format: RenderFormat = options.format;
+      if (options.textOutput !== undefined) {
+        if (options.textOutput !== "path" && options.textOutput !== "text") {
+          console.error(
+            `Invalid text output mode: ${options.textOutput} (expected "path" or "text")`,
+          );
+          process.exit(1);
+        }
+        if (format !== "svg") {
+          console.error("--text-output is only valid with --format svg");
+          process.exit(1);
+        }
+      }
+      const textOutput: TextOutput | undefined = options.textOutput;
       let slides: number[] | undefined;
       if (options.slides !== undefined) {
         slides = options.slides.split(",").map((s) => Number(s.trim()));
@@ -136,6 +154,7 @@ program
       runRender(input, options.o, {
         format,
         slides,
+        textOutput,
         verbose: options.verbose,
       }).catch((err: unknown) => {
         printBuildError(err);

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -74,11 +74,14 @@ async function generateSvgs(
   const fontDirs = [resolveBundledFontsDir()];
 
   const t2 = Date.now();
+  // インライン SVG なのでネイティブ <text> + サブセットフォント埋め込みが使える。
+  // ブラウザのテキスト描画 (ヒンティング等) が効き、テキスト選択も可能になる
   const slides = await convertPptxToSvg(buffer, {
     width: slideWidth,
     fontDirs,
     fontMapping: EXTRA_FONT_MAPPING,
     skipSystemFonts: true,
+    textOutput: "text",
   });
   log(`Converting to SVG... done (${Date.now() - t2}ms)`);
 

--- a/packages/pom-cli/src/render.test.ts
+++ b/packages/pom-cli/src/render.test.ts
@@ -87,6 +87,33 @@ describe("runRender", () => {
     expect(fs.readdirSync(outputDir)).toEqual(["slide-01.svg"]);
   });
 
+  it("textOutput 指定は convertPptxToSvg にそのまま渡される", async () => {
+    convertPptxToSvgMock.mockResolvedValue([
+      { slideNumber: 1, svg: "<svg/>" },
+    ] as never);
+
+    await runRender(inputFile, outputDir, {
+      format: "svg",
+      textOutput: "text",
+    });
+
+    expect(convertPptxToSvgMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ textOutput: "text" }),
+    );
+  });
+
+  it("textOutput 未指定では convertPptxToSvg にキー自体を渡さない", async () => {
+    convertPptxToSvgMock.mockResolvedValue([
+      { slideNumber: 1, svg: "<svg/>" },
+    ] as never);
+
+    await runRender(inputFile, outputDir, { format: "svg" });
+
+    const options = convertPptxToSvgMock.mock.calls[0][1];
+    expect(options).not.toHaveProperty("textOutput");
+  });
+
   it("slides 指定に存在しない番号があれば警告する", async () => {
     convertPptxToPngMock.mockResolvedValue(makePngSlides(1) as never);
 

--- a/packages/pom-cli/src/render.ts
+++ b/packages/pom-cli/src/render.ts
@@ -6,6 +6,7 @@ import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
 import { loadInput } from "./input.ts";
 
 export type RenderFormat = "png" | "svg";
+export type TextOutput = "path" | "text";
 
 function makeLog(verbose: boolean) {
   if (!verbose) return (_msg: string) => {};
@@ -18,6 +19,7 @@ export async function runRender(
   options: {
     format?: RenderFormat;
     slides?: number[];
+    textOutput?: TextOutput;
     verbose?: boolean;
   } = {},
 ): Promise<void> {
@@ -67,7 +69,10 @@ export async function runRender(
   const t2 = Date.now();
   let outputs: { slideNumber: number; data: string | Buffer }[];
   if (format === "svg") {
-    const slides = await convertPptxToSvg(buffer, convertOptions);
+    const slides = await convertPptxToSvg(buffer, {
+      ...convertOptions,
+      ...(options.textOutput ? { textOutput: options.textOutput } : {}),
+    });
     outputs = slides.map((s) => ({ slideNumber: s.slideNumber, data: s.svg }));
   } else {
     const slides = await convertPptxToPng(buffer, convertOptions);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: ^15.0.0
         version: 15.0.0
       pptx-glimpse:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.2
@@ -6334,6 +6334,10 @@ packages:
 
   pptx-glimpse@1.0.1:
     resolution: {integrity: sha512-aZVo5hVEDSB/peKfBxo0xTb+6H2YMin3RP1Fwry37IRDn6K+7RjU/RPliiSJSTNJpgKDQYPLdIejBIoJfapLhw==}
+    engines: {node: '>=22'}
+
+  pptx-glimpse@1.1.0:
+    resolution: {integrity: sha512-yGCg170cWATRnlLv6QZ8ytf6UGoxp2ddWbWd61KdR6D+FR7qXx5GxkY2CZni2NhvIfEUx0Asc/IK0N7qoIgjMg==}
     engines: {node: '>=22'}
 
   pptxgenjs@4.0.1:
@@ -14188,6 +14192,13 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   pptx-glimpse@1.0.1:
+    dependencies:
+      '@resvg/resvg-wasm': 2.6.2
+      fast-xml-parser: 5.8.0
+      fflate: 0.8.3
+      opentype.js: 1.3.4
+
+  pptx-glimpse@1.1.0:
     dependencies:
       '@resvg/resvg-wasm': 2.6.2
       fast-xml-parser: 5.8.0


### PR DESCRIPTION
## 概要

pptx-glimpse を 1.1.0 に更新し、新しく追加された SVG ネイティブテキスト出力機能 (`textOutput: "text"`) を pom-cli に取り込みます。

`textOutput: "text"` を指定すると、テキストをグリフのアウトライン `<path>` ではなくネイティブ `<text>` 要素 + サブセット化フォントの `@font-face` (data URI) 埋め込みで出力します。ブラウザでのインライン表示時にネイティブテキスト描画 (ヒンティング等) が効き、テキスト選択・コピーも可能になります。

## 変更内容

- **依存更新**: `pptx-glimpse` を `^1.0.1` → `^1.1.0` (pom-cli のみ)
- **`pom render`**: `--text-output <path|text>` オプションを追加
  - デフォルトは従来どおり `path` (後方互換)
  - `--format svg` 以外との組み合わせ、不正な値はエラー
- **`pom preview`**: 常に `textOutput: "text"` で変換するように変更
  - インライン SVG 表示のため `<img src>` 参照やサニタイズ環境の制約を受けず、この機能が最も活きる経路
- render.test.ts にオプション透過のテストを 2 件追加
- README に `--text-output` の説明を追加
- changeset (minor) 追加

## スコープ

pptx-glimpse は `pom-vscode` と `apps/website` でも使用していますが、本 PR では pom-cli に限定しています (vscode は webview、website playground は別経路のため適用は別途検討)。

## 動作確認

- typecheck / lint / test (28 件) / fmt / knip / build すべて通過
- E2E: `pom render --format svg --text-output text` で `<text>` + `@font-face` が出力されることを確認 (サンプルスライドで 41KB → 14KB に減少)
- `pom preview` を起動し、SSE 経由で埋め込みフォント入り SVG が配信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)