### PR TITLE
テストコード (*.test.ts) を lint / typecheck の対象に含める

### DIFF
--- a/packages/pom-md/eslint.config.mts
+++ b/packages/pom-md/eslint.config.mts
@@ -3,5 +3,5 @@ import { defineSharedConfig } from "../../eslint.config.shared.mjs";
 export default defineSharedConfig({
   tsconfigRootDir: import.meta.dirname,
   environment: "browser",
-  ignores: ["**/*.test.ts", "docs/**", "eslint.config.mts", "vitest.config.ts"],
+  ignores: ["docs/**", "eslint.config.mts", "vitest.config.ts"],
 });

--- a/packages/pom-md/package.json
+++ b/packages/pom-md/package.json
@@ -39,7 +39,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "lint": "eslint",

--- a/packages/pom-md/tsconfig.build.json
+++ b/packages/pom-md/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/pom-md/tsconfig.json
+++ b/packages/pom-md/tsconfig.json
@@ -6,12 +6,8 @@
     "target": "es2022",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
     "rewriteRelativeImportExtensions": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/pom/eslint.config.mts
+++ b/packages/pom/eslint.config.mts
@@ -4,7 +4,6 @@ export default defineSharedConfig({
   tsconfigRootDir: import.meta.dirname,
   environment: "browser",
   ignores: [
-    "**/*.test.ts",
     "main.ts",
     "vrt/**",
     "preview/**",

--- a/packages/pom/src/autoFit/autoFit.test.ts
+++ b/packages/pom/src/autoFit/autoFit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { walkPOMTree } from "../shared/walkTree.ts";
 import { reduceTableRowHeight } from "./strategies/reduceTableRowHeight.ts";
 import { reduceFontSize } from "./strategies/reduceFontSize.ts";

--- a/packages/pom/src/calcYogaLayout/measureCompositeNodes.test.ts
+++ b/packages/pom/src/calcYogaLayout/measureCompositeNodes.test.ts
@@ -12,7 +12,7 @@ function makeNode(overrides: Partial<ProcessArrowNode> = {}): ProcessArrowNode {
     type: "processArrow",
     steps: [{ label: "A" }, { label: "B" }, { label: "C" }],
     ...overrides,
-  } as ProcessArrowNode;
+  };
 }
 
 describe("measureProcessArrow", () => {

--- a/packages/pom/src/parseXml/parseXml.test.ts
+++ b/packages/pom/src/parseXml/parseXml.test.ts
@@ -255,7 +255,7 @@ describe("parseXml", () => {
           type: "svg",
           w: 32,
           h: 32,
-          svgContent: expect.stringContaining("<svg"),
+          svgContent: expect.stringContaining("<svg") as string,
         },
       ]);
       // svgContent に path が含まれることを確認
@@ -274,7 +274,7 @@ describe("parseXml", () => {
           w: 32,
           h: 32,
           color: "#1D4ED8",
-          svgContent: expect.stringContaining("<svg"),
+          svgContent: expect.stringContaining("<svg") as string,
         },
       ]);
     });

--- a/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
@@ -110,7 +110,10 @@ describe("createTextOptions", () => {
 
 describe("renderTextNode (runs 分岐)", () => {
   it("runs ありの Text でノード単位の glow / outline が各 run に適用される", () => {
-    const addText = vi.fn();
+    const addText =
+      vi.fn<
+        (items: { options: { glow?: unknown; outline?: unknown } }[]) => void
+      >();
     const ctx = { slide: { addText } } as unknown as RenderContext;
 
     renderTextNode(

--- a/packages/pom/tsconfig.check.json
+++ b/packages/pom/tsconfig.check.json
@@ -13,5 +13,5 @@
     "scripts/docs-images/**/*",
     "main.ts"
   ],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/pom/tsconfig.json
+++ b/packages/pom/tsconfig.json
@@ -14,5 +14,5 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
close #823

## 目的

`packages/pom` / `packages/pom-md` で `**/*.test.ts` が ESLint と typecheck の両方から除外されており、テストコードが静的チェックの空白地帯になっていたため、除外を外してテストにも lint / typecheck を効かせる。

## 変更内容

### packages/pom

- `eslint.config.mts` の ignores から `**/*.test.ts` を削除
- `tsconfig.json` / `tsconfig.check.json` の exclude から `**/*.test.ts` を削除
  - build は tsdown のため `tsconfig.json` の除外解除は emit に影響しない。ESLint の projectService が test ファイルを解決するために必要
- 除外解除で発覚した lint エラー 7 件（4 ファイル）を修正
  - `autoFit.test.ts`: 未使用の `vi` import を削除
  - `measureCompositeNodes.test.ts`: 不要な型アサーションを削除
  - `parseXml.test.ts`: `expect.stringContaining` の any を `as string` で明示
  - `renderPptx.textOptions.test.ts`: `vi.fn` にシグネチャを与えて `mock.calls` 経由の unsafe any アクセスを解消

### packages/pom-md

- `eslint.config.mts` の ignores から `**/*.test.ts` を削除
- build が `tsc`（tsconfig.json）のため、emit 用設定を `tsconfig.build.json` に分離（test 除外を維持）し、`tsconfig.json` は typecheck / ESLint projectService 用として test を含める構成に変更
  - `integration.test.ts` が pom 本体のソースを相対 import しているため、`rootDir` 制約を build 側のみに残すことで typecheck を通している
- `build` スクリプトを `tsc -p tsconfig.build.json` に変更

## changeset について

公開物（dist）への変化がない開発設定のみの変更のため、changeset は追加していません（過去の lint / tsconfig 設定変更・tsdown 移行も changeset なしの先例あり）。`tsconfig.build.json` は `files` に含まれず publish されません。

## ローカル検証

- `packages/pom`: `pnpm run lint` / `lint:deps` / `typecheck` / `test:run`（513 passed）/ `build` / `knip`（main と同一出力）/ `fmt:check` すべて pass
- `packages/pom-md`: `pnpm run lint` / `typecheck` / `test:run`（84 passed）/ `build`（dist に test 混入なし）/ `knip` / `fmt:check` すべて pass
- lint / typecheck 対象に test が含まれることを `eslint <test file>` と `tsc --listFilesOnly` で確認（pom: 25 ファイル、pom-md: 2 ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
