### PR TITLE
chore(pom): Vitest coverage thresholds を導入してカバレッジ低下で CI を fail させる

### DIFF
--- a/packages/pom/vitest.config.ts
+++ b/packages/pom/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     coverage: {
       include: ["src/**/*.ts"],
       reporter: ["text", "html", "json", "json-summary"],
+      // 実測値 (2026-06-13 時点: statements 87.84 / branches 76.21 / functions 92.76 / lines 89.08)
+      // からわずかなマージンを引いた値。下回ると test:coverage が fail する。
+      thresholds: {
+        statements: 87,
+        branches: 75,
+        functions: 92,
+        lines: 88,
+      },
     },
     benchmark: {
       include: ["bench/**/*.bench.ts"],


### PR DESCRIPTION
close #824

## 目的

`packages/pom` の `vitest.config.ts` に `coverage.thresholds` を設定し、カバレッジが基準を下回ったら `test:coverage`(およびそれを実行する CI)を fail させる。これまで CI はカバレッジ計測と PR コメントでの main 比較のみで、カバレッジが下がっても green のまま通っていた。

## 変更内容

- `packages/pom/vitest.config.ts` の `coverage` に `thresholds` を追加
  - 実測値(2026-06-13 時点: statements 87.84% / branches 76.21% / functions 92.76% / lines 89.08%)からわずかなマージンを引いた値を設定
  - statements: 87 / branches: 75 / functions: 92 / lines: 88

## `thresholds.autoUpdate` を採用しない理由

issue の実装方針に従い採用可否を検討した結果、今回は **不採用** とした。

- `autoUpdate: true` はカバレッジが閾値を上回った際に `vitest.config.ts` 自体を書き換える仕組みだが、CI 上で書き換わっても commit されないため、ラチェットとして機能させるには別途自動 commit の仕組みが必要になる
- ローカルでもテスト実行のたびに config に diff が発生し、本来の変更と無関係な差分が PR に混入しやすい
- 下限が実測値ギリギリまで自動で上がると、計測のわずかな揺れで無関係な PR が fail するリスクがある

閾値の引き上げは、テスト拡充が進んだタイミングで明示的な PR として行う。

## 影響パッケージ

- `packages/pom` のみ(dev 設定のみの変更で、published な成果物に変更なし。changeset は不要と判断)

## ローカル検証手順

```bash
cd packages/pom
pnpm run test:coverage   # → 現状コードでパスする (exit 0) ことを確認済み
```

閾値超過時の fail 確認(実施済み): `lines` を一時的に 99 へ上げて実行すると
`ERROR: Coverage for lines (89.08%) does not meet global threshold (99%)` で exit code 1 になることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
