### PR TITLE
chore: pom-md / pom-jsx / pom-vscode / website に Vitest coverage thresholds を導入

### DIFF
--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
     coverage: {
       include: ["playground/**/*.{ts,tsx}"],
       reporter: ["text", "html", "json", "json-summary"],
+      // 実測値 (2026-06-13 時点: statements 50.12 / branches 48.29 / functions 53.6 / lines 51.18)
+      // からわずかなマージンを引いた値。下回ると test:coverage が fail する。
+      thresholds: {
+        statements: 49,
+        branches: 47,
+        functions: 53,
+        lines: 50,
+      },
     },
   },
   resolve: {

--- a/packages/pom-jsx/vitest.config.ts
+++ b/packages/pom-jsx/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
     coverage: {
       include: ["src/**/*.ts"],
       reporter: ["text", "html", "json", "json-summary"],
+      // 実測値 (2026-06-13 時点: statements 89.62 / branches 92.5 / functions 76.74 / lines 98.63)
+      // からわずかなマージンを引いた値。下回ると test:coverage が fail する。
+      thresholds: {
+        statements: 89,
+        branches: 92,
+        functions: 76,
+        lines: 98,
+      },
     },
   },
   resolve: {

--- a/packages/pom-md/vitest.config.ts
+++ b/packages/pom-md/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
     coverage: {
       include: ["src/**/*.ts"],
       reporter: ["text", "html", "json", "json-summary"],
+      // 実測値 (2026-06-13 時点: statements 97.25 / branches 82.4 / functions 100 / lines 97.2)
+      // からわずかなマージンを引いた値。下回ると test:coverage が fail する。
+      thresholds: {
+        statements: 96,
+        branches: 81,
+        functions: 99,
+        lines: 96,
+      },
     },
   },
 });

--- a/packages/pom-vscode/vitest.config.ts
+++ b/packages/pom-vscode/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     coverage: {
       include: ["src/**/*.ts"],
       reporter: ["text", "html", "json", "json-summary"],
+      // 実測値 (2026-06-13 時点: statements 31.25 / branches 32.95 / functions 29.03 / lines 31.92)
+      // からわずかなマージンを引いた値。下回ると test:coverage が fail する。
+      thresholds: {
+        statements: 30,
+        branches: 32,
+        functions: 28,
+        lines: 31,
+      },
     },
   },
 });


### PR DESCRIPTION
close #853

## 目的

#824 / PR #852(`packages/pom` への導入)の後続として、CI で `test:coverage` を実行している残り 4 パッケージ(`pom-md` / `pom-jsx` / `pom-vscode` / `apps/website`)の `vitest.config.ts` に `coverage.thresholds` を設定し、カバレッジが基準を下回ったら `test:coverage`(およびそれを実行する CI)を fail させる。

## 変更内容

各パッケージの `vitest.config.ts` の `coverage` に `thresholds` を追加。閾値は実測値(2026-06-13 時点)から #852 と同じ方式でわずかなマージン(四捨五入 − 1pt、約 0.5〜1.3pt)を引いた値。

| パッケージ | statements | branches | functions | lines |
|---|---|---|---|---|
| `packages/pom-md`(実測) | 97.25 | 82.4 | 100 | 97.2 |
| → 閾値 | 96 | 81 | 99 | 96 |
| `packages/pom-jsx`(実測) | 89.62 | 92.5 | 76.74 | 98.63 |
| → 閾値 | 89 | 92 | 76 | 98 |
| `packages/pom-vscode`(実測) | 31.25 | 32.95 | 29.03 | 31.92 |
| → 閾値 | 30 | 32 | 28 | 31 |
| `apps/website`(実測) | 50.12 | 48.29 | 53.6 | 51.18 |
| → 閾値 | 49 | 47 | 53 | 50 |

`thresholds.autoUpdate` は #852 で不採用とした理由(CI 上で config が書き換わっても commit されない / ローカル実行のたびに無関係な diff が混入する / 計測の揺れで無関係な PR が fail するリスク)がそのまま当てはまるため採用しない(issue の実装方針どおり)。

## 影響パッケージ

- `packages/pom-md` / `packages/pom-jsx` / `packages/pom-vscode` / `apps/website`(いずれも dev 設定のみの変更で、published な成果物に変更なし。#852 と同様に changeset は不要と判断)

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom-md run test:coverage   # exit 0 確認済み
pnpm --filter @hirokisakabe/pom-jsx run test:coverage  # exit 0 確認済み
pnpm --filter pom-vscode run test:coverage             # 閾値エラーなし(下記注釈参照)
pnpm --filter pom-docs run test:coverage               # exit 0 確認済み
```

閾値超過時の fail 確認(実施済み): `pom-md` の `lines` を一時的に 99 へ上げて実行すると `ERROR: Coverage for lines (97.2%) does not meet global threshold (99%)` で exit code 1 になることを確認した。

注釈: `pom-vscode` はローカル(macOS)では `generatePreview.integration.test.ts` の worker 終了タイムアウトにより本変更前から exit 1 になる既存事象があり、閾値起因のエラーは出力されないことを確認した。CI(ubuntu)では main で `ci-pom-vscode.yml` が連続 success しており、本 PR の CI で exit 0 を最終確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
