### PR TITLE
[codex] deps: update pptx-glimpse to 1.1.1

### DIFF
--- a/.changeset/bright-bikes-glimpse.md
+++ b/.changeset/bright-bikes-glimpse.md
@@ -1,0 +1,6 @@
+---
+"@hirokisakabe/pom-cli": patch
+"pom-vscode": patch
+---
+
+pptx-glimpse を 1.1.1 に更新しました。

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -31,7 +31,7 @@
     "next": "^16",
     "nextra": "^4",
     "nextra-theme-docs": "^4",
-    "pptx-glimpse": "^1.0.1",
+    "pptx-glimpse": "^1.1.1",
     "radix-ui": "^1.5.0",
     "react": "^19",
     "react-dom": "^19",

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -43,7 +43,7 @@
     "@hirokisakabe/pom": "workspace:*",
     "@hirokisakabe/pom-md": "workspace:*",
     "commander": "^15.0.0",
-    "pptx-glimpse": "^1.1.0"
+    "pptx-glimpse": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^25.9.2"

--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -113,7 +113,7 @@
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1",
     "mocha": "^11.7.6",
-    "pptx-glimpse": "^1.0.1",
+    "pptx-glimpse": "^1.1.1",
     "sharp": "^0.34.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^4
         version: 4.6.1(@types/react@19.2.17)(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nextra@4.6.1(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
       pptx-glimpse:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.1
+        version: 1.1.1
       radix-ui:
         specifier: ^1.5.0
         version: 1.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -251,8 +251,8 @@ importers:
         specifier: ^15.0.0
         version: 15.0.0
       pptx-glimpse:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@types/node':
         specifier: ^25.9.2
@@ -338,8 +338,8 @@ importers:
         specifier: ^11.7.6
         version: 11.7.6
       pptx-glimpse:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.1
+        version: 1.1.1
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -6332,12 +6332,8 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  pptx-glimpse@1.0.1:
-    resolution: {integrity: sha512-aZVo5hVEDSB/peKfBxo0xTb+6H2YMin3RP1Fwry37IRDn6K+7RjU/RPliiSJSTNJpgKDQYPLdIejBIoJfapLhw==}
-    engines: {node: '>=22'}
-
-  pptx-glimpse@1.1.0:
-    resolution: {integrity: sha512-yGCg170cWATRnlLv6QZ8ytf6UGoxp2ddWbWd61KdR6D+FR7qXx5GxkY2CZni2NhvIfEUx0Asc/IK0N7qoIgjMg==}
+  pptx-glimpse@1.1.1:
+    resolution: {integrity: sha512-hvCx7fIgmfOjsj6AQH5DoDPEjBAjhVhlggXC6evURI47nmP4Avdj8uX0Kneu+1t4cNNS/Lm1kkTGiWpWgk6s1Q==}
     engines: {node: '>=22'}
 
   pptxgenjs@4.0.1:
@@ -14191,14 +14187,7 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  pptx-glimpse@1.0.1:
-    dependencies:
-      '@resvg/resvg-wasm': 2.6.2
-      fast-xml-parser: 5.8.0
-      fflate: 0.8.3
-      opentype.js: 1.3.4
-
-  pptx-glimpse@1.1.0:
+  pptx-glimpse@1.1.1:
     dependencies:
       '@resvg/resvg-wasm': 2.6.2
       fast-xml-parser: 5.8.0


### PR DESCRIPTION
## 概要

- `pptx-glimpse` を `1.1.1` に更新
- `apps/website`, `packages/pom-cli`, `packages/pom-vscode` の依存宣言を `^1.1.1` に統一
- lockfile から旧バージョン (`1.0.1`, `1.1.0`) を整理
- `@hirokisakabe/pom-cli` / `pom-vscode` の patch changeset を追加

## 影響範囲

- CLI の `pom render` / preview で利用する PPTX → PNG/SVG 変換
- VS Code extension の live preview で利用する PPTX → SVG 変換
- website playground の preview 変換

## 検証

- `pnpm --filter @hirokisakabe/pom-cli run typecheck`
- `pnpm --filter pom-vscode run typecheck`
- `pnpm --filter pom-docs run typecheck`
- `pnpm --filter @hirokisakabe/pom-cli run test:run`
- `NODE_OPTIONS=--max-old-space-size=8192 ../../node_modules/.bin/vitest run --maxWorkers=1 --no-file-parallelism` (`packages/pom-vscode`)
- `pnpm --filter @hirokisakabe/pom-cli run build`
- `pnpm --filter pom-vscode run build`

補足: `pnpm --filter pom-vscode run test:run` はローカルの `packages/pom-vscode/node_modules/.bin/vitest` が古い pnpm store path を指していたため `MODULE_NOT_FOUND` で失敗しました。root の Vitest binary を使うと実行でき、通常 heap では integration test worker が OOM したため、heap を 8GB に増やして全 48 tests の通過を確認しています。