### PR TITLE
docs: 直近マージ後のドキュメント追従漏れを整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - **AI Friendly** — Simple XML structure designed for LLM code generation.
 - **Declarative** — Describe slides as XML. No imperative API calls needed.
 - **Flexible Layout** — Flexbox-style layout with VStack / HStack, powered by yoga-layout.
-- **Rich Nodes** — 18 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
+- **Rich Nodes** — 20 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
 - **Schema-validated** — XML input is validated with Zod schemas at runtime with clear error messages.
 - **PowerPoint Native** — Full access to native PowerPoint shape features (roundRect, ellipse, arrows, etc.).
 
@@ -45,10 +45,12 @@ npm install @hirokisakabe/pom
 import { buildPptx } from "@hirokisakabe/pom";
 
 const xml = `
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
-  <Text fontSize="48" bold="true">Presentation Title</Text>
-  <Text fontSize="24" color="666666">Subtitle</Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+    <Text fontSize="48" bold="true">Presentation Title</Text>
+    <Text fontSize="24" color="666666">Subtitle</Text>
+  </VStack>
+</Slide>
 `;
 
 const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -16,6 +16,7 @@ import matrixImg from "@/content/images/matrix.png";
 import processArrowImg from "@/content/images/processArrow.png";
 import pyramidImg from "@/content/images/pyramid.png";
 import shapeImg from "@/content/images/shape.png";
+import svgImg from "@/content/images/svg.png";
 import tableImg from "@/content/images/table.png";
 import textImg from "@/content/images/text.png";
 import timelineImg from "@/content/images/timeline.png";
@@ -54,7 +55,7 @@ const features = [
   {
     title: "Rich Nodes",
     description:
-      "18 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.",
+      "20 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.",
     icon: "🧩",
   },
   {
@@ -88,19 +89,22 @@ const nodes: { name: string; image: StaticImageData }[] = [
   { name: "Layer", image: layerImg },
   { name: "VStack", image: vstackImg },
   { name: "HStack", image: hstackImg },
+  { name: "Svg", image: svgImg },
 ];
 
 const codeExample = `import { buildPptx } from "@hirokisakabe/pom";
 
 const xml = \`
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
-  <Text fontSize="48" bold="true">
-    Presentation Title
-  </Text>
-  <Text fontSize="24" color="666666">
-    Generated with pom
-  </Text>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+    <Text fontSize="48" bold="true">
+      Presentation Title
+    </Text>
+    <Text fontSize="24" color="666666">
+      Generated with pom
+    </Text>
+  </VStack>
+</Slide>
 \`;
 
 const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
@@ -165,7 +169,7 @@ export default async function LandingPage() {
         </h1>
         <p className="mb-10 max-w-2xl text-lg text-gray-600 dark:text-gray-400">
           Write XML. Get editable PPTX. pom turns declarative markup into native
-          PowerPoint slides with Flexbox layout, 18 built-in node types, and
+          PowerPoint slides with Flexbox layout, 20 built-in node types, and
           first-class AI support.
         </p>
         <div className="flex gap-4">

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -118,6 +118,10 @@ To print per-step timing on stderr:
 pom render slides.pom.xml -o ./images --verbose
 ```
 
+## Diagnostics
+
+`pom build` and `pom render` invoke `buildPptx` with `strict: true`, so any layout diagnostic (e.g. `NODE_OUT_OF_BOUNDS`, `NODE_OVERLAP`, `ARROW_REF_NOT_FOUND`, `PER_SIDE_BORDER_WITH_RADIUS`) fails the run with a non-zero exit code and prints the diagnostic codes / messages to stderr. Fix the offending XML and re-run to proceed. The `pom preview` server continues to update even when diagnostics are emitted, so you can iterate on the file interactively.
+
 ## Fonts
 
 This package bundles Carlito and Noto Sans CJK JP fonts for image rendering. These fonts are used when converting slides to SVG in the preview server and to PNG / SVG in `pom render`. System fonts are not scanned.

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -120,7 +120,7 @@ pom render slides.pom.xml -o ./images --verbose
 
 ## Diagnostics
 
-`pom build` and `pom render` invoke `buildPptx` with `strict: true`, so any layout diagnostic (e.g. `NODE_OUT_OF_BOUNDS`, `NODE_OVERLAP`, `ARROW_REF_NOT_FOUND`, `PER_SIDE_BORDER_WITH_RADIUS`) fails the run with a non-zero exit code and prints the diagnostic codes / messages to stderr. Fix the offending XML and re-run to proceed. The `pom preview` server continues to update even when diagnostics are emitted, so you can iterate on the file interactively.
+`pom build` and `pom render` invoke `buildPptx` with `strict: true`, so any diagnostic collected during the build — layout problems (`NODE_OUT_OF_BOUNDS`, `NODE_OVERLAP`, `ARROW_REF_NOT_FOUND`, `PER_SIDE_BORDER_WITH_RADIUS`), image / master issues (`IMAGE_MEASURE_FAILED`, `IMAGE_NOT_PREFETCHED`, `MASTER_PPTX_PARSE_FAILED`), or `AUTOFIT_OVERFLOW` — fails the run with a non-zero exit code and prints the diagnostic codes / messages to stderr. Fix the offending XML or input and re-run to proceed. The `pom preview` server continues to update even when diagnostics are emitted, so you can iterate on the file interactively.
 
 ## Fonts
 

--- a/packages/pom-md/README.md
+++ b/packages/pom-md/README.md
@@ -27,7 +27,14 @@ size: 16:9
 ## Detailed Data
 
 ```pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 ```
 
 ---
@@ -35,10 +42,12 @@ size: 16:9
 ## Process
 
 ```pomxml
-<Flow>
-  <Step>Plan</Step>
-  <Step>Develop</Step>
-  <Step>Release</Step>
+<Flow direction="horizontal" w="600" h="200">
+  <FlowNode id="plan" shape="flowChartProcess" text="Plan" />
+  <FlowNode id="develop" shape="flowChartProcess" text="Develop" />
+  <FlowNode id="release" shape="flowChartTerminator" text="Release" />
+  <FlowConnection from="plan" to="develop" />
+  <FlowConnection from="develop" to="release" />
 </Flow>
 ```
 ````

--- a/packages/pom-md/README.md
+++ b/packages/pom-md/README.md
@@ -127,7 +127,14 @@ For complex diagrams that Markdown cannot express, embed pom XML directly:
 
 ````markdown
 ```pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 ```
 ````
 

--- a/packages/pom-md/docs/index.md
+++ b/packages/pom-md/docs/index.md
@@ -27,7 +27,14 @@ size: 16:9
 ## Detailed Data
 
 ```pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 ```
 ````
 

--- a/packages/pom-md/docs/pomxml-code-fence.md
+++ b/packages/pom-md/docs/pomxml-code-fence.md
@@ -8,7 +8,14 @@ Wrap pom XML in a fenced code block with the `pomxml` language identifier:
 
 ````markdown
 ```pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 ```
 ````
 
@@ -20,7 +27,14 @@ The content inside `pomxml` fences is passed through to the output XML as-is, wi
 
 ````markdown
 ```pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 ```
 ````
 
@@ -28,10 +42,12 @@ The content inside `pomxml` fences is passed through to the output XML as-is, wi
 
 ````markdown
 ```pomxml
-<Flow>
-  <Step>Plan</Step>
-  <Step>Develop</Step>
-  <Step>Release</Step>
+<Flow direction="horizontal" w="600" h="200">
+  <FlowNode id="plan" shape="flowChartProcess" text="Plan" />
+  <FlowNode id="develop" shape="flowChartProcess" text="Develop" />
+  <FlowNode id="release" shape="flowChartTerminator" text="Release" />
+  <FlowConnection from="plan" to="develop" />
+  <FlowConnection from="develop" to="release" />
 </Flow>
 ```
 ````
@@ -40,10 +56,10 @@ The content inside `pomxml` fences is passed through to the output XML as-is, wi
 
 ````markdown
 ```pomxml
-<Timeline>
-  <Event>Phase 1</Event>
-  <Event>Phase 2</Event>
-  <Event>Phase 3</Event>
+<Timeline direction="horizontal" w="900" h="120">
+  <TimelineItem date="Q1" title="Phase 1" />
+  <TimelineItem date="Q2" title="Phase 2" />
+  <TimelineItem date="Q3" title="Phase 3" />
 </Timeline>
 ```
 ````
@@ -59,7 +75,14 @@ You can freely mix Markdown content and `pomxml` code fences within the same sli
 - Budget within target
 
 ```pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 ```
 ````
 

--- a/packages/pom-md/src/parseMd.test.ts
+++ b/packages/pom-md/src/parseMd.test.ts
@@ -93,12 +93,16 @@ describe("parseMd", () => {
       const md = `# タイトル
 
 \`\`\`pomxml
-<Chart type="bar" labels="Q1,Q2" values="100,200" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="200" />
+  </ChartSeries>
+</Chart>
 \`\`\``;
       const { xml } = parseMd(md);
-      expect(xml).toContain(
-        '<Chart type="bar" labels="Q1,Q2" values="100,200" />',
-      );
+      expect(xml).toContain('<Chart chartType="bar"');
+      expect(xml).toContain('<ChartDataPoint label="Q1" value="100"');
     });
 
     it("pomxml 以外のコードフェンスは無視する", () => {
@@ -507,7 +511,14 @@ size: 16:9
 ## 詳細データ
 
 \`\`\`pomxml
-<Chart type="bar" labels="Q1,Q2,Q3,Q4" values="100,80,120,150" />
+<Chart chartType="bar" w="600" h="300">
+  <ChartSeries name="Revenue">
+    <ChartDataPoint label="Q1" value="100" />
+    <ChartDataPoint label="Q2" value="80" />
+    <ChartDataPoint label="Q3" value="120" />
+    <ChartDataPoint label="Q4" value="150" />
+  </ChartSeries>
+</Chart>
 \`\`\`
 
 ---
@@ -515,10 +526,12 @@ size: 16:9
 ## プロセス
 
 \`\`\`pomxml
-<Flow>
-  <Step>企画</Step>
-  <Step>開発</Step>
-  <Step>リリース</Step>
+<Flow direction="horizontal" w="600" h="200">
+  <FlowNode id="plan" shape="flowChartProcess" text="企画" />
+  <FlowNode id="develop" shape="flowChartProcess" text="開発" />
+  <FlowNode id="release" shape="flowChartTerminator" text="リリース" />
+  <FlowConnection from="plan" to="develop" />
+  <FlowConnection from="develop" to="release" />
 </Flow>
 \`\`\``;
       const { xml } = parseMd(md);
@@ -534,11 +547,11 @@ size: 16:9
 
       // スライド 2
       expect(xml).toContain("詳細データ");
-      expect(xml).toContain('<Chart type="bar"');
+      expect(xml).toContain('<Chart chartType="bar"');
 
       // スライド 3
       expect(xml).toContain("プロセス");
-      expect(xml).toContain("<Flow>");
+      expect(xml).toContain("<Flow");
     });
   });
 });

--- a/packages/pom-md/src/parseMd.ts
+++ b/packages/pom-md/src/parseMd.ts
@@ -340,7 +340,12 @@ function collectTable(
  * ## 詳細
  *
  * \`\`\`pomxml
- * <Chart type="bar" labels="Q1,Q2" values="100,200" />
+ * <Chart chartType="bar" w="600" h="300">
+ *   <ChartSeries name="Revenue">
+ *     <ChartDataPoint label="Q1" value="100" />
+ *     <ChartDataPoint label="Q2" value="200" />
+ *   </ChartSeries>
+ * </Chart>
  * \`\`\`
  * `);
  *

--- a/packages/pom-vscode/docs/supported-formats.md
+++ b/packages/pom-vscode/docs/supported-formats.md
@@ -28,13 +28,15 @@ Write slides directly in pom XML for full control over layout and styling.
 **Pipeline:** `.pom.xml → buildPptx() → pptx-glimpse → SVG → Webview`
 
 ```xml
-<VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
-  <Text fontSize="28" bold="true">Hello World</Text>
-  <Ul>
-    <Li>First point</Li>
-    <Li>Second point</Li>
-  </Ul>
-</VStack>
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+    <Text fontSize="28" bold="true">Hello World</Text>
+    <Ul>
+      <Li>First point</Li>
+      <Li>Second point</Li>
+    </Ul>
+  </VStack>
+</Slide>
 ```
 
 See the [Nodes](/nodes) reference for the full list of available XML nodes and their attributes.

--- a/packages/pom/README.md
+++ b/packages/pom/README.md
@@ -40,7 +40,7 @@
 - **Flexible Layout** — Flexbox-style layout with VStack / HStack, powered by yoga-layout. Ratio-based layouts (e.g., 2:1 columns) via the `grow` attribute (CSS `flex-grow`).
 - **Shorthand + Dot Notation** — Layout/style attributes (e.g. `padding`, `margin`, `border`, `fill`, `shadow`) can mix shorthand and dot notation on the same node. Shorthand sets defaults and dot notation overrides specific keys.
 - **Per-Side Borders** — `borderTop` / `borderRight` / `borderBottom` / `borderLeft` style each edge independently (e.g. `borderLeft.width="6"` for an accent bar, `borderBottom.width="3"` for an underlined heading), merging field-by-field with the uniform `border`. See [Nodes — Common Properties](./docs/nodes.md#common-properties).
-- **Rich Nodes** — 18 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
+- **Rich Nodes** — 20 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
 - **Design Tokens** — Declare a color palette once with a top-level `<Theme>` element and reference tokens as `$name` from any color attribute. See [Nodes — Top-Level `<Theme>`](./docs/nodes.md#top-level-theme-design-tokens).
 - **Schema-validated** — XML input is validated with Zod schemas at runtime with clear error messages.
 - **PowerPoint Native** — Generates real editable PowerPoint shapes — not images. Recipients can modify everything. Linear gradient backgrounds (`backgroundGradient="linear-gradient(135deg, #667EEA 0%, #764BA2 100%)"`) are exported as native gradient fills.

--- a/packages/pom/docs/api-reference.md
+++ b/packages/pom/docs/api-reference.md
@@ -15,8 +15,9 @@ async function buildPptx(
     masterPptx?: ArrayBuffer | Uint8Array;
     textMeasurement?: TextMeasurementMode;
     autoFit?: boolean;
+    strict?: boolean;
   },
-): Promise<PptxGenJS>;
+): Promise<BuildPptxResult>;
 ```
 
 ### Parameters

--- a/packages/pom/docs/index.mdx
+++ b/packages/pom/docs/index.mdx
@@ -11,7 +11,8 @@
 - **AI Friendly** — Simple XML structure suited for LLM code generation
 - **Declarative** — Describe slides in XML. No imperative API calls needed
 - **Flexible Layout** — Flexbox-style layout powered by yoga-layout (VStack / HStack)
-- **Rich Nodes** — 18 built-in node types: charts, flowcharts, tables, timelines, and more
+- **Rich Nodes** — 20 built-in node types: charts, flowcharts, tables, timelines, and more
+- **Design Tokens** — Declare a color palette once with a top-level `<Theme>` element and reference tokens as `$name` from any color attribute
 - **Schema-validated** — Runtime validation with Zod schemas
 - **PowerPoint Native** — Full use of native PowerPoint shape features
 - **Pixel Units** — Intuitive pixel-based sizing (internally converted to inches at 96 DPI)
@@ -62,10 +63,12 @@ Each slide must be wrapped in a `<Slide>` element. To produce multiple slides, l
 | ProcessArrow | Chevron-style process diagram                 |
 | Pyramid      | Pyramid diagram                               |
 | Line         | Line / arrow                                  |
+| Arrow        | Connector between nodes referenced by `id`    |
 | Layer        | Absolute positioning container                |
 | VStack       | Vertical stack layout                         |
 | HStack       | Horizontal stack layout                       |
 | Icon         | Lucide icon                                   |
+| Svg          | Inline SVG graphic                            |
 
 See the [Nodes](/nodes) for details. For color, font, and visual effect guidance, see the [Styling Guide](/styling-guide).
 

--- a/packages/pom/docs/nodes.md
+++ b/packages/pom/docs/nodes.md
@@ -208,6 +208,8 @@ A node for displaying bullet-point lists. Use `<Li>` child elements to define li
 
 Li also supports `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, and `<Span>` inline formatting: `<Li>Normal <B>bold</B> item</Li>`, `<Li>See <A href="https://example.com">link</A></Li>`, `<Li><U>underline</U> item</Li>`, `<Li><Span color="FF0000">red</Span> item</Li>`
 
+> **Line spacing convention:** `Ul` / `Ol` use a different line-spacing rule than `Text`. The rendered row height (and the yoga layout measurement) follows the bundled-font line-height ratio multiplied by `lineHeight`: `measureFontLineHeightRatio × lineHeight × fontSize`. In contrast, `Text` (and the text inside `Shape`) uses a fixed value of `lineHeight × fontSize` for both measurement and rendering (PowerPoint `spcPts`). Use the same `lineHeight` value when you want a `Ul` block and a `Text` block to look visually consistent; the absolute pixel values may differ slightly. See [Text Measurement — Line Height and Rendering](./text-measurement.md#line-height-and-rendering).
+
 ### 3. Ol (Ordered List)
 
 A node for displaying numbered lists. Has all Ul attributes plus the following:

--- a/packages/pom/docs/styling-guide.md
+++ b/packages/pom/docs/styling-guide.md
@@ -12,6 +12,29 @@ Colors are specified as **6-digit hex without the `#` prefix** (e.g., `FF0000`, 
 <VStack backgroundColor="F8F9FA"><Text>Light gray background</Text></VStack>
 ```
 
+### Design Tokens with `<Theme>`
+
+Declare a color palette once at the top level with a `<Theme>` element and reference each token from any color attribute as `$tokenName`. This keeps the palette in one place instead of repeating hex values on every node.
+
+```xml
+<Theme surface="0F172A" accent="38BDF8" textMain="F8FAFC" textMuted="94A3B8" />
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="16" backgroundColor="$surface">
+    <Text fontSize="28" color="$textMain" bold="true">Title</Text>
+    <Timeline dateColor="$textMuted" titleColor="$textMain" w="1000" h="120">
+      <TimelineItem date="Q1" title="Phase 1" color="$accent" />
+    </Timeline>
+  </VStack>
+</Slide>
+```
+
+- At most one `<Theme>` per document; it applies to all slides regardless of position.
+- `$tokenName` references are resolved in color attributes (any attribute ending in `Color` / `Colors`, `color` keys inside object/JSON attributes, `highlight`) and inside `backgroundGradient` strings.
+- Composite nodes (`Timeline`, `Matrix`, `Tree`, `Flow`) expose dedicated text-color attributes (e.g. `dateColor` / `titleColor` / `axisLabelColor` / `textColor` / `connectorStyle.labelColor`) so the whole deck — including labels on charts and diagrams — can be retinted from a single `<Theme>`.
+- Token names start with a letter and may contain letters, digits, `_`, and `-`. Values are 6-digit hex (`#` prefix optional). Referencing an unknown token throws a `ParseXmlError` with a "did you mean" suggestion.
+
+See [Nodes — Top-Level `<Theme>`](./nodes.md#top-level-theme-design-tokens) for the full reference.
+
 ### Recommended Color Palette
 
 A set of colors that work well for business presentations:
@@ -63,12 +86,16 @@ The default font is **Noto Sans JP**, bundled with pom for accurate text measure
 
 ### Line Height
 
-Control line spacing with `lineHeight` (multiplier, default: `1.3`).
+Control line spacing with `lineHeight` (multiplier of `fontSize`, default: `1.3`).
 
 ```xml
 <Text lineHeight="1.5">Wider line spacing for readability</Text>
 <Text lineHeight="1.0">Tight line spacing</Text>
 ```
+
+For `Text` (and the text inside `Shape`), `lineHeight` is reflected in both the yoga layout measurement (block height = lines × `fontSize` × `lineHeight`) and the rendered line spacing, which is emitted as a fixed value (PowerPoint `spcPts`) of `fontSize × lineHeight`. This keeps the measured height and the rendered line height aligned, so a tall `lineHeight` no longer creates asymmetric whitespace above/below the glyph ink.
+
+`Ul` / `Ol` use a different convention. Their line spacing is rendered as a multiplier (PowerPoint `spcPct`) of the bundled-font metric, so the effective row height is `measureFontLineHeightRatio × lineHeight × fontSize`. Use the same `lineHeight` value when you want `Text` and `Ul` blocks to look visually consistent; the absolute pixel values may differ slightly.
 
 ## Text Decoration
 
@@ -134,6 +161,26 @@ Apply a background highlight to text:
 <Text highlight="90EE90">Green highlighted text</Text>
 ```
 
+### Text Effects (glow / outline)
+
+`glow` adds a glow halo around the characters; `outline` draws a border along the character edges. Both are exported as native PowerPoint text effects (editable, not rasterized) and are useful for keeping titles legible on top of background images.
+
+```xml
+<Text fontSize="40" bold="true" color="FFFFFF" glow.size="8" glow.opacity="0.5" glow.color="1D4ED8">Glowing title</Text>
+<Text fontSize="40" bold="true" color="FFFFFF" outline.size="2" outline.color="0F172A">Outlined title</Text>
+```
+
+| Property         | Type   | Description                                       |
+| ---------------- | ------ | ------------------------------------------------- |
+| `glow.size`      | number | Glow radius in px (default: `8`)                  |
+| `glow.opacity`   | 0–1    | Glow opacity (default: `0.75`)                    |
+| `glow.color`     | hex    | Glow color (default: `FFFFFF`)                    |
+| `outline.size`   | number | Outline width in px (default: `1`)                |
+| `outline.color`  | hex    | Outline color (default: `FFFFFF`)                 |
+
+- Both apply per text node. When inline formatting (`<B>`, `<Span>`, ...) is used, the node-level effect applies to all runs.
+- LibreOffice does not render character glow (outline renders fine); open the PPTX in PowerPoint to see the glow.
+
 ### Text Alignment
 
 ```xml
@@ -197,6 +244,18 @@ Round corners with `borderRadius`:
 <Text backgroundColor="1D4ED8" borderRadius="8" padding="16" color="FFFFFF">Rounded box</Text>
 ```
 
+### Per-Side Border
+
+Style each edge independently with `borderTop` / `borderRight` / `borderBottom` / `borderLeft`. Each uses the same fields as `border` (`color` / `width` / `dashType`).
+
+```xml
+<Text borderLeft.color="1D4ED8" borderLeft.width="6" padding.left="16">Accent bar</Text>
+<Text borderBottom.color="333333" borderBottom.width="3">Underlined heading</Text>
+```
+
+- Per-side values merge field-by-field with the uniform `border` (per-side takes precedence) — `border.color="E5E7EB" border.width="1" borderLeft.width="6"` is a thin frame with a thick left accent.
+- Per-side borders **cannot be combined with `borderRadius`**. When both are specified, the per-side values are ignored and the uniform `border` style is used, and a `PER_SIDE_BORDER_WITH_RADIUS` diagnostic is emitted at build time.
+
 ## Shadow
 
 Add drop shadows to any node (except Line):
@@ -225,6 +284,19 @@ Control background transparency with `opacity` (0 = fully transparent, 1 = fully
 ```xml
 <Text backgroundColor="1D4ED8" opacity="0.5" padding="16">Semi-transparent blue background</Text>
 ```
+
+## Rotation
+
+`Text`, `Shape`, `Image`, and `Icon` accept `rotate` as a number of degrees clockwise. Rotation is applied only when rendering to PowerPoint; yoga layout uses the unrotated bounding box, so the rotated node does not change sibling placement or the parent's size.
+
+```xml
+<Text rotate="12">Rotated label</Text>
+<Shape shapeType="rect" w="120" h="60" rotate="-15" />
+<Image src="sample.png" w="160" h="100" rotate="8" />
+<Icon name="cpu" rotate="45" />
+```
+
+> Rotated nodes are intentionally excluded from the `NODE_OUT_OF_BOUNDS` diagnostic because their final bounds cannot be derived from the static layout — verify them visually.
 
 ### Overlay Pattern with Layer
 

--- a/packages/pom/docs/styling-guide.md
+++ b/packages/pom/docs/styling-guide.md
@@ -170,13 +170,13 @@ Apply a background highlight to text:
 <Text fontSize="40" bold="true" color="FFFFFF" outline.size="2" outline.color="0F172A">Outlined title</Text>
 ```
 
-| Property         | Type   | Description                                       |
-| ---------------- | ------ | ------------------------------------------------- |
-| `glow.size`      | number | Glow radius in px (default: `8`)                  |
-| `glow.opacity`   | 0–1    | Glow opacity (default: `0.75`)                    |
-| `glow.color`     | hex    | Glow color (default: `FFFFFF`)                    |
-| `outline.size`   | number | Outline width in px (default: `1`)                |
-| `outline.color`  | hex    | Outline color (default: `FFFFFF`)                 |
+| Property        | Type   | Description                        |
+| --------------- | ------ | ---------------------------------- |
+| `glow.size`     | number | Glow radius in px (default: `8`)   |
+| `glow.opacity`  | 0–1    | Glow opacity (default: `0.75`)     |
+| `glow.color`    | hex    | Glow color (default: `FFFFFF`)     |
+| `outline.size`  | number | Outline width in px (default: `1`) |
+| `outline.color` | hex    | Outline color (default: `FFFFFF`)  |
 
 - Both apply per text node. When inline formatting (`<B>`, `<Span>`, ...) is used, the node-level effect applies to all runs.
 - LibreOffice does not render character glow (outline renders fine); open the PPTX in PowerPoint to see the glow.

--- a/packages/pom/docs/text-measurement.md
+++ b/packages/pom/docs/text-measurement.md
@@ -48,7 +48,7 @@ Font resolution applies consistently to all text-bearing nodes: `Text`, `Ul`, `O
 
 The user-supplied `lineHeight` (default `1.3`) is reflected in the yoga layout measurement of `Text` (and the text inside `Shape`): the block height is `lines × fontSize × lineHeight`.
 
-To keep the measured height aligned with the rendered output, the renderer emits the line spacing as a fixed value (PowerPoint `spcPts` = `fontSize × lineHeight` in pt). Using a fixed value instead of a multiplier (`spcPct`) avoids font-metric mismatches that previously left asymmetric whitespace above/below the glyph ink — see [#846](https://github.com/hirokisakabe/pom/pull/854). Glyphs are also vertically centered within the line box so a custom `lineHeight` produces evenly distributed top/bottom padding.
+To keep the measured height aligned with the rendered output, the renderer emits the line spacing as a fixed value (PowerPoint `spcPts` = `fontSize × lineHeight` in pt). Using a fixed value instead of a multiplier (`spcPct`) avoids font-metric mismatches that previously left asymmetric whitespace above/below the glyph ink — see [PR #854](https://github.com/hirokisakabe/pom/pull/854). Glyphs are also vertically centered within the line box so a custom `lineHeight` produces evenly distributed top/bottom padding.
 
 `Ul` / `Ol` still use the multiplier form (`spcPct` = `lineHeight` × bundled-font line-height ratio). Their measurement and rendering both go through `measureFontLineHeightRatio × lineHeight`, so the block height matches the rendered line spacing, but it differs slightly from a `Text` block with the same `lineHeight`.
 

--- a/packages/pom/docs/text-measurement.md
+++ b/packages/pom/docs/text-measurement.md
@@ -43,3 +43,13 @@ Font resolution applies consistently to all text-bearing nodes: `Text`, `Ul`, `O
 - **All environments**: Default (`"auto"`) works fine - bundled fonts ensure consistent results
 - **Reduced bundle size**: Use `"fallback"` if you want to avoid loading bundled fonts (less accurate but smaller bundle)
 - **Custom fonts**: When using `fontFamily` other than `Noto Sans JP`, pom automatically uses fallback measurement to avoid metric mismatch
+
+## Line Height and Rendering
+
+The user-supplied `lineHeight` (default `1.3`) is reflected in the yoga layout measurement of `Text` (and the text inside `Shape`): the block height is `lines × fontSize × lineHeight`.
+
+To keep the measured height aligned with the rendered output, the renderer emits the line spacing as a fixed value (PowerPoint `spcPts` = `fontSize × lineHeight` in pt). Using a fixed value instead of a multiplier (`spcPct`) avoids font-metric mismatches that previously left asymmetric whitespace above/below the glyph ink — see [#846](https://github.com/hirokisakabe/pom/pull/854). Glyphs are also vertically centered within the line box so a custom `lineHeight` produces evenly distributed top/bottom padding.
+
+`Ul` / `Ol` still use the multiplier form (`spcPct` = `lineHeight` × bundled-font line-height ratio). Their measurement and rendering both go through `measureFontLineHeightRatio × lineHeight`, so the block height matches the rendered line spacing, but it differs slightly from a `Text` block with the same `lineHeight`.
+
+The PNG / SVG output produced by `pom render` and the previews shown by `pom preview` / pom-vscode go through `pptx-glimpse`, which has supported `spcPts` since version 1.1.1. Both rendering paths now honor the fixed `Text` line spacing emitted by pom.

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -16,6 +16,7 @@ metadata:
 ユーザーの指示からスライドの内容・枚数・テーマを把握する。
 
 明示されていない場合のデフォルト:
+
 - 枚数: 指示の内容量に適した枚数（3〜8 枚程度）
 - ファイル名: `slides.pom.xml`
 
@@ -42,34 +43,34 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
 
 デッキごとに以下の 5 ロールの色を決める。アクセントは 1 色に絞り、使用面積はスライドの 1 割以下に抑える（見出し脇のバー、強調数字、アイコンなど）。
 
-| ロール | 役割 |
-| --- | --- |
-| base | スライド背景。真っ白 `FFFFFF` 固定にしない（オフホワイトやダークも検討する） |
-| surface | カード・パネルの背景 |
-| ink | 本文テキスト。純黒 `000000` は避ける |
-| muted | 補助テキスト・キャプション |
-| accent | 強調 1 色。多用しない |
+| ロール  | 役割                                                                         |
+| ------- | ---------------------------------------------------------------------------- |
+| base    | スライド背景。真っ白 `FFFFFF` 固定にしない（オフホワイトやダークも検討する） |
+| surface | カード・パネルの背景                                                         |
+| ink     | 本文テキスト。純黒 `000000` は避ける                                         |
+| muted   | 補助テキスト・キャプション                                                   |
+| accent  | 強調 1 色。多用しない                                                        |
 
 プリセット例（そのまま使ってよいが、テーマに合わせて調整する）:
 
-| トーン | base | surface | ink | muted | accent |
-| --- | --- | --- | --- | --- | --- |
-| コーポレート | `F8F9FB` | `FFFFFF` | `1F2937` | `6B7280` | `1E3A8A` |
+| トーン                   | base     | surface  | ink      | muted    | accent   |
+| ------------------------ | -------- | -------- | -------- | -------- | -------- |
+| コーポレート             | `F8F9FB` | `FFFFFF` | `1F2937` | `6B7280` | `1E3A8A` |
 | ウォーム・エディトリアル | `FAF6F0` | `FFFFFF` | `292524` | `78716C` | `C2410C` |
-| ダーク・テック | `0F172A` | `1E293B` | `F1F5F9` | `94A3B8` | `38BDF8` |
-| フレッシュ | `F6FBF9` | `FFFFFF` | `1A2E2A` | `5F7470` | `0D9488` |
+| ダーク・テック           | `0F172A` | `1E293B` | `F1F5F9` | `94A3B8` | `38BDF8` |
+| フレッシュ               | `F6FBF9` | `FFFFFF` | `1A2E2A` | `5F7470` | `0D9488` |
 
 #### タイポグラフィスケール
 
 デッキ全体で以下の 5 段階だけを使う。中間サイズを場当たりで増やさず、1 枚のスライドに使うのは最大 3 段階まで。
 
-| 段階 | fontSize | 用途 |
-| --- | --- | --- |
-| display | 44〜60, bold | 表紙タイトル、KPI の数字 |
-| title | 28〜32, bold | スライドタイトル |
-| heading | 18〜20, bold | カード見出し・小見出し |
-| body | 14〜16 | 本文・箇条書き |
-| caption | 11〜12, muted 色 | 補足・出典・ページ番号 |
+| 段階    | fontSize         | 用途                     |
+| ------- | ---------------- | ------------------------ |
+| display | 44〜60, bold     | 表紙タイトル、KPI の数字 |
+| title   | 28〜32, bold     | スライドタイトル         |
+| heading | 18〜20, bold     | カード見出し・小見出し   |
+| body    | 14〜16           | 本文・箇条書き           |
+| caption | 11〜12, muted 色 | 補足・出典・ページ番号   |
 
 - タイトルと本文のジャンプ率（サイズ差）をはっきりつける。中途半端な差（例: 24 と 20 の併用）は階層を曖昧にする
 - bold は display / title / heading と強調語のみ。本文全体を bold にしない
@@ -88,17 +89,17 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
 
 デッキは以下のアーキタイプの組み合わせで構成する。全スライドを同じレイアウトにせず、アーキタイプを切り替えてリズムを作る。
 
-| アーキタイプ | 構成 |
-| --- | --- |
-| 表紙 | display タイトル + サブタイトル + アクセントの細いバー。要素を絞り、余白を大胆に取る |
-| アジェンダ | accent 色の番号 + 項目名の縦リスト |
-| セクション扉 | 章番号と章タイトルのみ。表紙と同系の構成にして本編スライドと区別する |
-| キーメッセージ | title + 本文 or 箇条書き。最も基本の 1 カラム |
-| 比較 | 見出し付きカード 2〜3 枚を HStack で均等幅に並べる |
-| タイムライン / プロセス | `Timeline` / `ProcessArrow` ノードを使う |
-| データ | `Chart` / `Table` + そこから言えるインサイト 1 行（heading） |
-| KPI | display サイズの数字 2〜4 個 + caption のラベル |
-| まとめ / CTA | キーメッセージの再掲 + 次のアクション |
+| アーキタイプ            | 構成                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| 表紙                    | display タイトル + サブタイトル + アクセントの細いバー。要素を絞り、余白を大胆に取る |
+| アジェンダ              | accent 色の番号 + 項目名の縦リスト                                                   |
+| セクション扉            | 章番号と章タイトルのみ。表紙と同系の構成にして本編スライドと区別する                 |
+| キーメッセージ          | title + 本文 or 箇条書き。最も基本の 1 カラム                                        |
+| 比較                    | 見出し付きカード 2〜3 枚を HStack で均等幅に並べる                                   |
+| タイムライン / プロセス | `Timeline` / `ProcessArrow` ノードを使う                                             |
+| データ                  | `Chart` / `Table` + そこから言えるインサイト 1 行（heading）                         |
+| KPI                     | display サイズの数字 2〜4 個 + caption のラベル                                      |
+| まとめ / CTA            | キーメッセージの再掲 + 次のアクション                                                |
 
 **縦方向の揃え**: アクセントバー・番号・アイコンなど高さの異なる要素をテキストと HStack で並べるときは `alignItems="center"` を基本にする。`Text` のレイアウトボックスは `fontSize × lineHeight` の高さを持つが、グリフは行ボックス内で上下中央に描画されるため、`center` で揃えると隣接要素も視覚的にテキストの中央に揃う。文字の baseline と合わせたいときは `end` を使う。
 
@@ -168,6 +169,7 @@ Step 2 で決めたデザイントークンとアーキタイプを全スライ�
 ---
 
 <!-- BEGIN llm.txt -->
+
 # pom XML Reference
 
 A compact reference for the pom XML format, designed to be pasted into LLM prompts.
@@ -224,31 +226,31 @@ Declare a color palette once at the top level and reference each token from any 
 
 ## Common Attributes (All Nodes)
 
-| Attribute         | Type                                                       | Description                                |
-| ----------------- | ---------------------------------------------------------- | ------------------------------------------ |
-| `id`              | string                                                     | Unique identifier within the slide (used by `Arrow` connectors) |
-| `w`               | number / `"max"` / `"50%"`                                 | Width                                      |
-| `h`               | number / `"max"` / `"50%"`                                 | Height                                     |
-| `grow`            | positive number                                            | Flex grow ratio among siblings (CSS `flex-grow`). `grow="2"` and `grow="1"` produce a 2:1 split. Along the parent's main axis `w="max"` / `h="max"` behave as `grow="1"`; when both are specified, `grow` takes precedence |
-| `minW` `maxW`     | number                                                     | Min / max width                            |
-| `minH` `maxH`     | number                                                     | Min / max height                           |
-| `padding`         | number / `padding.top="8" padding.bottom="8"`              | Padding (shorthand + dot notation can be mixed) |
-| `backgroundColor` | hex                                                        | Background color                           |
-| `backgroundGradient` | `linear-gradient(135deg, #667EEA 0%, #764BA2 100%)`     | Linear gradient background. Angle (`<n>deg` or `to right` etc., default `180deg`) + 2 or more hex color stops with optional `%` positions. Takes precedence over `backgroundColor`. On the slide root node it becomes the slide background |
-| `backgroundImage` | `backgroundImage.src="url" backgroundImage.sizing="cover"` | Background image                           |
-| `border`          | `border.color="333" border.width="1"`                      | Border (shorthand + dot notation can be mixed) |
-| `borderTop` `borderRight` `borderBottom` `borderLeft` | `borderLeft.color="1D4ED8" borderLeft.width="6"` | Per-side border with the same fields as `border`. Overrides `border` for that side (field-by-field). Useful for accent bars / underlined headings. Cannot be combined with `borderRadius` (per-side values are ignored with a warning) |
-| `borderRadius`    | number                                                     | Border radius (px)                         |
-| `opacity`         | 0-1                                                        | Background opacity                         |
-| `margin`          | number / `margin.top="8" margin.bottom="8"`                | Margin (shorthand + dot notation can be mixed) |
-| `zIndex`          | number                                                     | Stacking order (higher = on top)           |
-| `position`        | `relative` / `absolute`                                    | Positioning mode                           |
-| `top`             | number                                                     | Top offset (when using position)           |
-| `right`           | number                                                     | Right offset (when using position)         |
-| `bottom`          | number                                                     | Bottom offset (when using position)        |
-| `left`            | number                                                     | Left offset (when using position)          |
-| `alignSelf`       | `auto` / `start` / `center` / `end` / `stretch`            | Override parent's alignItems for this node |
-| `shadow`          | `shadow.type="outer" shadow.blur="4" shadow.offset="2" shadow.color="000"` | Drop shadow (shorthand + dot notation can be mixed; not supported on Line) |
+| Attribute                                             | Type                                                                       | Description                                                                                                                                                                                                                                |
+| ----------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`                                                  | string                                                                     | Unique identifier within the slide (used by `Arrow` connectors)                                                                                                                                                                            |
+| `w`                                                   | number / `"max"` / `"50%"`                                                 | Width                                                                                                                                                                                                                                      |
+| `h`                                                   | number / `"max"` / `"50%"`                                                 | Height                                                                                                                                                                                                                                     |
+| `grow`                                                | positive number                                                            | Flex grow ratio among siblings (CSS `flex-grow`). `grow="2"` and `grow="1"` produce a 2:1 split. Along the parent's main axis `w="max"` / `h="max"` behave as `grow="1"`; when both are specified, `grow` takes precedence                 |
+| `minW` `maxW`                                         | number                                                                     | Min / max width                                                                                                                                                                                                                            |
+| `minH` `maxH`                                         | number                                                                     | Min / max height                                                                                                                                                                                                                           |
+| `padding`                                             | number / `padding.top="8" padding.bottom="8"`                              | Padding (shorthand + dot notation can be mixed)                                                                                                                                                                                            |
+| `backgroundColor`                                     | hex                                                                        | Background color                                                                                                                                                                                                                           |
+| `backgroundGradient`                                  | `linear-gradient(135deg, #667EEA 0%, #764BA2 100%)`                        | Linear gradient background. Angle (`<n>deg` or `to right` etc., default `180deg`) + 2 or more hex color stops with optional `%` positions. Takes precedence over `backgroundColor`. On the slide root node it becomes the slide background |
+| `backgroundImage`                                     | `backgroundImage.src="url" backgroundImage.sizing="cover"`                 | Background image                                                                                                                                                                                                                           |
+| `border`                                              | `border.color="333" border.width="1"`                                      | Border (shorthand + dot notation can be mixed)                                                                                                                                                                                             |
+| `borderTop` `borderRight` `borderBottom` `borderLeft` | `borderLeft.color="1D4ED8" borderLeft.width="6"`                           | Per-side border with the same fields as `border`. Overrides `border` for that side (field-by-field). Useful for accent bars / underlined headings. Cannot be combined with `borderRadius` (per-side values are ignored with a warning)     |
+| `borderRadius`                                        | number                                                                     | Border radius (px)                                                                                                                                                                                                                         |
+| `opacity`                                             | 0-1                                                                        | Background opacity                                                                                                                                                                                                                         |
+| `margin`                                              | number / `margin.top="8" margin.bottom="8"`                                | Margin (shorthand + dot notation can be mixed)                                                                                                                                                                                             |
+| `zIndex`                                              | number                                                                     | Stacking order (higher = on top)                                                                                                                                                                                                           |
+| `position`                                            | `relative` / `absolute`                                                    | Positioning mode                                                                                                                                                                                                                           |
+| `top`                                                 | number                                                                     | Top offset (when using position)                                                                                                                                                                                                           |
+| `right`                                               | number                                                                     | Right offset (when using position)                                                                                                                                                                                                         |
+| `bottom`                                              | number                                                                     | Bottom offset (when using position)                                                                                                                                                                                                        |
+| `left`                                                | number                                                                     | Left offset (when using position)                                                                                                                                                                                                          |
+| `alignSelf`                                           | `auto` / `start` / `center` / `end` / `stretch`                            | Override parent's alignItems for this node                                                                                                                                                                                                 |
+| `shadow`                                              | `shadow.type="outer" shadow.blur="4" shadow.offset="2" shadow.color="000"` | Drop shadow (shorthand + dot notation can be mixed; not supported on Line)                                                                                                                                                                 |
 
 ## Leaf Rotation
 
@@ -378,11 +380,11 @@ All Ul attributes plus:
 <Image src="https://example.com/img.png" w="200" h="150" />
 ```
 
-| Attribute | Type / Values                                                                                                            |
-| --------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `src`     | string (URL / path / base64)                                                                                             |
-| `sizing`  | `'{"type":"contain"}' ` / `'{"type":"cover"}'` / `'{"type":"crop","x":0,"y":0,"w":100,"h":100}'`                         |
-| `rotate`  | number (degrees clockwise, render-only)                                                                                  |
+| Attribute | Type / Values                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------ |
+| `src`     | string (URL / path / base64)                                                                     |
+| `sizing`  | `'{"type":"contain"}' ` / `'{"type":"cover"}'` / `'{"type":"crop","x":0,"y":0,"w":100,"h":100}'` |
+| `rotate`  | number (degrees clockwise, render-only)                                                          |
 
 ### Icon
 
@@ -398,7 +400,7 @@ Displays an icon from the Lucide icon library (1,900+ icons available).
 | `name`    | Lucide icon name (required). See examples below                          |
 | `size`    | number (default: 24, in px)                                              |
 | `color`   | hex color (`#` prefix optional, default: `#000000`)                      |
-| `rotate`  | number (degrees clockwise, render-only)                                |
+| `rotate`  | number (degrees clockwise, render-only)                                  |
 | `variant` | `circle-filled`, `circle-outlined`, `square-filled`, `square-outlined`   |
 | `bgColor` | hex color for background shape (`#` prefix optional, default: `#E0E0E0`) |
 
@@ -414,11 +416,11 @@ Renders an inline SVG as a rasterized PNG image. Use this node for custom SVG gr
 </Svg>
 ```
 
-| Attribute | Type / Values                                          |
-| --------- | ------------------------------------------------------ |
-| `w`       | number (default: 24, width in px)                      |
-| `h`       | number (default: 24, height in px)                     |
-| `color`   | hex color (`#` prefix optional)                        |
+| Attribute | Type / Values                      |
+| --------- | ---------------------------------- |
+| `w`       | number (default: 24, width in px)  |
+| `h`       | number (default: 24, height in px) |
+| `color`   | hex color (`#` prefix optional)    |
 
 A `<svg>` child element is required. When `color` is specified, it sets `stroke` and `fill="none"` on the root `<svg>` element; explicit `stroke`/`fill` on child elements take precedence.
 
@@ -627,7 +629,7 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 | ---------------- | ----------------------------------------------------- |
 | `layout`         | `vertical` / `horizontal`                             |
 | `nodeShape`      | `rect` / `roundRect` / `ellipse`                      |
-| `textColor`      | hex (node label text color, default: `FFFFFF`)       |
+| `textColor`      | hex (node label text color, default: `FFFFFF`)        |
 | `nodeWidth`      | number (default: 120)                                 |
 | `nodeHeight`     | number (default: 40)                                  |
 | `levelGap`       | number (default: 60)                                  |
@@ -650,12 +652,12 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 </Flow>
 ```
 
-| Attribute        | Type / Values                                                                          |
-| ---------------- | -------------------------------------------------------------------------------------- |
-| `direction`      | `horizontal` / `vertical`                                                              |
-| `nodeWidth`      | number (default: 120)                                                                  |
-| `nodeHeight`     | number (default: 60)                                                                   |
-| `nodeGap`        | number (default: 80)                                                                   |
+| Attribute        | Type / Values                                                                                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `direction`      | `horizontal` / `vertical`                                                                                              |
+| `nodeWidth`      | number (default: 120)                                                                                                  |
+| `nodeHeight`     | number (default: 60)                                                                                                   |
+| `nodeGap`        | number (default: 80)                                                                                                   |
 | `connectorStyle` | `connectorStyle.color="hex" connectorStyle.width="2" connectorStyle.arrowType="arrow" connectorStyle.labelColor="hex"` |
 
 `<FlowNode>` attributes:
@@ -721,19 +723,19 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 
 ## Child Element Tag Reference
 
-| Parent Node      | Child Tags                                          | Mapped Property              |
-| ---------------- | --------------------------------------------------- | ---------------------------- |
-| `<Chart>`        | `<ChartSeries>` > `<ChartDataPoint>`                | `data`                       |
-| `<Table>`        | `<Col>`, `<Tr>` > `<Td>`       | `columns`, `rows`            |
+| Parent Node      | Child Tags                                            | Mapped Property              |
+| ---------------- | ----------------------------------------------------- | ---------------------------- |
+| `<Chart>`        | `<ChartSeries>` > `<ChartDataPoint>`                  | `data`                       |
+| `<Table>`        | `<Col>`, `<Tr>` > `<Td>`                              | `columns`, `rows`            |
 | `<Text>`         | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
 | `<Li>`           | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
-| `<Td>`    | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
-| `<Timeline>`     | `<TimelineItem>`                                    | `items`                      |
-| `<Matrix>`       | `<MatrixAxes>`, `<MatrixQuadrants>`, `<MatrixItem>` | `axes`, `quadrants`, `items` |
-| `<Tree>`         | `<TreeItem>` (recursive)                            | `data`                       |
-| `<Flow>`         | `<FlowNode>`, `<FlowConnection>`                    | `nodes`, `connections`       |
-| `<ProcessArrow>` | `<ProcessArrowStep>`                                | `steps`                      |
-| `<Pyramid>`      | `<PyramidLevel>`                                    | `levels`                     |
+| `<Td>`           | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
+| `<Timeline>`     | `<TimelineItem>`                                      | `items`                      |
+| `<Matrix>`       | `<MatrixAxes>`, `<MatrixQuadrants>`, `<MatrixItem>`   | `axes`, `quadrants`, `items` |
+| `<Tree>`         | `<TreeItem>` (recursive)                              | `data`                       |
+| `<Flow>`         | `<FlowNode>`, `<FlowConnection>`                      | `nodes`, `connections`       |
+| `<ProcessArrow>` | `<ProcessArrowStep>`                                  | `steps`                      |
+| `<Pyramid>`      | `<PyramidLevel>`                                      | `levels`                     |
 
 When the same property is specified via both attributes (JSON string) and child elements, child elements take precedence.
 
@@ -845,6 +847,7 @@ pom-cli がない場合はスキップしてその旨を伝える。
 ### 7. 完了報告
 
 以下を報告する:
+
 - 保存したファイル名
 - 生成したスライドの枚数と各スライドのタイトル
 - セルフレビューの結果: 実施した修正の概要と残課題（スキップした場合はその理由）

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -169,7 +169,6 @@ Step 2 で決めたデザイントークンとアーキタイプを全スライ�
 ---
 
 <!-- BEGIN llm.txt -->
-
 # pom XML Reference
 
 A compact reference for the pom XML format, designed to be pasted into LLM prompts.
@@ -226,31 +225,31 @@ Declare a color palette once at the top level and reference each token from any 
 
 ## Common Attributes (All Nodes)
 
-| Attribute                                             | Type                                                                       | Description                                                                                                                                                                                                                                |
-| ----------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `id`                                                  | string                                                                     | Unique identifier within the slide (used by `Arrow` connectors)                                                                                                                                                                            |
-| `w`                                                   | number / `"max"` / `"50%"`                                                 | Width                                                                                                                                                                                                                                      |
-| `h`                                                   | number / `"max"` / `"50%"`                                                 | Height                                                                                                                                                                                                                                     |
-| `grow`                                                | positive number                                                            | Flex grow ratio among siblings (CSS `flex-grow`). `grow="2"` and `grow="1"` produce a 2:1 split. Along the parent's main axis `w="max"` / `h="max"` behave as `grow="1"`; when both are specified, `grow` takes precedence                 |
-| `minW` `maxW`                                         | number                                                                     | Min / max width                                                                                                                                                                                                                            |
-| `minH` `maxH`                                         | number                                                                     | Min / max height                                                                                                                                                                                                                           |
-| `padding`                                             | number / `padding.top="8" padding.bottom="8"`                              | Padding (shorthand + dot notation can be mixed)                                                                                                                                                                                            |
-| `backgroundColor`                                     | hex                                                                        | Background color                                                                                                                                                                                                                           |
-| `backgroundGradient`                                  | `linear-gradient(135deg, #667EEA 0%, #764BA2 100%)`                        | Linear gradient background. Angle (`<n>deg` or `to right` etc., default `180deg`) + 2 or more hex color stops with optional `%` positions. Takes precedence over `backgroundColor`. On the slide root node it becomes the slide background |
-| `backgroundImage`                                     | `backgroundImage.src="url" backgroundImage.sizing="cover"`                 | Background image                                                                                                                                                                                                                           |
-| `border`                                              | `border.color="333" border.width="1"`                                      | Border (shorthand + dot notation can be mixed)                                                                                                                                                                                             |
-| `borderTop` `borderRight` `borderBottom` `borderLeft` | `borderLeft.color="1D4ED8" borderLeft.width="6"`                           | Per-side border with the same fields as `border`. Overrides `border` for that side (field-by-field). Useful for accent bars / underlined headings. Cannot be combined with `borderRadius` (per-side values are ignored with a warning)     |
-| `borderRadius`                                        | number                                                                     | Border radius (px)                                                                                                                                                                                                                         |
-| `opacity`                                             | 0-1                                                                        | Background opacity                                                                                                                                                                                                                         |
-| `margin`                                              | number / `margin.top="8" margin.bottom="8"`                                | Margin (shorthand + dot notation can be mixed)                                                                                                                                                                                             |
-| `zIndex`                                              | number                                                                     | Stacking order (higher = on top)                                                                                                                                                                                                           |
-| `position`                                            | `relative` / `absolute`                                                    | Positioning mode                                                                                                                                                                                                                           |
-| `top`                                                 | number                                                                     | Top offset (when using position)                                                                                                                                                                                                           |
-| `right`                                               | number                                                                     | Right offset (when using position)                                                                                                                                                                                                         |
-| `bottom`                                              | number                                                                     | Bottom offset (when using position)                                                                                                                                                                                                        |
-| `left`                                                | number                                                                     | Left offset (when using position)                                                                                                                                                                                                          |
-| `alignSelf`                                           | `auto` / `start` / `center` / `end` / `stretch`                            | Override parent's alignItems for this node                                                                                                                                                                                                 |
-| `shadow`                                              | `shadow.type="outer" shadow.blur="4" shadow.offset="2" shadow.color="000"` | Drop shadow (shorthand + dot notation can be mixed; not supported on Line)                                                                                                                                                                 |
+| Attribute         | Type                                                       | Description                                |
+| ----------------- | ---------------------------------------------------------- | ------------------------------------------ |
+| `id`              | string                                                     | Unique identifier within the slide (used by `Arrow` connectors) |
+| `w`               | number / `"max"` / `"50%"`                                 | Width                                      |
+| `h`               | number / `"max"` / `"50%"`                                 | Height                                     |
+| `grow`            | positive number                                            | Flex grow ratio among siblings (CSS `flex-grow`). `grow="2"` and `grow="1"` produce a 2:1 split. Along the parent's main axis `w="max"` / `h="max"` behave as `grow="1"`; when both are specified, `grow` takes precedence |
+| `minW` `maxW`     | number                                                     | Min / max width                            |
+| `minH` `maxH`     | number                                                     | Min / max height                           |
+| `padding`         | number / `padding.top="8" padding.bottom="8"`              | Padding (shorthand + dot notation can be mixed) |
+| `backgroundColor` | hex                                                        | Background color                           |
+| `backgroundGradient` | `linear-gradient(135deg, #667EEA 0%, #764BA2 100%)`     | Linear gradient background. Angle (`<n>deg` or `to right` etc., default `180deg`) + 2 or more hex color stops with optional `%` positions. Takes precedence over `backgroundColor`. On the slide root node it becomes the slide background |
+| `backgroundImage` | `backgroundImage.src="url" backgroundImage.sizing="cover"` | Background image                           |
+| `border`          | `border.color="333" border.width="1"`                      | Border (shorthand + dot notation can be mixed) |
+| `borderTop` `borderRight` `borderBottom` `borderLeft` | `borderLeft.color="1D4ED8" borderLeft.width="6"` | Per-side border with the same fields as `border`. Overrides `border` for that side (field-by-field). Useful for accent bars / underlined headings. Cannot be combined with `borderRadius` (per-side values are ignored with a warning) |
+| `borderRadius`    | number                                                     | Border radius (px)                         |
+| `opacity`         | 0-1                                                        | Background opacity                         |
+| `margin`          | number / `margin.top="8" margin.bottom="8"`                | Margin (shorthand + dot notation can be mixed) |
+| `zIndex`          | number                                                     | Stacking order (higher = on top)           |
+| `position`        | `relative` / `absolute`                                    | Positioning mode                           |
+| `top`             | number                                                     | Top offset (when using position)           |
+| `right`           | number                                                     | Right offset (when using position)         |
+| `bottom`          | number                                                     | Bottom offset (when using position)        |
+| `left`            | number                                                     | Left offset (when using position)          |
+| `alignSelf`       | `auto` / `start` / `center` / `end` / `stretch`            | Override parent's alignItems for this node |
+| `shadow`          | `shadow.type="outer" shadow.blur="4" shadow.offset="2" shadow.color="000"` | Drop shadow (shorthand + dot notation can be mixed; not supported on Line) |
 
 ## Leaf Rotation
 
@@ -380,11 +379,11 @@ All Ul attributes plus:
 <Image src="https://example.com/img.png" w="200" h="150" />
 ```
 
-| Attribute | Type / Values                                                                                    |
-| --------- | ------------------------------------------------------------------------------------------------ |
-| `src`     | string (URL / path / base64)                                                                     |
-| `sizing`  | `'{"type":"contain"}' ` / `'{"type":"cover"}'` / `'{"type":"crop","x":0,"y":0,"w":100,"h":100}'` |
-| `rotate`  | number (degrees clockwise, render-only)                                                          |
+| Attribute | Type / Values                                                                                                            |
+| --------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src`     | string (URL / path / base64)                                                                                             |
+| `sizing`  | `'{"type":"contain"}' ` / `'{"type":"cover"}'` / `'{"type":"crop","x":0,"y":0,"w":100,"h":100}'`                         |
+| `rotate`  | number (degrees clockwise, render-only)                                                                                  |
 
 ### Icon
 
@@ -400,7 +399,7 @@ Displays an icon from the Lucide icon library (1,900+ icons available).
 | `name`    | Lucide icon name (required). See examples below                          |
 | `size`    | number (default: 24, in px)                                              |
 | `color`   | hex color (`#` prefix optional, default: `#000000`)                      |
-| `rotate`  | number (degrees clockwise, render-only)                                  |
+| `rotate`  | number (degrees clockwise, render-only)                                |
 | `variant` | `circle-filled`, `circle-outlined`, `square-filled`, `square-outlined`   |
 | `bgColor` | hex color for background shape (`#` prefix optional, default: `#E0E0E0`) |
 
@@ -416,11 +415,11 @@ Renders an inline SVG as a rasterized PNG image. Use this node for custom SVG gr
 </Svg>
 ```
 
-| Attribute | Type / Values                      |
-| --------- | ---------------------------------- |
-| `w`       | number (default: 24, width in px)  |
-| `h`       | number (default: 24, height in px) |
-| `color`   | hex color (`#` prefix optional)    |
+| Attribute | Type / Values                                          |
+| --------- | ------------------------------------------------------ |
+| `w`       | number (default: 24, width in px)                      |
+| `h`       | number (default: 24, height in px)                     |
+| `color`   | hex color (`#` prefix optional)                        |
 
 A `<svg>` child element is required. When `color` is specified, it sets `stroke` and `fill="none"` on the root `<svg>` element; explicit `stroke`/`fill` on child elements take precedence.
 
@@ -629,7 +628,7 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 | ---------------- | ----------------------------------------------------- |
 | `layout`         | `vertical` / `horizontal`                             |
 | `nodeShape`      | `rect` / `roundRect` / `ellipse`                      |
-| `textColor`      | hex (node label text color, default: `FFFFFF`)        |
+| `textColor`      | hex (node label text color, default: `FFFFFF`)       |
 | `nodeWidth`      | number (default: 120)                                 |
 | `nodeHeight`     | number (default: 40)                                  |
 | `levelGap`       | number (default: 60)                                  |
@@ -652,12 +651,12 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 </Flow>
 ```
 
-| Attribute        | Type / Values                                                                                                          |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `direction`      | `horizontal` / `vertical`                                                                                              |
-| `nodeWidth`      | number (default: 120)                                                                                                  |
-| `nodeHeight`     | number (default: 60)                                                                                                   |
-| `nodeGap`        | number (default: 80)                                                                                                   |
+| Attribute        | Type / Values                                                                          |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `direction`      | `horizontal` / `vertical`                                                              |
+| `nodeWidth`      | number (default: 120)                                                                  |
+| `nodeHeight`     | number (default: 60)                                                                   |
+| `nodeGap`        | number (default: 80)                                                                   |
 | `connectorStyle` | `connectorStyle.color="hex" connectorStyle.width="2" connectorStyle.arrowType="arrow" connectorStyle.labelColor="hex"` |
 
 `<FlowNode>` attributes:
@@ -723,19 +722,19 @@ Connector between two nodes referenced by `id`. Draws a straight line between th
 
 ## Child Element Tag Reference
 
-| Parent Node      | Child Tags                                            | Mapped Property              |
-| ---------------- | ----------------------------------------------------- | ---------------------------- |
-| `<Chart>`        | `<ChartSeries>` > `<ChartDataPoint>`                  | `data`                       |
-| `<Table>`        | `<Col>`, `<Tr>` > `<Td>`                              | `columns`, `rows`            |
+| Parent Node      | Child Tags                                          | Mapped Property              |
+| ---------------- | --------------------------------------------------- | ---------------------------- |
+| `<Chart>`        | `<ChartSeries>` > `<ChartDataPoint>`                | `data`                       |
+| `<Table>`        | `<Col>`, `<Tr>` > `<Td>`       | `columns`, `rows`            |
 | `<Text>`         | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
 | `<Li>`           | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
-| `<Td>`           | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
-| `<Timeline>`     | `<TimelineItem>`                                      | `items`                      |
-| `<Matrix>`       | `<MatrixAxes>`, `<MatrixQuadrants>`, `<MatrixItem>`   | `axes`, `quadrants`, `items` |
-| `<Tree>`         | `<TreeItem>` (recursive)                              | `data`                       |
-| `<Flow>`         | `<FlowNode>`, `<FlowConnection>`                      | `nodes`, `connections`       |
-| `<ProcessArrow>` | `<ProcessArrowStep>`                                  | `steps`                      |
-| `<Pyramid>`      | `<PyramidLevel>`                                      | `levels`                     |
+| `<Td>`    | `<B>`, `<I>`, `<A>`, `<U>`, `<S>`, `<Mark>`, `<Span>` | `runs` (inline formatting)   |
+| `<Timeline>`     | `<TimelineItem>`                                    | `items`                      |
+| `<Matrix>`       | `<MatrixAxes>`, `<MatrixQuadrants>`, `<MatrixItem>` | `axes`, `quadrants`, `items` |
+| `<Tree>`         | `<TreeItem>` (recursive)                            | `data`                       |
+| `<Flow>`         | `<FlowNode>`, `<FlowConnection>`                    | `nodes`, `connections`       |
+| `<ProcessArrow>` | `<ProcessArrowStep>`                                | `steps`                      |
+| `<Pyramid>`      | `<PyramidLevel>`                                    | `levels`                     |
 
 When the same property is specified via both attributes (JSON string) and child elements, child elements take precedence.
 

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -100,7 +100,7 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
 | KPI | display サイズの数字 2〜4 個 + caption のラベル |
 | まとめ / CTA | キーメッセージの再掲 + 次のアクション |
 
-**縦方向の揃え**: アクセントバー・番号・アイコンなど高さの異なる要素をテキストと HStack で並べるときは `alignItems="end"` を基本にする。`Text` のレイアウトボックスは `fontSize × lineHeight` の高さを持ち行送り分の余白を含むため、グリフはボックス内で下寄りに描かれる。`center` で揃えると隣の要素が文字より上に浮いて見える。
+**縦方向の揃え**: アクセントバー・番号・アイコンなど高さの異なる要素をテキストと HStack で並べるときは `alignItems="center"` を基本にする。`Text` のレイアウトボックスは `fontSize × lineHeight` の高さを持つが、グリフは行ボックス内で上下中央に描画されるため、`center` で揃えると隣接要素も視覚的にテキストの中央に揃う。文字の baseline と合わせたいときは `end` を使う。
 
 代表例（パレット: コーポレート）:
 
@@ -119,11 +119,11 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
   <VStack w="100%" h="max" padding="64" backgroundColor="F8F9FB" gap="32">
     <Text fontSize="32" bold="true" color="1F2937">アジェンダ</Text>
     <VStack gap="16">
-      <HStack gap="16" alignItems="end">
+      <HStack gap="16" alignItems="center">
         <Text fontSize="20" bold="true" color="1E3A8A">01</Text>
         <Text fontSize="16" color="1F2937">背景と課題</Text>
       </HStack>
-      <HStack gap="16" alignItems="end">
+      <HStack gap="16" alignItems="center">
         <Text fontSize="20" bold="true" color="1E3A8A">02</Text>
         <Text fontSize="16" color="1F2937">提案内容</Text>
       </HStack>
@@ -154,8 +154,8 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
   </VStack>
 </Slide>
 
-<!-- 本編スライド共通の見出し（アクセントバー + タイトル）。center だとバーが文字より上に浮く -->
-<HStack gap="16" alignItems="end">
+<!-- 本編スライド共通の見出し（アクセントバー + タイトル）。glyph は行ボックス内中央配置なので center が自然に揃う -->
+<HStack gap="16" alignItems="center">
   <Shape shapeType="rect" w="6" h="32" fill.color="1E3A8A" />
   <Text fontSize="32" bold="true" color="1F2937">スライドタイトル</Text>
 </HStack>
@@ -816,7 +816,7 @@ Building emits warnings (`diagnostics`) for layout problems that can be detected
 
 - **はみ出し・重なり**: スライド外へのはみ出しと要素同士の重なりは build 時の警告で検出済みの前提。画像では警告に出ない残り（テキストの見切れ、`rotate` したノードや `Layer` 内の意図しない衝突）だけを確認する（見つけたら最優先で修正する）
 - **余白**: 外周 padding が確保されているか。要素が窮屈になっていないか、一部だけ不自然に空いていないか
-- **整列**: 揃うべき左端・上端が揃っているか。並べたカードの幅が均等か。アクセントバー・番号・アイコンが隣のテキストの文字より上に浮いていないか（`alignItems="center"` 起因のズレは `end` に変える）
+- **整列**: 揃うべき左端・上端が揃っているか。並べたカードの幅が均等か。アクセントバー・番号・アイコンと隣のテキストの揃え（`alignItems="center"` が基本。視覚的に浮く場合は `end` を試す）
 - **階層**: タイトルが一目で本文と区別できるか。視線の流れ（左上 → 右下）が自然か
 - **配色**: Step 2 で決めたパレットから逸脱した色が混入していないか。テキストと背景のコントラストが十分か
 - **密度**: 詰め込みすぎのスライドがないか（あれば 2 枚に分割する）


### PR DESCRIPTION
close #859

## 概要

直近の機能追加 PR (#821 / #836 / #837 / #839 / #842 / #848 / #854) で発生したユーザー向け docs の追従漏れを一括で整理する。

## 主な変更点

- **Quick Start を `<Slide>` 必須仕様に揃える**
  - root README / `apps/website/app/page.tsx` の Quick Start サンプルを `<Slide>` ラッパー付きに更新
  - `packages/pom-vscode/docs/supported-formats.md` の XML 例も同様に修正
- **node 数 / node list を 20 ノード (Arrow / Svg を含む) に揃える**
  - root README / `packages/pom/README.md` / `packages/pom/docs/index.mdx` / `apps/website/app/page.tsx` の表記をすべて 20 に更新
  - landing page の node gallery に Svg を追加
- **`buildPptx` API reference を現行実装に追従**
  - `packages/pom/docs/api-reference.md` のシグネチャに `strict?: boolean` を追加し、戻り値を `Promise<BuildPptxResult>` に修正
- **新規機能を styling-guide / text-measurement / nodes に追記**
  - `<Theme>` / `\$name` 色参照 / 複合ノードのテキスト色追従
  - per-side border (`borderTop` / `borderRight` / `borderBottom` / `borderLeft`) と `PER_SIDE_BORDER_WITH_RADIUS` diagnostic
  - Text effects (`glow` / `outline`)
  - `rotate` (Text / Shape / Image / Icon)
  - `lineHeight` の挙動: yoga 計測への反映、Text/Shape は固定値 `spcPts`、Ul/Ol は multiplier `spcPct` のまま
  - pptx-glimpse 1.1.1 での `spcPts` 対応に関する記述
- **`pom-md` の `pomxml` サンプルを現行 XML schema に修正**
  - `<Chart type labels values>` / `<Step>` / `<Event>` 等の旧シンタックスを `ChartSeries` / `ChartDataPoint` / `FlowNode` / `FlowConnection` / `TimelineItem` ベースの現行形に置き換え
  - JSDoc 例とテストフィクスチャも同様に修正
- **`pom-slide` SKILL.md の Text 縦揃え記述を PR #854 後の挙動に合わせる**
  - グリフが行ボックス内中央配置になった点を反映し、`alignItems="center"` を基本として扱うよう書き換え
- **`pom-cli` README に strict diagnostics の挙動を明記**
  - `pom build` / `pom render` は `buildPptx` を `strict: true` で呼ぶため、レイアウト系・画像系・master 系の **すべての** diagnostics で run が失敗する旨を記述

## 影響パッケージパス

- `README.md`
- `packages/pom/README.md` / `packages/pom/docs/*.md` / `packages/pom/docs/index.mdx`
- `packages/pom-cli/README.md`
- `packages/pom-md/README.md` / `packages/pom-md/docs/*.md` / `packages/pom-md/src/parseMd.ts` / `packages/pom-md/src/parseMd.test.ts`
- `packages/pom-vscode/docs/supported-formats.md`
- `apps/website/app/page.tsx`
- `skills/pom-slide/SKILL.md`

挙動変更を伴うコードは無く、すべて docs / コメント / テストフィクスチャの追従修正です。

## ローカル検証

- `pnpm exec prettier --check` (変更した docs 群) → ✓ All matched files use Prettier code style
- `pnpm --filter @hirokisakabe/pom run test:run -- docsSamples` → ✓ 516 passed / 2 skipped
- `pnpm --filter @hirokisakabe/pom-md run test:run` → ✓ 84 passed
- `pnpm --filter @hirokisakabe/pom run typecheck` / `lint` → ✓
- `pnpm --filter @hirokisakabe/pom-md run typecheck` / `lint` → ✓
- `pnpm --filter pom-docs run typecheck` / `lint` → ✓

## 補足

- cross-review (Codex CLI) を実施し、指摘 4 件 (warning 2 / info 2) を追加 commit (`68dbd79`) で対応済み。
- VRT baseline / docs images の再生成は不要 (見た目に影響する変更なし)。