### PR TITLE
docs: 各パッケージ README のフォーマットを統一

### DIFF
--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -1,8 +1,27 @@
-# @hirokisakabe/pom-cli
+<h1 align="center">pom-cli</h1>
+<p align="center">
+  CLI tool for <a href="https://www.npmjs.com/package/@hirokisakabe/pom">pom</a> — preview, build, and render presentations from pom XML / Markdown.
+</p>
 
-CLI tool for [pom](https://github.com/hirokisakabe/pom) — preview, build, and render presentations from pom XML / Markdown.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@hirokisakabe/pom-cli"><img src="https://img.shields.io/npm/v/@hirokisakabe/pom-cli.svg" alt="npm version"></a>
+  <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@hirokisakabe/pom-cli.svg" alt="License"></a>
+</p>
+
+---
+
+## Features
+
+- **Live Preview Server** — `pom preview` opens a browser, watches the source file, and rebuilds + reloads on every save (handles editor atomic writes like Vim).
+- **PPTX Build** — `pom build` converts `.pom.xml` / `.pom.md` to a `.pptx` file, with optional `--watch` mode for incremental rebuilds.
+- **PNG / SVG Render** — `pom render` rasterizes each slide to PNG (default) or SVG without LibreOffice, useful for slide-image previews in docs.
+- **Diagnostic Surfacing** — Layout, image, master, and auto-fit diagnostics from `buildPptx` fail the run on stderr with a non-zero exit (`pom build` / `pom render`), while `pom preview` keeps updating so issues can be fixed interactively.
+- **Bundled Fonts** — Carlito and Noto Sans CJK JP are bundled for consistent text measurement and SVG rendering across machines.
+- **Configurable Output** — Choose port, target slides, output format, text rendering mode (`path` outlines vs native `<text>`), and verbose per-step timing.
 
 ## Installation
+
+> Requires Node.js 18+
 
 ```bash
 npm install -g @hirokisakabe/pom-cli

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -16,7 +16,7 @@
 - **PPTX Build** — `pom build` converts `.pom.xml` / `.pom.md` to a `.pptx` file, with optional `--watch` mode for incremental rebuilds.
 - **PNG / SVG Render** — `pom render` rasterizes each slide to PNG (default) or SVG without LibreOffice, useful for slide-image previews in docs.
 - **Diagnostic Surfacing** — Layout, image, master, and auto-fit diagnostics from `buildPptx` fail the run on stderr with a non-zero exit (`pom build` / `pom render`), while `pom preview` keeps updating so issues can be fixed interactively.
-- **Bundled Fonts** — Carlito and Noto Sans CJK JP are bundled for consistent text measurement and SVG rendering across machines.
+- **Bundled Fonts** — Carlito and Noto Sans CJK JP are bundled for SVG / PNG rendering, so output looks the same on machines without those fonts installed.
 - **Configurable Output** — Choose port, target slides, output format, text rendering mode (`path` outlines vs native `<text>`), and verbose per-step timing.
 
 ## Installation

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -19,11 +19,13 @@
 
 ## Installation
 
-> Requires React 18+ and `@hirokisakabe/pom` as peer dependencies.
+> Requires React 18+
 
 ```bash
-npm install @hirokisakabe/pom-editor @hirokisakabe/pom react
+npm install @hirokisakabe/pom-editor react
 ```
+
+`@hirokisakabe/pom` is pulled in automatically as a regular dependency — no separate install needed.
 
 ## Quick Start
 

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -1,14 +1,31 @@
-# @hirokisakabe/pom-editor
+<h1 align="center">pom-editor</h1>
+<p align="center">
+  Visual AST editor for <a href="https://www.npmjs.com/package/@hirokisakabe/pom">pom</a> — drag-and-drop reordering of slide node trees.
+</p>
 
-Visual AST editor for [pom](https://github.com/hirokisakabe/pom) — drag-and-drop reordering of slide node trees.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@hirokisakabe/pom-editor"><img src="https://img.shields.io/npm/v/@hirokisakabe/pom-editor.svg" alt="npm version"></a>
+  <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@hirokisakabe/pom-editor.svg" alt="License"></a>
+</p>
 
-## Install
+---
+
+## Features
+
+- **Drag-and-Drop Reordering** — Sort sibling nodes within `VStack` / `HStack` / `Layer` containers, plus top-level slides, by dragging them in the AST tree.
+- **XML In / XML Out** — Accepts a pom XML string via `xml` and returns the updated XML via `onChange` after each reorder, so it drops into any editor / preview layout.
+- **AST-Aware Tree View** — Renders the parsed pom AST as a labeled tree so the structure of slides and nested containers is visible at a glance.
+- **Powered by `@dnd-kit`** — Built on `@dnd-kit/core` + `@dnd-kit/sortable` for accessible, keyboard-friendly drag interactions.
+
+## Installation
+
+> Requires React 18+ and `@hirokisakabe/pom` as peer dependencies.
 
 ```bash
 npm install @hirokisakabe/pom-editor @hirokisakabe/pom react
 ```
 
-## Usage
+## Quick Start
 
 ```tsx
 import { PomAstEditor } from "@hirokisakabe/pom-editor";
@@ -49,11 +66,6 @@ function App() {
 | `onChange` | `(xml: string) => void` | Called with updated XML after each drag-and-drop reorder |
 
 Renders a tree of nodes from the parsed XML. Nodes within the same parent container (`VStack`, `HStack`, `Layer`) can be reordered by dragging. Top-level slides can also be reordered.
-
-## Requirements
-
-- React 18 or later
-- `@hirokisakabe/pom` (peer dependency resolved automatically as a workspace dependency; install separately in non-monorepo setups)
 
 ## License
 

--- a/packages/pom-jsx/README.md
+++ b/packages/pom-jsx/README.md
@@ -12,12 +12,18 @@
 
 `pom-jsx` lets you write [pom](https://www.npmjs.com/package/@hirokisakabe/pom) slide definitions in JSX/TSX instead of raw XML strings. It renders your JSX tree to the XML that `buildPptx` expects.
 
-## Requirements
+## Features
 
-- Node.js 18+
-- TypeScript with JSX support (`tsx` / `ts-node` / compiled `.tsx`)
+- **JSX/TSX Authoring** — Write pom slides as JSX/TSX. The tree is serialized to a pom XML string and passed to `buildPptx`.
+- **Typed Components** — Every pom node is exported as a PascalCase component with typed props, so attribute typos and missing required attributes surface at compile time.
+- **Inline Text Formatting** — `B` / `I` / `U` / `S` / `A` / `Span` / `Mark` work inside `Text` and `Li` for bold, italic, underline, strike, links, styled spans, and highlights.
+- **Fragment Support** — Standard JSX Fragments (`<>...</>`) render children without a wrapper, making multi-slide composition natural.
+- **Reusable Custom Components** — Compose recurring slide layouts as ordinary JSX function components.
+- **Smart Attribute Serialization** — Numbers pass through as-is, booleans serialize compactly (`<Text bold>`), and objects / arrays are JSON-stringified automatically.
 
 ## Installation
+
+> Requires Node.js 18+ and a TypeScript-with-JSX setup (`tsx` / `ts-node` / compiled `.tsx`).
 
 ```bash
 npm install @hirokisakabe/pom @hirokisakabe/pom-jsx

--- a/packages/pom-md/README.md
+++ b/packages/pom-md/README.md
@@ -1,14 +1,33 @@
-# @hirokisakabe/pom-md
+<h1 align="center">pom-md</h1>
+<p align="center">
+  Markdown wrapper for <a href="https://www.npmjs.com/package/@hirokisakabe/pom">pom</a> — write slides in Markdown with <code>pomxml</code> code fences.
+</p>
 
-Markdown wrapper for [pom](https://github.com/hirokisakabe/pom) — write slides in Markdown with `pomxml` code fences.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@hirokisakabe/pom-md"><img src="https://img.shields.io/npm/v/@hirokisakabe/pom-md.svg" alt="npm version"></a>
+  <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@hirokisakabe/pom-md.svg" alt="License"></a>
+</p>
 
-## Install
+---
+
+## Features
+
+- **Markdown-First Authoring** — Write slide content as standard Markdown (headings, lists, paragraphs, tables, images). `parseMd()` converts it to pom XML.
+- **`pomxml` Code Fences** — Drop into raw pom XML inside a code fence to embed charts, flows, timelines, and any other pom node Markdown cannot express.
+- **Slide Separators** — `---` (horizontal rule) splits the document into successive slides, Marp-style.
+- **Frontmatter Configuration** — Set slide size (`16:9` / `4:3`), default background color, and master PPTX template path in a YAML frontmatter block.
+- **Per-Slide Directives** — Override settings on a single slide with Marp-style `<!-- backgroundColor: red -->` HTML comments.
+- **Composable with `buildPptx`** — `parseMd()` returns the XML string plus parsed metadata so you can hand it straight to `@hirokisakabe/pom`'s `buildPptx`.
+
+## Installation
+
+> Requires Node.js 18+
 
 ```bash
 npm install @hirokisakabe/pom-md @hirokisakabe/pom
 ```
 
-## Usage
+## Quick Start
 
 Create a `.pom.md` file:
 

--- a/packages/pom-vscode/README.md
+++ b/packages/pom-vscode/README.md
@@ -8,13 +8,11 @@
   <a href="https://github.com/hirokisakabe/pom/blob/main/LICENSE"><img src="https://img.shields.io/github/license/hirokisakabe/pom.svg" alt="License"></a>
 </p>
 
+<p align="center">
+  <img src="images/preview.png" alt="pom-vscode preview" width="800">
+</p>
+
 ---
-
-## Overview
-
-**pom-vscode** brings live slide preview to VS Code. Write presentations in Markdown (`.pom.md`) or XML (`.pom.xml`) and see the result instantly — no manual export needed during editing.
-
-![pom-vscode preview](images/preview.png)
 
 ## Features
 
@@ -24,22 +22,20 @@
 - **Error Diagnostics** — Inline error display helps you catch issues as you type.
 - **Command Palette** — Open preview via `pom: Open Preview`, export via `pom: Export PPTX`.
 
-## Getting Started
+## Installation
 
 > Requires VS Code 1.85+
 
-### Install
-
 Search for **pom** in the VS Code Extensions view, or install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode).
 
-### Usage
+## Quick Start
 
 1. Create a new file with `.pom.md` or `.pom.xml` extension
 2. Click the preview icon in the editor title bar, or run `pom: Open Preview` from the Command Palette
 3. Edit your file — the preview updates in real time
 4. When ready, run `pom: Export PPTX` to generate a PowerPoint file
 
-### Supported Formats
+## Supported Formats
 
 | Format  | Extension  | Description                                       |
 | ------- | ---------- | ------------------------------------------------- |

--- a/packages/pom/README.md
+++ b/packages/pom/README.md
@@ -27,6 +27,7 @@
 ## Table of Contents
 
 - [Features](#features)
+- [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Available Nodes](#available-nodes)
 - [Node Examples](#node-examples)
@@ -49,13 +50,15 @@
 - **Master Slide** — Define headers, footers, and page numbers once — applied to all slides automatically.
 - **Accurate Text Measurement** — Text width measured with opentype.js and bundled Noto Sans JP fonts for consistent layout.
 
-## Quick Start
+## Installation
 
 > Requires Node.js 18+
 
 ```bash
 npm install @hirokisakabe/pom
 ```
+
+## Quick Start
 
 ```typescript
 import { buildPptx } from "@hirokisakabe/pom";


### PR DESCRIPTION
close #861

## 概要

`packages/*/README.md` のフォーマットが 2 系統 (A: HTML centered header + badge / B: 素の Markdown H1) に分断されていた状態を、issue #861 で確定した A 系統ベースの統一方針に揃えた。対象 6 パッケージすべてに共通の構造を適用している。

## 統一した要素

- **Header**: `<h1 align="center">` + 1 行説明 + 必須 2 種 badge (npm or VS Marketplace + License)
- **区切り線**: header 直後に `---` を 1 本
- **Features**: 全パッケージに `## Features` (箇条書き 4〜10 項目) を追加
- **前提条件**: `## Installation` の直前に `> Requires ...` callout を配置
- **セクション名**: `## Installation` / `## Quick Start` を独立した H2 として統一
- **スクリーンショット**: `pom-vscode` の preview 画像を header 直後（divider 前）に移設

## 影響パッケージ

- `packages/pom/README.md` — Quick Start を `## Installation` と `## Quick Start` に分割、callout を Installation 側へ
- `packages/pom-jsx/README.md` — Features 追加、`## Requirements` → callout 化（Setup は Quick Start 前の package 固有セクションとして保持）
- `packages/pom-md/README.md` — B 系統から A 系統へ完全再構成、Features と callout を追加
- `packages/pom-vscode/README.md` — `## Overview` 削除、screenshot を divider 前へ、`## Getting Started` の H3 サブセクションを top-level H2 に展開
- `packages/pom-editor/README.md` — B 系統から A 系統へ完全再構成、`## Requirements` → callout 化
- `packages/pom-cli/README.md` — B 系統から A 系統へ完全再構成、Features と callout を追加

## cross-review 由来の追加 commit

`e04f6b9` で codex CLI の指摘を反映:

- pom-editor: `package.json` で `@hirokisakabe/pom` は通常 dependency (`workspace:*`) として宣言されているため、「peer dependency」表記と二重 install 例を修正
- pom-cli: bundled Carlito / Noto は SVG / PNG rendering 用であり、テキスト計測（core 側 opentype.js + bundled Noto Sans JP）とは責務が別なので Features の表現を訂正

## ローカル検証

- `pnpm exec prettier --check ../*/README.md` (packages/pom 配下から) — 全 README が prettier OK
- `pnpm -r run lint` — 全 package で pass
- `pnpm -r run typecheck` — 全 package で pass
- `acceptance-check 861` — 受け入れ条件 6 件すべて ✓
- `cross-review` (codex backend) — critical 0 / warning 0（指摘済み 2 件は本 PR 内で対応） / info 0

## スコープ外（issue で明示）

- `apps/website/` 配下の README / docs
- 各 README の個別コンテンツ (API リファレンス / コード例) の中身刷新
- `AGENTS.md` / `CLAUDE.md` のフォーマット統一
