### PR TITLE
feat(pom-editor): AST の nest 構造変更 (cross-parent DnD) を可能にする

### DIFF
--- a/.changeset/pom-editor-cross-parent-dnd.md
+++ b/.changeset/pom-editor-cross-parent-dnd.md
@@ -1,0 +1,7 @@
+---
+"@hirokisakabe/pom-editor": minor
+---
+
+`PomAstEditor` の DnD を拡張し、AST の nest 構造そのものを変更できるようにしました。これまで同じ親内のきょうだい並び替えしかできなかったところ、別の container (`VStack` / `HStack` / `Layer`) への移動、container 配下のノードの root への引き上げ、container 自体の入れ子化が可能になります。各行の前後の隙間 (gap) に drop すると **きょうだい**として挿入され、container 本体に drop すると **その container の末尾子要素**として nest される動作を UI 上でも区別できるようにしました (gap は青い挿入インジケータ、inside drop は container 本体の青ハイライト)。サイクルになる移動 (自分の子孫の中への drop) と container 以外への inside drop は構造上禁止しています。
+
+破壊的変更ではありませんが、内部依存だった `@dnd-kit/sortable` / `@dnd-kit/utilities` は不要になったため削除しています (公開 API は不変)。

--- a/packages/pom-editor/AGENTS.md
+++ b/packages/pom-editor/AGENTS.md
@@ -12,7 +12,7 @@ pnpm --filter @hirokisakabe/pom-editor run knip        # Detect unused code
 pnpm --filter @hirokisakabe/pom-editor run test:run    # Run tests (vitest + jsdom)
 ```
 
-React 18+ is a peer dependency. DnD is powered by `@dnd-kit/core` + `@dnd-kit/sortable`.
+React 18+ is a peer dependency. DnD is powered by `@dnd-kit/core` (`useDraggable` / `useDroppable`); the editor exposes per-row gap droppables (`gap:<parentId>:<index>`) for sibling insertion and per-container body droppables (`inside:<id>`) for nesting.
 
 ## Release Flow
 

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -16,7 +16,7 @@
 - **Distinct "between" vs "inside" Drop Targets** — Dropping on the gap before/after a row inserts as a sibling; dropping on a container body itself nests the node inside.
 - **XML In / XML Out** — Accepts a pom XML string via `xml` and returns the updated XML via `onChange` after each edit, so it drops into any editor / preview layout.
 - **AST-Aware Tree View** — Renders the parsed pom AST as a labeled tree so the structure of slides and nested containers is visible at a glance.
-- **Powered by `@dnd-kit/core`** — Accessible, keyboard-friendly drag interactions.
+- **Powered by `@dnd-kit/core`** — Built on `@dnd-kit/core`'s `PointerSensor` for pointer-driven drag interactions.
 
 ## Installation
 

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -12,10 +12,11 @@
 
 ## Features
 
-- **Drag-and-Drop Reordering** — Sort sibling nodes within `VStack` / `HStack` / `Layer` containers, plus top-level slides, by dragging them in the AST tree.
-- **XML In / XML Out** — Accepts a pom XML string via `xml` and returns the updated XML via `onChange` after each reorder, so it drops into any editor / preview layout.
+- **Drag-and-Drop Structure Editing** — Reorder siblings, move nodes between `VStack` / `HStack` / `Layer` containers, pull container children up to the root, or nest a container inside another — all by dragging in the AST tree.
+- **Distinct "between" vs "inside" Drop Targets** — Dropping on the gap before/after a row inserts as a sibling; dropping on a container body itself nests the node inside.
+- **XML In / XML Out** — Accepts a pom XML string via `xml` and returns the updated XML via `onChange` after each edit, so it drops into any editor / preview layout.
 - **AST-Aware Tree View** — Renders the parsed pom AST as a labeled tree so the structure of slides and nested containers is visible at a glance.
-- **Powered by `@dnd-kit`** — Built on `@dnd-kit/core` + `@dnd-kit/sortable` for accessible, keyboard-friendly drag interactions.
+- **Powered by `@dnd-kit/core`** — Accessible, keyboard-friendly drag interactions.
 
 ## Installation
 
@@ -67,7 +68,12 @@ function App() {
 | `xml`      | `string`                | pom XML string (one or more `<Slide>` elements)          |
 | `onChange` | `(xml: string) => void` | Called with updated XML after each drag-and-drop reorder |
 
-Renders a tree of nodes from the parsed XML. Nodes within the same parent container (`VStack`, `HStack`, `Layer`) can be reordered by dragging. Top-level slides can also be reordered.
+Renders a tree of nodes from the parsed XML. Each row supports two drop targets:
+
+- A thin gap between rows — drop here to insert as a **sibling** at that position (works across parents, so a node can be moved to any container or pulled up to the root).
+- The container row body itself — drop here to nest the dragged node as the **last child of that container** (`VStack` / `HStack` / `Layer` only). Drops on non-container bodies are ignored.
+
+Top-level slides can be reordered via the root-level gaps. Cycle-forming drops (e.g. moving a container into its own descendant) are silently rejected.
 
 ## License
 

--- a/packages/pom-editor/package.json
+++ b/packages/pom-editor/package.json
@@ -45,8 +45,6 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@hirokisakabe/pom": "workspace:*"
   },
   "devDependencies": {

--- a/packages/pom-editor/src/AstTree.test.tsx
+++ b/packages/pom-editor/src/AstTree.test.tsx
@@ -1,60 +1,57 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+interface DragSubject {
+  id: string;
+  data?: { current?: unknown };
+}
+
+interface DragEvent {
+  active: DragSubject;
+  over: DragSubject | null;
+}
+
 let capturedHandlers: {
-  onDragOver?: (event: {
-    active: { id: string; data: { current: { parentId: string } } };
-    over: { id: string; data: { current: { parentId: string } } } | null;
-  }) => void;
-  onDragEnd?: (event: {
-    active: { id: string; data: { current: { parentId: string } } };
-    over: { id: string; data: { current: { parentId: string } } } | null;
-  }) => void;
+  onDragStart?: (event: { active: DragSubject }) => void;
+  onDragOver?: (event: DragEvent) => void;
+  onDragEnd?: (event: DragEvent) => void;
   onDragCancel?: () => void;
 } = {};
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({
     children,
+    onDragStart,
     onDragOver,
     onDragEnd,
     onDragCancel,
   }: {
     children: React.ReactNode;
+    onDragStart?: typeof capturedHandlers.onDragStart;
     onDragOver?: typeof capturedHandlers.onDragOver;
     onDragEnd?: typeof capturedHandlers.onDragEnd;
     onDragCancel?: typeof capturedHandlers.onDragCancel;
   }) => {
-    capturedHandlers = { onDragOver, onDragEnd, onDragCancel };
+    capturedHandlers = { onDragStart, onDragOver, onDragEnd, onDragCancel };
     return <>{children}</>;
   },
   PointerSensor: class {},
   useSensor: () => ({}),
   useSensors: () => [],
-  closestCenter: () => null,
+  closestCenter: () => [],
+  pointerWithin: () => [],
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    isDragging: false,
+  }),
+  useDroppable: () => ({
+    setNodeRef: () => {},
+    isOver: false,
+  }),
 }));
-
-vi.mock("@dnd-kit/sortable", async () => {
-  const actual =
-    await vi.importActual<typeof import("@dnd-kit/sortable")>(
-      "@dnd-kit/sortable",
-    );
-  return {
-    ...actual,
-    SortableContext: ({ children }: { children: React.ReactNode }) => (
-      <>{children}</>
-    ),
-    useSortable: () => ({
-      attributes: {},
-      listeners: {},
-      setNodeRef: () => {},
-      transform: null,
-      transition: null,
-      isDragging: false,
-    }),
-    verticalListSortingStrategy: undefined,
-  };
-});
 
 import type { POMNode } from "@hirokisakabe/pom/clientApi";
 import { AstTree } from "./AstTree.tsx";
@@ -97,61 +94,39 @@ function makeAst(): AstNode[] {
   ];
 }
 
-function event(
-  activeId: string,
-  activeParent: string,
-  overId: string | null,
-  overParent: string | null,
-) {
+function dragTo(activeId: string, overId: string | null): DragEvent {
   return {
-    active: { id: activeId, data: { current: { parentId: activeParent } } },
-    over:
-      overId === null || overParent === null
-        ? null
-        : { id: overId, data: { current: { parentId: overParent } } },
+    active: { id: activeId },
+    over: overId === null ? null : { id: overId },
   };
 }
 
-function labelWrapper(text: string): HTMLElement {
-  // SortableItem renders: <div><div style={...highlight}><span handle/><span>{label}</span></div>{children}</div>
-  // We match by visible label text, and the parent <div> carries the highlight style.
-  const labelSpan = screen.getByText(text);
-  const wrapper = labelSpan.parentElement;
-  if (!wrapper) throw new Error(`No wrapper for "${text}"`);
-  return wrapper;
-}
-
-describe("AstTree DnD state transitions", () => {
-  it("同一親内での reorder が onChange 経由で反映される", () => {
+describe("AstTree DnD — gap drops (sibling reorder & cross-parent)", () => {
+  it("同一親内 gap への drop で reorder される", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
 
-    // Drag "A" (id 1, parent 0) over "B" (id 2, parent 0) — same parent.
-    capturedHandlers.onDragEnd?.(event("1", "0", "2", "0"));
+    // Drag Text "A" (id 1, parent 0, index 0) onto gap "after B" (gap:0:2)
+    capturedHandlers.onDragEnd?.(dragTo("1", "gap:0:2"));
 
     expect(onChange).toHaveBeenCalledTimes(1);
     const newNodes = onChange.mock.calls[0][0] as POMNode[];
-    // VStack children should be reordered: B then A.
     const slide1 = newNodes[0] as POMNode & { children: POMNode[] };
     expect(slide1.children).toHaveLength(2);
-    const t0 = slide1.children[0] as POMNode & { text: string };
-    const t1 = slide1.children[1] as POMNode & { text: string };
-    expect(t0.text).toBe("B");
-    expect(t1.text).toBe("A");
+    expect((slide1.children[0] as POMNode & { text: string }).text).toBe("B");
+    expect((slide1.children[1] as POMNode & { text: string }).text).toBe("A");
   });
 
-  it("トップレベル slide の reorder (parentId === 'root') が onChange に反映される", () => {
+  it("トップレベル slide の gap drop で reorder される", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
 
-    // Drag slide 1 (id 0, parent root) over slide 2 (id 3, parent root).
-    // applyReorder() has a dedicated `activeParentId === "root"` branch — cover it.
-    capturedHandlers.onDragEnd?.(event("0", "root", "3", "root"));
+    // Drag slide 1 (id 0) onto gap:root:2 (after slide 2)
+    capturedHandlers.onDragEnd?.(dragTo("0", "gap:root:2"));
 
     expect(onChange).toHaveBeenCalledTimes(1);
     const newNodes = onChange.mock.calls[0][0] as POMNode[];
     expect(newNodes).toHaveLength(2);
-    // After swap, the (previously second) VStack with a single "C" child comes first.
     const first = newNodes[0] as POMNode & { children: POMNode[] };
     const second = newNodes[1] as POMNode & { children: POMNode[] };
     expect(first.children).toHaveLength(1);
@@ -159,73 +134,209 @@ describe("AstTree DnD state transitions", () => {
     expect(second.children).toHaveLength(2);
   });
 
-  it("異なる親への drag では onChange が呼ばれない (silent rejection)", () => {
+  it("cross-parent: 別 container の gap へ drop すると新しい親の子になる", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
 
-    // Drag "A" (id 1, parent 0) over "C" (id 4, parent 3) — different parents.
-    capturedHandlers.onDragEnd?.(event("1", "0", "4", "3"));
+    // Drag Text "B" (id 2, parent 0) into VStack slide 2's children at index 1
+    // (after Text "C")
+    capturedHandlers.onDragEnd?.(dragTo("2", "gap:3:1"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newNodes = onChange.mock.calls[0][0] as POMNode[];
+    const slide1 = newNodes[0] as POMNode & { children: POMNode[] };
+    const slide2 = newNodes[1] as POMNode & { children: POMNode[] };
+    expect(slide1.children).toHaveLength(1);
+    expect((slide1.children[0] as POMNode & { text: string }).text).toBe("A");
+    expect(slide2.children).toHaveLength(2);
+    expect((slide2.children[0] as POMNode & { text: string }).text).toBe("C");
+    expect((slide2.children[1] as POMNode & { text: string }).text).toBe("B");
+  });
+
+  it("container 配下のノードを root レベル gap に drop で root に引き上げられる", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    // Drag Text "A" (id 1, parent 0) to gap:root:1 (between slide 1 and slide 2)
+    capturedHandlers.onDragEnd?.(dragTo("1", "gap:root:1"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newNodes = onChange.mock.calls[0][0] as POMNode[];
+    expect(newNodes).toHaveLength(3);
+    // newNodes[0] = VStack with only B
+    const slide1 = newNodes[0] as POMNode & { children: POMNode[] };
+    expect(slide1.children).toHaveLength(1);
+    expect((slide1.children[0] as POMNode & { text: string }).text).toBe("B");
+    // newNodes[1] = Text "A" (pulled up to root)
+    expect(newNodes[1].type).toBe("text");
+    expect((newNodes[1] as POMNode & { text: string }).text).toBe("A");
+    // newNodes[2] = VStack with C
+    const slide3 = newNodes[2] as POMNode & { children: POMNode[] };
+    expect(slide3.children).toHaveLength(1);
+  });
+});
+
+describe("AstTree DnD — inside drops (container nesting)", () => {
+  it("inside drop で別 container の中に入れられる (container 自体の入れ子)", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    // Drag slide 1 VStack (id 0) into slide 2 VStack (id 3) as inside
+    capturedHandlers.onDragEnd?.(dragTo("0", "inside:3"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newNodes = onChange.mock.calls[0][0] as POMNode[];
+    // Only one root-level slide now (slide 2, which contains former slide 1)
+    expect(newNodes).toHaveLength(1);
+    const surviving = newNodes[0] as POMNode & { children: POMNode[] };
+    expect(surviving.type).toBe("vstack");
+    expect(surviving.children).toHaveLength(2);
+    // child 0 = Text "C", child 1 = nested VStack (former slide 1)
+    expect((surviving.children[0] as POMNode & { text: string }).text).toBe(
+      "C",
+    );
+    const nested = surviving.children[1] as POMNode & { children: POMNode[] };
+    expect(nested.type).toBe("vstack");
+    expect(nested.children).toHaveLength(2);
+  });
+
+  it("inside drop はコンテナ末尾に追加される (リーフを既存 container に入れる)", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    // Drag Text "A" (id 1) into slide 2 VStack (id 3) as inside
+    capturedHandlers.onDragEnd?.(dragTo("1", "inside:3"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newNodes = onChange.mock.calls[0][0] as POMNode[];
+    const slide1 = newNodes[0] as POMNode & { children: POMNode[] };
+    const slide2 = newNodes[1] as POMNode & { children: POMNode[] };
+    expect(slide1.children).toHaveLength(1);
+    expect((slide1.children[0] as POMNode & { text: string }).text).toBe("B");
+    expect(slide2.children).toHaveLength(2);
+    // A is appended at the end
+    expect((slide2.children[0] as POMNode & { text: string }).text).toBe("C");
+    expect((slide2.children[1] as POMNode & { text: string }).text).toBe("A");
+  });
+
+  it("自分の subtree への drop は拒否される (サイクル防止)", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    // Drag slide 1 VStack (id 0) into its own child gap:0:0 — would be a cycle
+    capturedHandlers.onDragEnd?.(dragTo("0", "gap:0:0"));
+    // Also try inside:0 (drop into itself)
+    capturedHandlers.onDragEnd?.(dragTo("0", "inside:0"));
 
     expect(onChange).not.toHaveBeenCalled();
   });
+});
 
-  it("異なる親に over しているとき、該当行に赤ハイライト + not-allowed カーソルが付与される", () => {
+describe("AstTree DnD — visual feedback distinguishes inside vs between", () => {
+  it("inside drop ターゲットに対して container 本体が青ハイライトされる", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
 
-    // Trigger onDragOver: active id 1 (parent 0) over id 4 (parent 3).
     act(() => {
-      capturedHandlers.onDragOver?.(event("1", "0", "4", "3"));
+      capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
     });
 
-    const over = labelWrapper('Text: "C"');
-    expect(over.style.backgroundColor).toBe("rgb(254, 226, 226)");
-    // jsdom does not normalize the hex value; keep the literal.
-    expect(over.style.outline).toBe("1px solid #dc2626");
-    expect(over.style.cursor).toBe("not-allowed");
+    // Both VStack rows are present; the one we dropped onto gets the inside highlight.
+    const insideHighlighted = screen
+      .getAllByText("VStack")
+      .map((el) => el.parentElement)
+      .find((el) => el?.style.backgroundColor === "rgb(219, 234, 254)");
+    expect(insideHighlighted).toBeTruthy();
+    expect(insideHighlighted!.style.outline).toBe("1px solid #2563eb");
   });
 
-  it("drag cancel 後に invalidOverId がクリアされ、赤ハイライト・not-allowed カーソル指定が残らない", () => {
+  it("gap drop ターゲットに対して挿入インジケータが青で表示される", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
 
     act(() => {
-      capturedHandlers.onDragOver?.(event("1", "0", "4", "3"));
+      capturedHandlers.onDragOver?.(dragTo("1", "gap:0:2"));
     });
-    // Sanity: highlight applied.
-    expect(labelWrapper('Text: "C"').style.backgroundColor).toBe(
-      "rgb(254, 226, 226)",
-    );
+
+    const gap = document.querySelector<HTMLElement>('[data-testid="gap:0:2"]');
+    expect(gap).not.toBeNull();
+    expect(gap!.style.backgroundColor).toBe("rgb(59, 130, 246)");
+  });
+
+  it("inside と gap で異なる背景色が使われる (UI 上区別できる)", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    act(() => {
+      capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
+    });
+    const insideBg = screen
+      .getAllByText("VStack")
+      .map((el) => el.parentElement)
+      .find((el) => el?.style.backgroundColor)?.style.backgroundColor;
+
+    act(() => {
+      capturedHandlers.onDragOver?.(dragTo("1", "gap:0:2"));
+    });
+    const gap = document.querySelector<HTMLElement>('[data-testid="gap:0:2"]');
+    const gapBg = gap?.style.backgroundColor;
+
+    // Different colors used for the two feedback modes.
+    expect(insideBg).toBeTruthy();
+    expect(gapBg).toBeTruthy();
+    expect(insideBg).not.toBe(gapBg);
+  });
+});
+
+describe("AstTree DnD — drag lifecycle clears state", () => {
+  it("drag cancel 後にハイライトがクリアされる", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    act(() => {
+      capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
+    });
+    expect(
+      screen
+        .getAllByText("VStack")
+        .some((el) => el.parentElement?.style.backgroundColor),
+    ).toBe(true);
 
     act(() => {
       capturedHandlers.onDragCancel?.();
     });
 
-    const over = labelWrapper('Text: "C"');
-    expect(over.style.backgroundColor).toBe("");
-    expect(over.style.outline).toBe("");
-    expect(over.style.cursor).toBe("");
+    expect(
+      screen
+        .getAllByText("VStack")
+        .every((el) => !el.parentElement?.style.backgroundColor),
+    ).toBe(true);
   });
 
-  it("drag end (異なる親 silent reject) 後に invalidOverId がクリアされ、赤ハイライト指定が残らない", () => {
+  it("drag end 後にハイライトがクリアされる", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
 
     act(() => {
-      capturedHandlers.onDragOver?.(event("1", "0", "4", "3"));
+      capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
     });
-    expect(labelWrapper('Text: "C"').style.backgroundColor).toBe(
-      "rgb(254, 226, 226)",
-    );
-
     act(() => {
-      capturedHandlers.onDragEnd?.(event("1", "0", "4", "3"));
+      capturedHandlers.onDragEnd?.(dragTo("1", "inside:3"));
     });
 
-    const over = labelWrapper('Text: "C"');
-    expect(over.style.backgroundColor).toBe("");
-    expect(over.style.outline).toBe("");
-    expect(over.style.cursor).toBe("");
+    expect(
+      screen
+        .getAllByText("VStack")
+        .every((el) => !el.parentElement?.style.backgroundColor),
+    ).toBe(true);
+  });
+
+  it("over が null の drag end では onChange が呼ばれない", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    capturedHandlers.onDragEnd?.(dragTo("1", null));
+
     expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/pom-editor/src/AstTree.test.tsx
+++ b/packages/pom-editor/src/AstTree.test.tsx
@@ -230,6 +230,27 @@ describe("AstTree DnD — inside drops (container nesting)", () => {
 
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("non-container を親にする gap drop は構造防御として拒否される", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    // gap:1:0 — would make Text "A" (id 1) act as the parent for the moved
+    // node. The UI never renders this gap (leaves have no child list), but
+    // applyMoveToGap must still reject it defensively if a stale id reaches it.
+    capturedHandlers.onDragEnd?.(dragTo("2", "gap:1:0"));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("存在しない parentId への gap drop は拒否される", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    capturedHandlers.onDragEnd?.(dragTo("1", "gap:999:0"));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });
 
 describe("AstTree DnD — visual feedback distinguishes inside vs between", () => {

--- a/packages/pom-editor/src/AstTree.tsx
+++ b/packages/pom-editor/src/AstTree.tsx
@@ -4,19 +4,22 @@ import {
   DragEndEvent,
   DragOverEvent,
   PointerSensor,
+  useDraggable,
+  useDroppable,
   useSensor,
   useSensors,
   closestCenter,
+  pointerWithin,
 } from "@dnd-kit/core";
-import {
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import type { CollisionDetection } from "@dnd-kit/core";
 import type { AstNode } from "./ast.ts";
 import type { POMNode } from "@hirokisakabe/pom/clientApi";
-import { applyReorder, rebuildNodes } from "./ast.ts";
+import {
+  applyMoveInside,
+  applyMoveToGap,
+  isContainerType,
+  rebuildNodes,
+} from "./ast.ts";
 
 const NODE_LABELS: Record<string, string> = {
   text: "Text",
@@ -61,45 +64,91 @@ function nodeLabel(node: POMNode): string {
   return base;
 }
 
-const InvalidOverContext = createContext<string | null>(null);
+const OverIdContext = createContext<string | null>(null);
+const ActiveIdContext = createContext<string | null>(null);
 
-interface SortableItemProps {
-  astNode: AstNode;
-  depth: number;
-  onChange: (nodes: POMNode[]) => void;
-  ast: AstNode[];
+const GAP_PREFIX = "gap:";
+const INSIDE_PREFIX = "inside:";
+
+function gapId(parentId: string, index: number): string {
+  return `${GAP_PREFIX}${parentId}:${index}`;
 }
 
-function SortableItem({ astNode, depth, onChange, ast }: SortableItemProps) {
-  const invalidOverId = useContext(InvalidOverContext);
-  const isInvalidOver = invalidOverId === astNode.id;
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({
-    id: astNode.id,
-    data: { parentId: astNode.parentId },
-  });
+function insideId(nodeId: string): string {
+  return `${INSIDE_PREFIX}${nodeId}`;
+}
 
-  const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.4 : 1,
-  };
+function parseGapId(id: string): { parentId: string; index: number } | null {
+  if (!id.startsWith(GAP_PREFIX)) return null;
+  const rest = id.slice(GAP_PREFIX.length);
+  const sep = rest.lastIndexOf(":");
+  if (sep === -1) return null;
+  const parentId = rest.slice(0, sep);
+  const index = Number.parseInt(rest.slice(sep + 1), 10);
+  if (Number.isNaN(index)) return null;
+  return { parentId, index };
+}
 
-  const handleCursor = isInvalidOver
-    ? "not-allowed"
-    : isDragging
-      ? "grabbing"
-      : "grab";
+function parseInsideId(id: string): string | null {
+  if (!id.startsWith(INSIDE_PREFIX)) return null;
+  return id.slice(INSIDE_PREFIX.length);
+}
+
+interface GapStripProps {
+  parentId: string;
+  index: number;
+  depth: number;
+}
+
+function GapStrip({ parentId, index, depth }: GapStripProps) {
+  const id = gapId(parentId, index);
+  const { setNodeRef } = useDroppable({ id });
+  const overId = useContext(OverIdContext);
+  const isOver = overId === id;
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div
+      ref={setNodeRef}
+      data-testid={id}
+      style={{
+        height: isOver ? "6px" : "4px",
+        marginLeft: `${depth * 16}px`,
+        backgroundColor: isOver ? "#3b82f6" : "transparent",
+        borderRadius: "2px",
+      }}
+    />
+  );
+}
+
+interface RowProps {
+  astNode: AstNode;
+  depth: number;
+}
+
+function Row({ astNode, depth }: RowProps) {
+  const isContainer = isContainerType(astNode.node.type);
+  const overId = useContext(OverIdContext);
+  const activeId = useContext(ActiveIdContext);
+
+  const drag = useDraggable({ id: astNode.id });
+  const isDragging = activeId === astNode.id;
+
+  const inside = useDroppable({
+    id: insideId(astNode.id),
+    disabled: !isContainer || isDragging,
+  });
+
+  const setBodyRef = (el: HTMLElement | null) => {
+    inside.setNodeRef(el);
+    drag.setNodeRef(el);
+  };
+
+  const isInsideOver = isContainer && overId === insideId(astNode.id);
+
+  return (
+    <div>
       <div
+        ref={setBodyRef}
         style={{
           display: "flex",
           alignItems: "center",
@@ -109,17 +158,18 @@ function SortableItem({ astNode, depth, onChange, ast }: SortableItemProps) {
           paddingBottom: "3px",
           borderRadius: "4px",
           userSelect: "none",
-          backgroundColor: isInvalidOver ? "#fee2e2" : undefined,
-          outline: isInvalidOver ? "1px solid #dc2626" : undefined,
-          cursor: isInvalidOver ? "not-allowed" : undefined,
+          opacity: isDragging ? 0.4 : 1,
+          backgroundColor: isInsideOver ? "#dbeafe" : undefined,
+          outline: isInsideOver ? "1px solid #2563eb" : undefined,
+          transition: "background-color 50ms",
         }}
       >
         <span
-          {...listeners}
-          {...attributes}
+          {...drag.listeners}
+          {...drag.attributes}
           style={{
-            cursor: handleCursor,
-            color: isInvalidOver ? "#dc2626" : "#9ca3af",
+            cursor: isDragging ? "grabbing" : "grab",
+            color: "#9ca3af",
             fontSize: "12px",
             lineHeight: 1,
             flexShrink: 0,
@@ -141,44 +191,34 @@ function SortableItem({ astNode, depth, onChange, ast }: SortableItemProps) {
           {nodeLabel(astNode.node)}
         </span>
       </div>
-      {astNode.children && astNode.children.length > 0 && (
-        <SortableChildrenList
-          children={astNode.children}
+      {astNode.children && (
+        <ChildList
+          parentId={astNode.id}
+          nodes={astNode.children}
           depth={depth + 1}
-          onChange={onChange}
-          ast={ast}
         />
       )}
     </div>
   );
 }
 
-interface SortableChildrenListProps {
-  children: AstNode[];
+interface ChildListProps {
+  parentId: string;
+  nodes: AstNode[];
   depth: number;
-  onChange: (nodes: POMNode[]) => void;
-  ast: AstNode[];
 }
 
-function SortableChildrenList({
-  children,
-  depth,
-  onChange,
-  ast,
-}: SortableChildrenListProps) {
-  const ids = children.map((c) => c.id);
+function ChildList({ parentId, nodes, depth }: ChildListProps) {
   return (
-    <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-      {children.map((child) => (
-        <SortableItem
-          key={child.id}
-          astNode={child}
-          depth={depth}
-          onChange={onChange}
-          ast={ast}
-        />
+    <>
+      <GapStrip parentId={parentId} index={0} depth={depth} />
+      {nodes.map((child, i) => (
+        <React.Fragment key={child.id}>
+          <Row astNode={child} depth={depth} />
+          <GapStrip parentId={parentId} index={i + 1} depth={depth} />
+        </React.Fragment>
       ))}
-    </SortableContext>
+    </>
   );
 }
 
@@ -187,13 +227,10 @@ export interface AstTreeProps {
   onChange: (nodes: POMNode[]) => void;
 }
 
-function getParentId(data: unknown): string | null {
-  if (typeof data === "object" && data !== null && "parentId" in data) {
-    const value = data.parentId;
-    return typeof value === "string" ? value : null;
-  }
-  return null;
-}
+const collisionDetection: CollisionDetection = (args) => {
+  const within = pointerWithin(args);
+  return within.length > 0 ? within : closestCenter(args);
+};
 
 export function AstTree({ ast, onChange }: AstTreeProps) {
   const sensors = useSensors(
@@ -201,61 +238,58 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
       activationConstraint: { distance: 4 },
     }),
   );
-  const [invalidOverId, setInvalidOverId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
 
-  function onDragOver({ active, over }: DragOverEvent) {
-    if (!over || active.id === over.id) {
-      setInvalidOverId(null);
+  function onDragStart(event: { active: { id: string | number } }) {
+    setActiveId(String(event.active.id));
+  }
+
+  function onDragOver({ over }: DragOverEvent) {
+    setOverId(over ? String(over.id) : null);
+  }
+
+  function applyDrop(activeId: string, overId: string): void {
+    const gap = parseGapId(overId);
+    if (gap) {
+      const newAst = applyMoveToGap(ast, activeId, gap.parentId, gap.index);
+      if (newAst !== ast) onChange(rebuildNodes(newAst));
       return;
     }
-    const activeParentId = getParentId(active.data.current);
-    const overParentId = getParentId(over.data.current);
-    if (activeParentId !== overParentId) {
-      setInvalidOverId(over.id as string);
-    } else {
-      setInvalidOverId(null);
+    const insideTarget = parseInsideId(overId);
+    if (insideTarget !== null) {
+      const newAst = applyMoveInside(ast, activeId, insideTarget);
+      if (newAst !== ast) onChange(rebuildNodes(newAst));
     }
   }
 
   function onDragEnd({ active, over }: DragEndEvent) {
-    setInvalidOverId(null);
-    if (!over || active.id === over.id) return;
-
-    const activeParentId = getParentId(active.data.current);
-    const overParentId = getParentId(over.data.current);
-    if (activeParentId === null || activeParentId !== overParentId) return;
-
-    const newAst = applyReorder(
-      ast,
-      active.id as string,
-      over.id as string,
-      activeParentId,
-    );
-    onChange(rebuildNodes(newAst));
+    setOverId(null);
+    setActiveId(null);
+    if (!over) return;
+    applyDrop(String(active.id), String(over.id));
   }
 
   function onDragCancel() {
-    setInvalidOverId(null);
+    setOverId(null);
+    setActiveId(null);
   }
 
-  const rootIds = ast.map((n) => n.id);
-
   return (
-    <div style={{ cursor: invalidOverId !== null ? "not-allowed" : undefined }}>
+    <div>
       <DndContext
         sensors={sensors}
-        collisionDetection={closestCenter}
+        collisionDetection={collisionDetection}
+        onDragStart={onDragStart}
         onDragOver={onDragOver}
         onDragEnd={onDragEnd}
         onDragCancel={onDragCancel}
       >
-        <InvalidOverContext.Provider value={invalidOverId}>
-          <SortableContext
-            items={rootIds}
-            strategy={verticalListSortingStrategy}
-          >
+        <ActiveIdContext.Provider value={activeId}>
+          <OverIdContext.Provider value={overId}>
+            <GapStrip parentId="root" index={0} depth={0} />
             {ast.map((astNode, i) => (
-              <div key={astNode.id}>
+              <React.Fragment key={astNode.id}>
                 {i > 0 && (
                   <div
                     style={{
@@ -277,16 +311,12 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
                 >
                   Slide {i + 1}
                 </div>
-                <SortableItem
-                  astNode={astNode}
-                  depth={0}
-                  onChange={onChange}
-                  ast={ast}
-                />
-              </div>
+                <Row astNode={astNode} depth={0} />
+                <GapStrip parentId="root" index={i + 1} depth={0} />
+              </React.Fragment>
             ))}
-          </SortableContext>
-        </InvalidOverContext.Provider>
+          </OverIdContext.Provider>
+        </ActiveIdContext.Provider>
       </DndContext>
     </div>
   );

--- a/packages/pom-editor/src/AstTree.tsx
+++ b/packages/pom-editor/src/AstTree.tsx
@@ -8,10 +8,8 @@ import {
   useDroppable,
   useSensor,
   useSensors,
-  closestCenter,
   pointerWithin,
 } from "@dnd-kit/core";
-import type { CollisionDetection } from "@dnd-kit/core";
 import type { AstNode } from "./ast.ts";
 import type { POMNode } from "@hirokisakabe/pom/clientApi";
 import {
@@ -104,14 +102,16 @@ function GapStrip({ parentId, index, depth }: GapStripProps) {
   const id = gapId(parentId, index);
   const { setNodeRef } = useDroppable({ id });
   const overId = useContext(OverIdContext);
+  const activeId = useContext(ActiveIdContext);
   const isOver = overId === id;
+  const isDragging = activeId !== null;
 
   return (
     <div
       ref={setNodeRef}
       data-testid={id}
       style={{
-        height: isOver ? "6px" : "4px",
+        height: isOver ? "10px" : isDragging ? "8px" : "2px",
         marginLeft: `${depth * 16}px`,
         backgroundColor: isOver ? "#3b82f6" : "transparent",
         borderRadius: "2px",
@@ -227,11 +227,6 @@ export interface AstTreeProps {
   onChange: (nodes: POMNode[]) => void;
 }
 
-const collisionDetection: CollisionDetection = (args) => {
-  const within = pointerWithin(args);
-  return within.length > 0 ? within : closestCenter(args);
-};
-
 export function AstTree({ ast, onChange }: AstTreeProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -279,7 +274,7 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
     <div>
       <DndContext
         sensors={sensors}
-        collisionDetection={collisionDetection}
+        collisionDetection={pointerWithin}
         onDragStart={onDragStart}
         onDragOver={onDragOver}
         onDragEnd={onDragEnd}

--- a/packages/pom-editor/src/ast.ts
+++ b/packages/pom-editor/src/ast.ts
@@ -1,5 +1,4 @@
 import type { POMNode } from "@hirokisakabe/pom/clientApi";
-import { arrayMove } from "@dnd-kit/sortable";
 
 export interface AstNode {
   id: string;
@@ -9,6 +8,10 @@ export interface AstNode {
 }
 
 const CONTAINER_TYPES = new Set(["vstack", "hstack", "layer"]);
+
+export function isContainerType(type: string): boolean {
+  return CONTAINER_TYPES.has(type);
+}
 
 export function buildAst(
   nodes: POMNode[],
@@ -51,53 +54,132 @@ function findNode(astNodes: AstNode[], id: string): AstNode | null {
   return null;
 }
 
-function reorderInParent(
+function isDescendantOrSelf(node: AstNode, id: string): boolean {
+  if (node.id === id) return true;
+  if (!node.children) return false;
+  return node.children.some((c) => isDescendantOrSelf(c, id));
+}
+
+function removeById(
+  astNodes: AstNode[],
+  id: string,
+): { newAst: AstNode[]; removed: AstNode } | null {
+  for (let i = 0; i < astNodes.length; i++) {
+    const current = astNodes[i];
+    if (current.id === id) {
+      return {
+        newAst: [...astNodes.slice(0, i), ...astNodes.slice(i + 1)],
+        removed: current,
+      };
+    }
+    if (current.children) {
+      const result = removeById(current.children, id);
+      if (result) {
+        return {
+          newAst: [
+            ...astNodes.slice(0, i),
+            { ...current, children: result.newAst },
+            ...astNodes.slice(i + 1),
+          ],
+          removed: result.removed,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function insertAt(
   astNodes: AstNode[],
   parentId: string,
-  oldIndex: number,
-  newIndex: number,
+  index: number,
+  insertion: AstNode,
 ): AstNode[] {
-  return astNodes.map((astNode) => {
-    if (astNode.id === parentId && astNode.children) {
+  if (parentId === "root") {
+    const node = { ...insertion, parentId: "root" };
+    return [...astNodes.slice(0, index), node, ...astNodes.slice(index)];
+  }
+  return astNodes.map((n) => {
+    if (n.id === parentId) {
+      const children = n.children ?? [];
+      const node = { ...insertion, parentId };
       return {
-        ...astNode,
-        children: arrayMove(astNode.children, oldIndex, newIndex),
+        ...n,
+        children: [...children.slice(0, index), node, ...children.slice(index)],
       };
     }
-    if (astNode.children) {
+    if (n.children) {
       return {
-        ...astNode,
-        children: reorderInParent(
-          astNode.children,
-          parentId,
-          oldIndex,
-          newIndex,
-        ),
+        ...n,
+        children: insertAt(n.children, parentId, index, insertion),
       };
     }
-    return astNode;
+    return n;
   });
 }
 
-export function applyReorder(
+function siblingsOf(ast: AstNode[], parentId: string): AstNode[] | null {
+  if (parentId === "root") return ast;
+  const parent = findNode(ast, parentId);
+  return parent?.children ?? null;
+}
+
+export function applyMoveToGap(
   ast: AstNode[],
   activeId: string,
-  overId: string,
-  activeParentId: string,
+  newParentId: string,
+  newIndex: number,
 ): AstNode[] {
-  if (activeParentId === "root") {
-    const oldIndex = ast.findIndex((c) => c.id === activeId);
-    const newIndex = ast.findIndex((c) => c.id === overId);
-    if (oldIndex === -1 || newIndex === -1) return ast;
-    return arrayMove(ast, oldIndex, newIndex);
+  const active = findNode(ast, activeId);
+  if (!active) return ast;
+  if (newParentId !== "root" && isDescendantOrSelf(active, newParentId))
+    return ast;
+
+  let adjustedIndex = newIndex;
+  if (active.parentId === newParentId) {
+    const siblings = siblingsOf(ast, newParentId);
+    if (siblings) {
+      const activeIndex = siblings.findIndex((c) => c.id === activeId);
+      if (activeIndex !== -1 && activeIndex < newIndex) {
+        adjustedIndex = newIndex - 1;
+      }
+    }
   }
 
-  const parent = findNode(ast, activeParentId);
-  if (!parent?.children) return ast;
+  const removeResult = removeById(ast, activeId);
+  if (!removeResult) return ast;
 
-  const oldIndex = parent.children.findIndex((c) => c.id === activeId);
-  const newIndex = parent.children.findIndex((c) => c.id === overId);
-  if (oldIndex === -1 || newIndex === -1) return ast;
+  return insertAt(
+    removeResult.newAst,
+    newParentId,
+    adjustedIndex,
+    removeResult.removed,
+  );
+}
 
-  return reorderInParent(ast, activeParentId, oldIndex, newIndex);
+export function applyMoveInside(
+  ast: AstNode[],
+  activeId: string,
+  containerId: string,
+): AstNode[] {
+  const active = findNode(ast, activeId);
+  if (!active) return ast;
+  if (isDescendantOrSelf(active, containerId)) return ast;
+
+  const container = findNode(ast, containerId);
+  if (!container) return ast;
+  if (!isContainerType(container.node.type)) return ast;
+
+  const removeResult = removeById(ast, activeId);
+  if (!removeResult) return ast;
+
+  const containerAfterRemove = findNode(removeResult.newAst, containerId);
+  const insertIndex = containerAfterRemove?.children?.length ?? 0;
+
+  return insertAt(
+    removeResult.newAst,
+    containerId,
+    insertIndex,
+    removeResult.removed,
+  );
 }

--- a/packages/pom-editor/src/ast.ts
+++ b/packages/pom-editor/src/ast.ts
@@ -132,8 +132,13 @@ export function applyMoveToGap(
 ): AstNode[] {
   const active = findNode(ast, activeId);
   if (!active) return ast;
-  if (newParentId !== "root" && isDescendantOrSelf(active, newParentId))
-    return ast;
+
+  if (newParentId !== "root") {
+    const newParent = findNode(ast, newParentId);
+    if (!newParent) return ast;
+    if (!isContainerType(newParent.node.type)) return ast;
+    if (isDescendantOrSelf(active, newParentId)) return ast;
+  }
 
   let adjustedIndex = newIndex;
   if (active.parentId === newParentId) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,12 +263,6 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.7)
       '@hirokisakabe/pom':
         specifier: workspace:*
         version: link:../pom
@@ -757,12 +751,6 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
 
   '@dnd-kit/utilities@3.2.2':
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
@@ -8677,13 +8665,6 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      tslib: 2.8.1
-
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
-      react: 19.2.7
       tslib: 2.8.1
 
   '@dnd-kit/utilities@3.2.2(react@19.2.7)':


### PR DESCRIPTION
close #865

## 概要

`PomAstEditor` の DnD を、同一親内のきょうだい並び替えに留まらず **AST の nest 構造そのものを変更できる**形に拡張しました。各行の前後に「sibling 挿入」のための gap、`VStack` / `HStack` / `Layer` の本体に「nest 挿入」のための inside drop の 2 種類の drop target を持たせ、どちらに drop したかで挙動を切り替えます。

## 主な変更

- `packages/pom-editor/src/ast.ts`
  - `applyReorder` (同一親 `arrayMove`) を廃止し、`applyMoveToGap(ast, activeId, newParentId, newIndex)` と `applyMoveInside(ast, activeId, containerId)` を新設。remove + insert ベースで cross-parent と nest 構造変更を一級でサポート。
  - サイクル防止 (`isDescendantOrSelf`)、container 型ガード (`isContainerType`)、新規親の存在/型検証を defensive に内包。
- `packages/pom-editor/src/AstTree.tsx`
  - `SortableContext` + `useSortable` を捨て、`useDraggable` + `useDroppable` 構成に置き換え。
  - drop target ID 規約: `gap:<parentId>:<index>` (sibling 挿入) / `inside:<id>` (nest 挿入)。`pointerWithin` を採用し、`closestCenter` フォールバックは「意図しないネスト」を引き起こすため不採用。
  - drag 中は gap strip を厚く描画 (`8px`) し、`inside` drop は container 本体に青ハイライト + outline、gap drop は青い挿入インジケータと UI 上区別。
- `packages/pom-editor/src/AstTree.test.tsx`
  - 同一親 reorder / トップレベル slide reorder / cross-parent / root 引き上げ / container 入れ子 / inside vs gap の視覚区別 / サイクル防止 / non-container 親への drop 拒否 / 存在しない parentId への drop 拒否 / drag lifecycle のクリア、計 15 件をカバー。
- `packages/pom-editor/package.json` / `pnpm-lock.yaml`: 不要になった `@dnd-kit/sortable` / `@dnd-kit/utilities` を削除。
- `README.md` / `AGENTS.md`: 新仕様に追従。
- `.changeset/pom-editor-cross-parent-dnd.md`: `@hirokisakabe/pom-editor` を minor bump。

## 影響範囲

`@hirokisakabe/pom-editor` パッケージのみ。公開 API (`PomAstEditor` の `xml` / `onChange`) は不変なので website (`apps/website/playground/.../AppLayout.tsx`) などの consumer は無改修で受け取れます。

## ローカル検証手順

```bash
pnpm --filter @hirokisakabe/pom run build           # client API の型を吐かせる
pnpm --filter @hirokisakabe/pom-editor run lint
pnpm --filter @hirokisakabe/pom-editor run typecheck
pnpm --filter @hirokisakabe/pom-editor run test:run
pnpm --filter @hirokisakabe/pom-editor run fmt:check
pnpm --filter @hirokisakabe/pom-editor run knip
pnpm --filter @hirokisakabe/pom-editor run build
```

すべて green。