### PR TITLE
fix(website): include pom-editor diffs in Vercel deploy trigger

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then base=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$base\" HEAD^2 -- ./ ../../packages/pom/docs/; else git diff --quiet HEAD^ HEAD -- ./ ../../packages/pom/docs/; fi"
+  "ignoreCommand": "if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then base=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$base\" HEAD^2 -- ./ ../../packages/pom/docs/ ../../packages/pom-editor/; else git diff --quiet HEAD^ HEAD -- ./ ../../packages/pom/docs/ ../../packages/pom-editor/; fi"
 }

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then base=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$base\" HEAD^2 -- ./ ../../packages/pom/docs/ ../../packages/pom-editor/; else git diff --quiet HEAD^ HEAD -- ./ ../../packages/pom/docs/ ../../packages/pom-editor/; fi"
+  "ignoreCommand": "P=\"./ ../../packages/pom/docs/ ../../packages/pom-editor/\"; if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then b=$(git merge-base HEAD^1 HEAD^2) && git diff --quiet \"$b\" HEAD^2 -- $P; else git diff --quiet HEAD^ HEAD -- $P; fi"
 }


### PR DESCRIPTION
## Summary

- `apps/website/vercel.json` の `ignoreCommand` が `./`（website）と `../../packages/pom/docs/` しか watch しておらず、playground が依存している `packages/pom-editor/` の差分があっても Vercel Preview が更新されなかった
- playground の `AppLayout.tsx` は `@hirokisakabe/pom-editor` から `PomAstEditor` を import しており、`next.config.mjs` で `packages/pom-editor/src/index.ts` を直接 alias しているため、pom-editor のソース変更は website の挙動に直結する
- `ignoreCommand` の diff path に `../../packages/pom-editor/` を追加し、pom-editor の差分でも Preview が生成されるようにした

## Test plan

- [ ] pom-editor だけを変更した PR で Vercel Preview がスキップされず deploy される
- [ ] website / pom docs に無関係な変更（例: 別 package のみ）では従来通りスキップされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)