### PR TITLE
docs: LibreOffice 経路の leading zero 注意を追加

### DIFF
--- a/.changeset/libreoffice-leading-zero-note.md
+++ b/.changeset/libreoffice-leading-zero-note.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": patch
+---
+
+LibreOffice fallback path で純数字テキストの先頭 0 が PNG 上で欠落する場合があることを README に注記しました。

--- a/apps/website/public/llm.txt
+++ b/apps/website/public/llm.txt
@@ -714,6 +714,8 @@ A per-side border (`borderTop` etc.) cannot be combined with `borderRadius`. To 
 - Property names are `w` / `h` (not `width` / `height`)
 - Children of `Layer` require `x` and `y`
 - `Tree` must have exactly one root `<TreeItem>`
+- For decorative agenda / section numbering, prefer `01.` or `#01` instead of pure numeric `01`.
+  LibreOffice-based fallback PNG conversion can drop leading zeros from pure numeric text, while the PPTX itself remains correct in PowerPoint.
 
 ## Build Diagnostics
 

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -113,6 +113,8 @@ pom render slides.pom.md -o ./images
 
 The images are written to the output directory as `slide-01.png`, `slide-02.png`, ... The directory is created if it does not exist. The rendering pipeline is the same as the preview server, so the images match what you see in `pom preview`.
 
+> **LibreOffice fallback caveat:** Current `pom render` uses `pptx-glimpse` directly and does not require LibreOffice. If you are using an older `pom-cli` / `pptx-glimpse` version or a fallback workflow that converts PPTX through LibreOffice before PNG output, pure numeric text with leading zeros (for example `01` / `001`) may be displayed without those zeros in the PNG (`01` -> `1`). The generated PPTX keeps the original text (`<a:t>01</a:t>`), so it displays as intended when opened in PowerPoint. For decorative numbering that must survive both paths, mix in one non-numeric character such as `01.` or `#01`.
+
 To output SVG instead of PNG:
 
 ```bash

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -133,11 +133,11 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
     <Text fontSize="32" bold="true" color="$ink">アジェンダ</Text>
     <VStack gap="16">
       <HStack gap="16" alignItems="center">
-        <Text fontSize="20" bold="true" color="$accent">01</Text>
+        <Text fontSize="20" bold="true" color="$accent">01.</Text>
         <Text fontSize="16" color="$ink">背景と課題</Text>
       </HStack>
       <HStack gap="16" alignItems="center">
-        <Text fontSize="20" bold="true" color="$accent">02</Text>
+        <Text fontSize="20" bold="true" color="$accent">02.</Text>
         <Text fontSize="16" color="$ink">提案内容</Text>
       </HStack>
     </VStack>
@@ -254,7 +254,7 @@ XML を書き始める前に、デッキ全体のデザイントークン（配�
 - h1 の `fontSize` / `color` も同一。スライドごとに 28 / 32 を揺らさない
 - VStack の `gap` (eyebrow と h1 の縦距離) と外周 `padding` も統一する
 - eyebrow の文言は `SECTION 0X · {大文字 1 語}` か `0X · {章タイトル}` のどちらかに固定し、書き分けない
-- 章番号（`01` `02` ...）は **A9 回避策** として常に `01.` や `#01` のように非数字を 1 文字混ぜる。`pom render` 経由の PNG では純数字の leading 0 が消える（"01" → "1"）ことがあるため
+- 章番号（`01` `02` ...）は **A9 回避策** として常に `01.` や `#01` のように非数字を 1 文字混ぜる。LibreOffice 経由の fallback / legacy PNG 化では純数字の leading 0 が消える（"01" -> "1"）ことがあるため
 
 #### 制約と回避（PPTX 原理限界）
 

--- a/skills/pom-slide/SKILL.md
+++ b/skills/pom-slide/SKILL.md
@@ -994,6 +994,8 @@ A per-side border (`borderTop` etc.) cannot be combined with `borderRadius`. To 
 - Property names are `w` / `h` (not `width` / `height`)
 - Children of `Layer` require `x` and `y`
 - `Tree` must have exactly one root `<TreeItem>`
+- For decorative agenda / section numbering, prefer `01.` or `#01` instead of pure numeric `01`.
+  LibreOffice-based fallback PNG conversion can drop leading zeros from pure numeric text, while the PPTX itself remains correct in PowerPoint.
 
 ## Build Diagnostics
 


### PR DESCRIPTION
close #887

## 目的

LibreOffice fallback / legacy PNG 化経路で、純数字テキストの先頭 `0` が PNG 上では欠落する場合があることを明文化します。現行 `pom render` は `pptx-glimpse` を直接使い LibreOffice 不要なので、その前提を保ったうえで fallback caveat として記載しています。

## 変更内容

- `packages/pom-cli/README.md` に leading zero 欠落の注意、PPTX 本体は正常であること、`01.` / `#01` の回避策を追記
- `skills/pom-slide/SKILL.md` のアジェンダ例を `01.` / `02.` に変更し、装飾ナンバリングの注意を追記
- `apps/website/public/llm.txt` と skill 内の埋め込み `llm.txt` ブロックに同じ注意を同期
- `@hirokisakabe/pom-cli` の patch changeset を追加

## 影響範囲

- `packages/pom-cli/README.md`
- `skills/pom-slide/SKILL.md`
- `apps/website/public/llm.txt`
- `.changeset/`

## 検証

- `bash scripts/check-skill-llm-sync.sh`
- `git diff --check main...HEAD`
- `pnpm exec prettier --check packages/pom-cli/README.md .changeset/libreoffice-leading-zero-note.md`
- cross-review: critical 0 / warning 0 / info 0
