### PR TITLE
Node 22 前提の pom / pom-vscode 契約を整備

### DIFF
--- a/.changeset/curly-jobs-watch.md
+++ b/.changeset/curly-jobs-watch.md
@@ -7,4 +7,4 @@
 "pom-vscode": minor
 ---
 
-Node.js のサポート範囲を 22 以降に引き上げました。`@pptx-glimpse/document` 消費に備えて、pom 関連 package と VS Code extension の engines を Node 22 に揃えています。
+Node.js のサポート範囲を 22 以降に引き上げました。`@pptx-glimpse/document` 消費に備えて、pom 関連 package と VS Code extension の engines を Node 22 に揃えています。VS Code extension は Node.js 22 extension host を前提にするため、最小 VS Code バージョンも 1.101 に引き上げています。

--- a/.changeset/curly-jobs-watch.md
+++ b/.changeset/curly-jobs-watch.md
@@ -1,0 +1,10 @@
+---
+"@hirokisakabe/pom": major
+"@hirokisakabe/pom-md": major
+"@hirokisakabe/pom-cli": minor
+"@hirokisakabe/pom-jsx": minor
+"@hirokisakabe/pom-editor": minor
+"pom-vscode": minor
+---
+
+Node.js のサポート範囲を 22 以降に引き上げました。`@pptx-glimpse/document` 消費に備えて、pom 関連 package と VS Code extension の engines を Node 22 に揃えています。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ apps/
 
 PPTX generation pipeline: **calcYogaLayout** → **toPositioned** → **renderPptx**. Additionally, **autoFit** adjusts slides when content overflows.
 
+Existing PPTX reading and structural round-trip work should treat `@pptx-glimpse/document` as the first candidate dependency (#895 option 2: pom → `@pptx-glimpse/document` one-way dependency). If typed model coverage is insufficient, prefer its `packageGraph.rawParts` OOXML escape hatch before adding new ZIP/XML handling in pom.
+
 ### Public API (`@hirokisakabe/pom`)
 
 - `buildPptx(xml, slideSize, options?)` — XML string → PPTX

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## Quick Start
 
-> Requires Node.js 18+
+> Requires Node.js 22+
 
 ```bash
 npm install @hirokisakabe/pom

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -21,7 +21,7 @@
 
 ## Installation
 
-> Requires Node.js 18+
+> Requires Node.js 22+
 
 ```bash
 npm install -g @hirokisakabe/pom-cli

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "author": "Hiroki Sakabe",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('dist/cli.js', '755')\"",

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -20,7 +20,7 @@
 
 ## Installation
 
-> Requires React 18+
+> Requires Node.js 22+ and React 18+
 
 ```bash
 npm install @hirokisakabe/pom-editor react

--- a/packages/pom-editor/package.json
+++ b/packages/pom-editor/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "author": "Hiroki Sakabe",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/pom-jsx/README.md
+++ b/packages/pom-jsx/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-> Requires Node.js 18+ and a TypeScript-with-JSX setup (`tsx` / `ts-node` / compiled `.tsx`).
+> Requires Node.js 22+ and a TypeScript-with-JSX setup (`tsx` / `ts-node` / compiled `.tsx`).
 
 ```bash
 npm install @hirokisakabe/pom @hirokisakabe/pom-jsx

--- a/packages/pom-jsx/package.json
+++ b/packages/pom-jsx/package.json
@@ -44,7 +44,7 @@
   ],
   "author": "Hiroki Sakabe",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/pom-md/README.md
+++ b/packages/pom-md/README.md
@@ -21,7 +21,7 @@
 
 ## Installation
 
-> Requires Node.js 18+
+> Requires Node.js 22+
 
 ```bash
 npm install @hirokisakabe/pom-md @hirokisakabe/pom

--- a/packages/pom-md/package.json
+++ b/packages/pom-md/package.json
@@ -36,7 +36,7 @@
   ],
   "author": "Hiroki Sakabe",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/pom-vscode/README.md
+++ b/packages/pom-vscode/README.md
@@ -24,7 +24,7 @@
 
 ## Installation
 
-> Requires VS Code 1.85+
+> Requires VS Code 1.101+ (Node.js 22 extension host)
 
 Search for **pom** in the VS Code Extensions view, or install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode).
 

--- a/packages/pom-vscode/docs/index.md
+++ b/packages/pom-vscode/docs/index.md
@@ -4,7 +4,7 @@ VS Code extension for live preview of `.pom.md` and `.pom.xml` files. It convert
 
 ## Requirements
 
-- VS Code 1.85 or later
+- VS Code 1.101 or later (Node.js 22 extension host)
 
 ## Install
 

--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": ">=22",
-    "vscode": "^1.85.0"
+    "vscode": "^1.101.0"
   },
   "icon": "icon.png",
   "categories": [

--- a/packages/pom-vscode/package.json
+++ b/packages/pom-vscode/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/pom-vscode"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "vscode": "^1.85.0"
   },
   "icon": "icon.png",

--- a/packages/pom/README.md
+++ b/packages/pom/README.md
@@ -52,7 +52,7 @@
 
 ## Installation
 
-> Requires Node.js 18+
+> Requires Node.js 22+
 
 ```bash
 npm install @hirokisakabe/pom

--- a/packages/pom/docs/index.mdx
+++ b/packages/pom/docs/index.mdx
@@ -21,7 +21,7 @@
 
 ## Quick Start
 
-Requires Node.js 18 or later.
+Requires Node.js 22 or later.
 
 ```bash
 npm install @hirokisakabe/pom

--- a/packages/pom/package.json
+++ b/packages/pom/package.json
@@ -43,7 +43,7 @@
   ],
   "author": "Hiroki Sakabe",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
close #923

## 目的

@pptx-glimpse/document 消費に備えて、pom 関連 package の Node.js engines を 22 以降に揃え、既存 PPTX 読み取り・round-trip の方針を AGENTS.md に明文化します。

## 変更内容

- @hirokisakabe/pom / pom-cli / pom-md / pom-jsx / pom-editor / pom-vscode の engines.node を >=22 に更新
- pom-vscode は Node.js 22 extension host 前提に合わせて engines.vscode を ^1.101.0 に更新
- README / docs の Node.js / VS Code 要件表記を更新
- @pptx-glimpse/document を既存 PPTX 読み取り・structural round-trip の第一候補とする方針を AGENTS.md に追記
- engines 変更を反映する changeset を追加

## 影響範囲

- packages/pom
- packages/pom-cli
- packages/pom-md
- packages/pom-jsx
- packages/pom-editor
- packages/pom-vscode
- ルート README / AGENTS.md

## 検証

- pnpm exec prettier --check 対象ファイル
- pnpm exec changeset status --since=main
- pnpm --filter @hirokisakabe/pom run typecheck
- pnpm --filter @hirokisakabe/pom-cli run typecheck
- pnpm --filter @hirokisakabe/pom-md run typecheck
- pnpm --filter @hirokisakabe/pom-jsx run typecheck
- pnpm --filter @hirokisakabe/pom-editor run typecheck
- pnpm --filter pom-vscode run typecheck
- pnpm --filter @hirokisakabe/pom-cli run lint
- pnpm --filter @hirokisakabe/pom-jsx run lint
- pnpm --filter @hirokisakabe/pom-editor run lint
- root の ESLint bin から packages/pom / packages/pom-md / packages/pom-vscode を lint
