### PR TITLE
pom-theme skill の PPTX 取り込みを programmatic 化

### DIFF
--- a/.changeset/tame-donkeys-dance.md
+++ b/.changeset/tame-donkeys-dance.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+PPTX から PowerPoint theme の配色を `ThemeTokens[]` JSON として抽出する `pom theme extract <pptx>` サブコマンドを追加しました。

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -15,6 +15,7 @@
 - **Live Preview Server** — `pom preview` opens a browser, watches the source file, and rebuilds + reloads on every save (handles editor atomic writes like Vim).
 - **PPTX Build** — `pom build` converts `.pom.xml` / `.pom.md` to a `.pptx` file, with optional `--watch` mode for incremental rebuilds.
 - **PNG / SVG Render** — `pom render` rasterizes each slide to PNG (default) or SVG without LibreOffice, useful for slide-image previews in docs.
+- **Theme Extraction** — `pom theme extract` reads an existing `.pptx` and prints its theme colors as pom `ThemeTokens` JSON, for onboarding brand assets.
 - **Diagnostic Surfacing** — Layout, image, master, and auto-fit diagnostics from `buildPptx` fail the run on stderr with a non-zero exit (`pom build` / `pom render`), while `pom preview` keeps updating so issues can be fixed interactively.
 - **Bundled Fonts** — Carlito and Noto Sans CJK JP are bundled for SVG / PNG rendering, so output looks the same on machines without those fonts installed.
 - **Configurable Output** — Choose port, target slides, output format, text rendering mode (`path` outlines vs native `<text>`), and verbose per-step timing.
@@ -138,6 +139,16 @@ To print per-step timing on stderr:
 ```bash
 pom render slides.pom.xml -o ./images --verbose
 ```
+
+### Theme Extract
+
+Extracts PowerPoint theme colors from an existing `.pptx` as pom `ThemeTokens` JSON — useful for onboarding brand assets (e.g. the `pom-theme` agent skill).
+
+```bash
+pom theme extract brand-master.pptx
+```
+
+Prints a JSON array to stdout with one entry per visible slide layout (`text` / `background` / `primary` / `secondary` / `accent3`–`accent6`, all 6-digit uppercase hex prefixed with `#`), preserving the source master/layout order.
 
 ## Diagnostics
 

--- a/packages/pom-cli/src/cli.ts
+++ b/packages/pom-cli/src/cli.ts
@@ -5,6 +5,7 @@ import { DiagnosticsError } from "@hirokisakabe/pom";
 import { runBuild, runBuildWatch } from "./build.ts";
 import { runPreview } from "./preview.ts";
 import { runRender, type RenderFormat, type TextOutput } from "./render.ts";
+import { runThemeExtract } from "./theme.ts";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -162,5 +163,20 @@ program
       });
     },
   );
+
+const theme = program.command("theme").description("Theme-related utilities");
+
+theme
+  .command("extract")
+  .description(
+    "Extract PowerPoint theme colors as pom ThemeTokens JSON (one entry per visible slide layout)",
+  )
+  .argument("<pptx>", "Input PPTX file")
+  .action((pptx: string) => {
+    runThemeExtract(pptx).catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
+  });
 
 program.parse();

--- a/packages/pom-cli/src/theme.test.ts
+++ b/packages/pom-cli/src/theme.test.ts
@@ -1,0 +1,57 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runThemeExtract } from "./theme.ts";
+
+const extractThemeTokensFromPptxMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@hirokisakabe/pom", () => ({
+  extractThemeTokensFromPptx: extractThemeTokensFromPptxMock,
+}));
+
+describe("theme extract", () => {
+  let tmpDir: string;
+  let inputFile: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pom-cli-theme-"));
+    inputFile = path.join(tmpDir, "deck.pptx");
+    fs.writeFileSync(inputFile, "dummy pptx bytes");
+    extractThemeTokensFromPptxMock.mockReset();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("extractThemeTokensFromPptx の結果を整形 JSON として stdout に出力する", async () => {
+    const tokens = [
+      {
+        text: "#000000",
+        background: "#FFFFFF",
+        primary: "#4472C4",
+        secondary: "#ED7D31",
+        accent3: "#A5A5A5",
+        accent4: "#FFC000",
+        accent5: "#5B9BD5",
+        accent6: "#70AD47",
+      },
+    ];
+    extractThemeTokensFromPptxMock.mockResolvedValue(tokens);
+
+    await runThemeExtract(inputFile);
+
+    expect(extractThemeTokensFromPptxMock).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(tokens, null, 2));
+  });
+
+  it("入力ファイルが存在しない場合はエラーを投げる", async () => {
+    await expect(
+      runThemeExtract(path.join(tmpDir, "missing.pptx")),
+    ).rejects.toThrow("Input file not found");
+  });
+});

--- a/packages/pom-cli/src/theme.ts
+++ b/packages/pom-cli/src/theme.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+import path from "path";
+import { extractThemeTokensFromPptx } from "@hirokisakabe/pom";
+
+export async function runThemeExtract(inputFile: string): Promise<void> {
+  const absInput = path.resolve(inputFile);
+
+  if (!fs.existsSync(absInput)) {
+    throw new Error(`Input file not found: ${absInput}`);
+  }
+
+  const buffer = fs.readFileSync(absInput);
+  const tokens = await extractThemeTokensFromPptx(buffer);
+  console.log(JSON.stringify(tokens, null, 2));
+}

--- a/skills/pom-theme/SKILL.md
+++ b/skills/pom-theme/SKILL.md
@@ -39,20 +39,20 @@ metadata:
 }
 ```
 
-| フィールド | 内容 |
-| --- | --- |
-| `name` | テーマ名（kebab-case） |
-| `tone` | トーンの言語表現（pom-slide のトーン選択に対応。例: コーポレート / ダーク・テック / ウォーム・エディトリアル） |
-| `colors.base` | スライド背景色（6 桁 hex、`#` なし） |
-| `colors.surface` | カード・パネルの背景色 |
-| `colors.ink` | 本文テキスト色 |
-| `colors.muted` | 補助テキスト・キャプション色 |
-| `colors.accent` | 強調 1 色 |
-| `colors.charts` | グラフ用の配列（`Chart` の `chartColors` に使う。accent を先頭に 3〜5 色） |
-| `typography.fontFamily` | 本文フォント名 |
-| `typography.headingFontFamily` | 見出しフォント名（省略時は `fontFamily` と同じ） |
-| `slideMaster` | `@hirokisakabe/pom` の `SlideMasterOptions` と同形。`buildPptx(xml, size, { master })` にそのまま渡せる。`background` / `margin` / `objects` / `slideNumber` / `title` を指定可能 |
-| `source` | テーマの出自の記録。`type` は `brandColor` / `masterPptx` / `website` / `image`。`masterPptx` 由来の場合は相対パスを `source.masterPptx` に記録する |
+| フィールド                     | 内容                                                                                                                                                                              |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                         | テーマ名（kebab-case）                                                                                                                                                            |
+| `tone`                         | トーンの言語表現（pom-slide のトーン選択に対応。例: コーポレート / ダーク・テック / ウォーム・エディトリアル）                                                                    |
+| `colors.base`                  | スライド背景色（6 桁 hex、`#` なし）                                                                                                                                              |
+| `colors.surface`               | カード・パネルの背景色                                                                                                                                                            |
+| `colors.ink`                   | 本文テキスト色                                                                                                                                                                    |
+| `colors.muted`                 | 補助テキスト・キャプション色                                                                                                                                                      |
+| `colors.accent`                | 強調 1 色                                                                                                                                                                         |
+| `colors.charts`                | グラフ用の配列（`Chart` の `chartColors` に使う。accent を先頭に 3〜5 色）                                                                                                        |
+| `typography.fontFamily`        | 本文フォント名                                                                                                                                                                    |
+| `typography.headingFontFamily` | 見出しフォント名（省略時は `fontFamily` と同じ）                                                                                                                                  |
+| `slideMaster`                  | `@hirokisakabe/pom` の `SlideMasterOptions` と同形。`buildPptx(xml, size, { master })` にそのまま渡せる。`background` / `margin` / `objects` / `slideNumber` / `title` を指定可能 |
+| `source`                       | テーマの出自の記録。`type` は `brandColor` / `masterPptx` / `website` / `image`。`masterPptx` 由来の場合は相対パスを `source.masterPptx` に記録する                               |
 
 > **フォントについて**: `fontFamily` はテーマに記録されるが、pom のテキスト計測は標準フォントベースのため、特殊なブランドフォントでは行幅の計測がずれることがある（フォント計測の拡張は pom 本体の今後の対応範囲）。日本語デッキでは `Noto Sans JP` を推奨。
 
@@ -93,12 +93,12 @@ command -v pom >/dev/null 2>&1 && pom theme extract <input.pptx>
 
 `ThemeTokens` のフィールドを以下の対応でテーマのロールに取り込む:
 
-| `ThemeTokens` フィールド | 元 XML 対応 | テーマのロール |
-| --- | --- | --- |
-| `background` | `<a:lt1>`（背景 1、`<a:sysClr>` の場合は `lastClr` を含めて解決済み） | base の候補。純白 `FFFFFF` の場合は Step 3 でオフホワイトへの調整を検討 |
-| `text` | `<a:dk1>`（テキスト 1、同上） | ink の候補。純黒 `000000` の場合は Step 3 で調整 |
-| `primary` | `<a:accent1>` | accent |
-| `secondary`, `accent3`〜`accent6` | `<a:accent2>`〜`<a:accent6>` | `colors.charts`（`primary` を先頭に、`secondary` → `accent3` → ... の順で 3〜5 色） |
+| `ThemeTokens` フィールド          | 元 XML 対応                                                           | テーマのロール                                                                      |
+| --------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `background`                      | `<a:lt1>`（背景 1、`<a:sysClr>` の場合は `lastClr` を含めて解決済み） | base の候補。純白 `FFFFFF` の場合は Step 3 でオフホワイトへの調整を検討             |
+| `text`                            | `<a:dk1>`（テキスト 1、同上）                                         | ink の候補。純黒 `000000` の場合は Step 3 で調整                                    |
+| `primary`                         | `<a:accent1>`                                                         | accent                                                                              |
+| `secondary`, `accent3`〜`accent6` | `<a:accent2>`〜`<a:accent6>`                                          | `colors.charts`（`primary` を先頭に、`secondary` → `accent3` → ... の順で 3〜5 色） |
 
 `surface` / `muted` に相当するロールは `extractThemeTokensFromPptx()` の戻り値に含まれない（`<a:lt2>` / `<a:dk2>` は API のスコープ外）ため、Step 3 の導出ルールで `base` / `ink` から都度算出する。
 
@@ -108,10 +108,10 @@ command -v pom >/dev/null 2>&1 && pom theme extract <input.pptx>
 unzip -p <input.pptx> ppt/theme/theme1.xml
 ```
 
-| theme1.xml | テーマのロール |
-| --- | --- |
+| theme1.xml                      | テーマのロール                                                                                |
+| ------------------------------- | --------------------------------------------------------------------------------------------- |
 | `<a:fontScheme>` の `minorFont` | `typography.fontFamily`（日本語デッキでは `<a:ea>` の typeface を優先、無ければ `<a:latin>`） |
-| `<a:fontScheme>` の `majorFont` | `typography.headingFontFamily` |
+| `<a:fontScheme>` の `majorFont` | `typography.headingFontFamily`                                                                |
 
 **マスターの背景オーバーライド（`<p:bg>`）について**: `extractThemeTokensFromPptx()` はテーマの配色スキームのみを返し、スライドマスター個別の背景オーバーライドは対象外なので、これも従来どおり手読みする。
 
@@ -154,11 +154,11 @@ unzip -p <input.pptx> ppt/slideMasters/slideMaster1.xml
 
 WCAG の相対輝度に基づくコントラスト比で以下を確認し、満たさない場合は明度を調整して再確認する:
 
-| 組み合わせ | 最低基準 |
-| --- | --- |
-| ink / base | 7:1 以上（最低でも 4.5:1） |
-| ink / surface | 4.5:1 以上 |
-| muted / base | 3:1 以上 |
+| 組み合わせ    | 最低基準                                          |
+| ------------- | ------------------------------------------------- |
+| ink / base    | 7:1 以上（最低でも 4.5:1）                        |
+| ink / surface | 4.5:1 以上                                        |
+| muted / base  | 3:1 以上                                          |
 | accent / base | 3:1 以上（accent をテキストや細いバーに使うため） |
 
 コントラスト比は `(L1 + 0.05) / (L2 + 0.05)`（L は相対輝度、L1 ≧ L2）。厳密な計算が難しい場合は `python3` ワンライナーで算出する:

--- a/skills/pom-theme/SKILL.md
+++ b/skills/pom-theme/SKILL.md
@@ -84,12 +84,17 @@ metadata:
 色の抽出は `@hirokisakabe/pom` の `extractThemeTokensFromPptx()`（[#906](https://github.com/hirokisakabe/pom/issues/906)）を `pom-cli` 経由で呼び出す。`<a:clrScheme>` の手読みは行わない。
 
 ```bash
-command -v pom >/dev/null 2>&1 && pom theme extract <input.pptx>
+if command -v pom >/dev/null 2>&1; then
+  pom theme extract <input.pptx>
+else
+  echo "pom-cli not installed" >&2
+fi
 ```
 
 - `pom`（pom-cli）が無い場合はブランドカラー直接指定での再実行を案内し、この手順をスキップする（`npm install -g @hirokisakabe/pom-cli` でインストール可能）。
-- 出力は `ThemeTokens`（`text` / `background` / `primary` / `secondary` / `accent3`〜`accent6`）の JSON 配列。スライドマスターごとに、配下の表示 layout 数だけ同じ値が繰り返される。通常は先頭要素を採用すればよい。マスターが複数あり値が異なる場合は候補としてユーザーに提示する。
-- コマンドが失敗する（`theme1.xml` が存在しない等）場合はエラー内容を報告し、ブランドカラー直接指定での再実行を案内する。
+- 出力は `ThemeTokens`（`text` / `background` / `primary` / `secondary` / `accent3`〜`accent6`）の JSON 配列で、各値は `#` 付き 6 桁大文字 hex（例: `#4472C4`）。スライドマスターごとに、配下の表示 layout 数だけ同じ値が繰り返される。通常は先頭要素を採用すればよい。マスターが複数あり値が異なる場合は候補としてユーザーに提示する。`pom-theme.json` の `colors.*` は `#` なし表記（冒頭「テーマファイル形式」参照）なので、取り込み時に `#` を外す。
+- コマンド自体が失敗する（PPTX が壊れている・ファイルが存在しない等）場合はエラー内容を報告し、ブランドカラー直接指定での再実行を案内する。
+- `theme1.xml` が読めない・`<a:clrScheme>` を含まない場合はエラーにならず、Office 標準のフォールバック配色（`primary: #4472C4` / `secondary: #ED7D31` / `accent3: #A5A5A5` / `accent4: #FFC000` / `accent5: #5B9BD5` / `accent6: #70AD47`）が返る。出力がこの値と一致する場合は theme 未検出を疑い、ユーザーに確認する。マスターが 1 つも解決できない場合は出力が空配列 `[]` になるため、その場合もブランドカラー直接指定を案内する。
 
 `ThemeTokens` のフィールドを以下の対応でテーマのロールに取り込む:
 

--- a/skills/pom-theme/SKILL.md
+++ b/skills/pom-theme/SKILL.md
@@ -81,34 +81,45 @@ metadata:
 
 #### b. 既存 PPTX マスターの読み込み
 
-PPTX は zip アーカイブなので、`unzip -p` でテーマ XML を直接読み取れる。
+色の抽出は `@hirokisakabe/pom` の `extractThemeTokensFromPptx()`（[#906](https://github.com/hirokisakabe/pom/issues/906)）を `pom-cli` 経由で呼び出す。`<a:clrScheme>` の手読みは行わない。
 
 ```bash
-# カラースキームとフォントスキーム
-unzip -p <input.pptx> ppt/theme/theme1.xml
-
-# マスターの背景定義（p:bg 要素）
-unzip -p <input.pptx> ppt/slideMasters/slideMaster1.xml
+command -v pom >/dev/null 2>&1 && pom theme extract <input.pptx>
 ```
 
-`theme1.xml` の `<a:clrScheme>` から色を、`<a:fontScheme>` からフォントを以下の対応で取り込む:
+- `pom`（pom-cli）が無い場合はブランドカラー直接指定での再実行を案内し、この手順をスキップする（`npm install -g @hirokisakabe/pom-cli` でインストール可能）。
+- 出力は `ThemeTokens`（`text` / `background` / `primary` / `secondary` / `accent3`〜`accent6`）の JSON 配列。スライドマスターごとに、配下の表示 layout 数だけ同じ値が繰り返される。通常は先頭要素を採用すればよい。マスターが複数あり値が異なる場合は候補としてユーザーに提示する。
+- コマンドが失敗する（`theme1.xml` が存在しない等）場合はエラー内容を報告し、ブランドカラー直接指定での再実行を案内する。
+
+`ThemeTokens` のフィールドを以下の対応でテーマのロールに取り込む:
+
+| `ThemeTokens` フィールド | 元 XML 対応 | テーマのロール |
+| --- | --- | --- |
+| `background` | `<a:lt1>`（背景 1、`<a:sysClr>` の場合は `lastClr` を含めて解決済み） | base の候補。純白 `FFFFFF` の場合は Step 3 でオフホワイトへの調整を検討 |
+| `text` | `<a:dk1>`（テキスト 1、同上） | ink の候補。純黒 `000000` の場合は Step 3 で調整 |
+| `primary` | `<a:accent1>` | accent |
+| `secondary`, `accent3`〜`accent6` | `<a:accent2>`〜`<a:accent6>` | `colors.charts`（`primary` を先頭に、`secondary` → `accent3` → ... の順で 3〜5 色） |
+
+`surface` / `muted` に相当するロールは `extractThemeTokensFromPptx()` の戻り値に含まれない（`<a:lt2>` / `<a:dk2>` は API のスコープ外）ため、Step 3 の導出ルールで `base` / `ink` から都度算出する。
+
+**フォント（`<a:fontScheme>`）について**: `extractThemeTokensFromPptx()` は色のみを扱い、フォント抽出は #906 のスコープ外。当面は従来どおり手読みする（programmatic 化は必要になれば別 issue で対応する）。
+
+```bash
+unzip -p <input.pptx> ppt/theme/theme1.xml
+```
 
 | theme1.xml | テーマのロール |
 | --- | --- |
-| `<a:lt1>`（背景 1） | base の候補。純白 `FFFFFF` の場合は Step 3 でオフホワイトへの調整を検討 |
-| `<a:lt2>`（背景 2） | surface の候補 |
-| `<a:dk1>`（テキスト 1） | ink の候補。純黒 `000000` の場合は Step 3 で調整 |
-| `<a:dk2>`（テキスト 2） | muted 導出の参考 |
-| `<a:accent1>` | accent |
-| `<a:accent1>`〜`<a:accent6>` | `colors.charts`（上から順に 3〜5 色） |
 | `<a:fontScheme>` の `minorFont` | `typography.fontFamily`（日本語デッキでは `<a:ea>` の typeface を優先、無ければ `<a:latin>`） |
 | `<a:fontScheme>` の `majorFont` | `typography.headingFontFamily` |
 
-色値は `<a:srgbClr val="..."/>` から取る。`<a:sysClr>`（`windowText` → `000000`、`window` → `FFFFFF`）の場合は `lastClr` 属性の値を使う。
+**マスターの背景オーバーライド（`<p:bg>`）について**: `extractThemeTokensFromPptx()` はテーマの配色スキームのみを返し、スライドマスター個別の背景オーバーライドは対象外なので、これも従来どおり手読みする。
 
-`slideMaster1.xml` の `<p:bg>` に単色背景（`<a:solidFill>`）があれば base および `slideMaster.background.color` に反映する。画像背景の場合は `slideMaster.background` には取り込まず、完了報告でその旨を伝える（画像背景の移植は対象外）。
+```bash
+unzip -p <input.pptx> ppt/slideMasters/slideMaster1.xml
+```
 
-`theme1.xml` が存在しない・読み取れない場合はエラー内容を報告し、ブランドカラー直接指定での再実行を案内する。
+`<p:bg>` に単色背景（`<a:solidFill>`）があれば base および `slideMaster.background.color` に反映する。画像背景の場合は `slideMaster.background` には取り込まず、完了報告でその旨を伝える（画像背景の移植は対象外）。
 
 #### c. Web サイト / 画像からの抽出
 
@@ -119,7 +130,7 @@ unzip -p <input.pptx> ppt/slideMasters/slideMaster1.xml
 
 ### 3. 5 ロールパレットの導出
 
-主ブランドカラーを accent に据え、残りのロールを導出する。PPTX マスター由来で全ロールが揃っている場合も、以下の品質基準（純白・純黒回避、コントラスト）を満たすよう微調整する。
+主ブランドカラーを accent に据え、残りのロールを導出する。PPTX マスター由来で base / ink / accent が判明している場合も、以下の品質基準（純白・純黒回避、コントラスト）を満たすよう微調整する。
 
 **ライト基調**:
 


### PR DESCRIPTION
close #909

## 概要

`skills/pom-theme/SKILL.md` の手順 2b（既存 PPTX マスターからの色抽出）を、`unzip -p` + LLM 手読みから [#906](https://github.com/hirokisakabe/pom/issues/906) で追加された `extractThemeTokensFromPptx()` の呼び出しに置き換えました。skill から Bash 経由で呼べるよう、`packages/pom-cli` に `pom theme extract <pptx>` サブコマンドを追加しています。

## 変更内容

- **`packages/pom-cli`**: `pom theme extract <pptx>` サブコマンドを追加（`extractThemeTokensFromPptx()` の結果を JSON で stdout に出力）。README にも使い方を追記
- **`skills/pom-theme/SKILL.md`**:
  - 手順 2b の `<a:clrScheme>` 手読みを `pom theme extract` 呼び出しに置き換え
  - `ThemeTokens` のフィールド（`text` / `background` / `primary` / `secondary` / `accent3`〜`accent6`）とテーマのロール（ink / base / accent / charts）の対応表を追加。`surface` / `muted` は API のスコープ外のため Step 3 の導出ルールに委譲する旨を明記
  - フォント（`<a:fontScheme>`）とマスター背景オーバーライド（`<p:bg>`）は #906 のスコープ外のため、引き続き `unzip` による手読みを維持する方針を明記
  - `pom theme extract` の出力（`#` 付き hex）と `pom-theme.json` の格納形式（`#` なし）の変換指示、および theme が読めない場合に発生する Office 標準フォールバック配色の挙動（エラーにならず黙って返る点）を追記
- changeset 追加（`@hirokisakabe/pom-cli` minor）

## 影響パッケージパス

- `packages/pom-cli/src/theme.ts`（新規）
- `packages/pom-cli/src/theme.test.ts`（新規）
- `packages/pom-cli/src/cli.ts`
- `packages/pom-cli/README.md`
- `skills/pom-theme/SKILL.md`
- `.changeset/tame-donkeys-dance.md`

## ローカル検証

- `pnpm --filter @hirokisakabe/pom-cli run test:run` — 全 5 ファイル / 30 テスト成功
- `pnpm --filter @hirokisakabe/pom-cli run typecheck` — エラーなし
- `pnpm --filter @hirokisakabe/pom-cli run lint` — エラーなし
- `pnpm --filter @hirokisakabe/pom-cli run fmt:check` / `npx prettier --check skills/pom-theme/SKILL.md` — フォーマット問題なし
- `gh skill publish --dry-run` — 既存の警告のみ（今回変更による新規エラーなし）
- `claude -p` による独立 reviewer session でのクロスレビューを実施し、warning 2 件（`#` 付き hex の変換指示欠落、フォールバック配色挙動の記載不備）を追加コミットで反映済み
