### PR TITLE
Text primitive を glimpse writer へ移行

### DIFF
--- a/.changeset/text-glimpse-writer.md
+++ b/.changeset/text-glimpse-writer.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+Text primitive の PPTX 生成を @pptx-glimpse/document writer 経由に移行しました。

--- a/packages/pom/package.json
+++ b/packages/pom/package.json
@@ -89,7 +89,7 @@
     "tsx": "4.23.0"
   },
   "dependencies": {
-    "@pptx-glimpse/document": "0.2.0",
+    "@pptx-glimpse/document": "0.5.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "fast-xml-parser": "^5.9.3",
     "image-size": "2.0.2",

--- a/packages/pom/src/buildContext.ts
+++ b/packages/pom/src/buildContext.ts
@@ -2,6 +2,7 @@ import type { TextMeasurementMode } from "./calcYogaLayout/measureText.ts";
 import { DiagnosticCollector } from "./diagnostics.ts";
 import { GlowEffectRegistry } from "./renderPptx/glowEffects.ts";
 import { GradientFillRegistry } from "./renderPptx/gradientFills.ts";
+import { GlimpseTextBoxRegistry } from "./renderPptx/glimpseTextBoxes.ts";
 
 export interface BuildContext {
   textMeasurementMode: TextMeasurementMode;
@@ -11,6 +12,7 @@ export interface BuildContext {
   diagnostics: DiagnosticCollector;
   gradientFills: GradientFillRegistry;
   glowEffects: GlowEffectRegistry;
+  glimpseTextBoxes: GlimpseTextBoxRegistry;
 }
 
 export function createBuildContext(
@@ -24,5 +26,6 @@ export function createBuildContext(
     diagnostics: new DiagnosticCollector(),
     gradientFills: new GradientFillRegistry(),
     glowEffects: new GlowEffectRegistry(),
+    glimpseTextBoxes: new GlimpseTextBoxRegistry(),
   };
 }

--- a/packages/pom/src/buildPptx.ts
+++ b/packages/pom/src/buildPptx.ts
@@ -9,6 +9,7 @@ import { DiagnosticsError } from "./diagnostics.ts";
 import { parseMasterPptx } from "./parseMasterPptx.ts";
 import { parseXml } from "./parseXml/parseXml.ts";
 import { patchPptxWriteForGlowEffects } from "./renderPptx/glowEffects.ts";
+import { patchPptxWriteForGlimpseTextBoxes } from "./renderPptx/glimpseTextBoxes.ts";
 import { patchPptxWriteForGradientFills } from "./renderPptx/gradientFills.ts";
 import { renderPptx } from "./renderPptx/renderPptx.ts";
 import { freeYogaTree } from "./shared/freeYogaTree.ts";
@@ -87,8 +88,11 @@ export async function buildPptx(
 
   const pptx = await renderPptx(positionedPages, slideSize, ctx, master);
 
-  // backgroundGradient / textGradient 使用時は write/writeFile に gradFill 置換の後処理を仕込む
+  // backgroundGradient 使用時は write/writeFile に gradFill 置換の後処理を仕込む
   patchPptxWriteForGradientFills(pptx, ctx.gradientFills);
+
+  // Text primitive は glimpse writer の text box XML で marker shape を置換する
+  patchPptxWriteForGlimpseTextBoxes(pptx, ctx.glimpseTextBoxes);
 
   // Shape / Icon の glow 指定がある場合は write/writeFile に effectLst 挿入の
   // 後処理を仕込む (gradientFills の patch 後にチェーンする)

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -1,0 +1,526 @@
+/**
+ * Text primitive の @pptx-glimpse/document writer への段階的 swap。
+ *
+ * 混在期間の合成方式は「pptxgenjs 出力 zip をベースに、swap 済み Text
+ * primitive の shape XML だけを glimpse writer で生成して該当 marker shape と
+ * 差し替える」方式を採用する。pptxgenjs 側にはまだ Shape / Image / Table /
+ * Chart など未 swap primitive と slide master 生成が残っているため、既存 zip を
+ * ベースにすると [Content_Types].xml / rels / media parts の管理を現行実装へ
+ * 寄せられる。代替案として glimpse の package をベースに未 swap primitive を
+ * pptxgenjs から取り込む方式も検討したが、初回スライス時点では pptxgenjs 側の
+ * 非 text primitive と master 出力を XML part 単位で切り出す責務が増え、以降の
+ * primitive swap より先に package 合成の複雑さが大きくなるため採用しない。
+ *
+ * marker shape は描画順を保持するためだけに pptxgenjs へ追加し、write 時に
+ * glimpse の `<p:sp>` で丸ごと置換する。Text content 自体は pptxgenjs `addText`
+ * を経由しない。
+ */
+import {
+  addTextBox,
+  asEmu,
+  asHundredthPt,
+  asOoxmlAngle,
+  asOoxmlPercent,
+  asPt,
+  createPptx,
+  type AddTextBoxGradientFillInput,
+  type AddTextBoxInput,
+  type AddTextBoxParagraphInput,
+  type AddTextBoxRunPropertiesInput,
+  type PptxSourceModelAddTextBoxEdit,
+} from "@pptx-glimpse/document";
+import type {
+  PositionedNode,
+  TextGlow,
+  TextOutline,
+  Underline,
+} from "../types.ts";
+import { parseLinearGradient } from "../shared/gradient.ts";
+import { EMU_PER_IN, pxToEmu, pxToPt } from "./units.ts";
+import { createTextOptions, resolveSubSup } from "./textOptions.ts";
+
+type PptxGenJSInstance = import("pptxgenjs").default;
+type WriteProps = NonNullable<Parameters<PptxGenJSInstance["write"]>[0]>;
+type WriteFileProps = NonNullable<
+  Parameters<PptxGenJSInstance["writeFile"]>[0]
+>;
+type TextPositionedNode = Extract<PositionedNode, { type: "text" }>;
+
+const MARKER_PREFIX = "pom-text:";
+const HYPERLINK_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
+
+interface GlimpseTextRun {
+  text: string;
+  properties: AddTextBoxRunPropertiesInput;
+  href?: string;
+}
+
+async function loadJSZip(): Promise<typeof import("jszip")> {
+  const mod = await import("jszip");
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
+  return (mod as any).default ?? mod;
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
+}
+
+function cleanHex(color: string | undefined): string | undefined {
+  return color?.replace(/^#/, "").toUpperCase();
+}
+
+function toColorInput(color: string | undefined) {
+  const hex = cleanHex(color);
+  return hex ? { kind: "srgb" as const, hex } : undefined;
+}
+
+function toUnderlineInput(underline: Underline | undefined) {
+  if (underline === undefined || underline === false) return undefined;
+  if (underline === true) return true;
+  return {
+    style: underline.style,
+    color: toColorInput(underline.color),
+  };
+}
+
+function toBaselineInput(
+  subscript: boolean | undefined,
+  superscript: boolean | undefined,
+) {
+  if (subscript) return "subscript" as const;
+  if (superscript) return "superscript" as const;
+  return undefined;
+}
+
+function toGlowInput(glow: TextGlow | undefined) {
+  if (!glow) return undefined;
+  return {
+    radius: asEmu(Math.round(pxToEmu(glow.size ?? 8))),
+    color: toColorInput(glow.color ?? "FFFFFF")!,
+  };
+}
+
+function toOutlineInput(outline: TextOutline | undefined) {
+  if (!outline) return undefined;
+  return {
+    width: asEmu(Math.round(pxToEmu(outline.size ?? 1))),
+    color: toColorInput(outline.color ?? "FFFFFF"),
+  };
+}
+
+function toCharSpacing(letterSpacingPx: number | undefined) {
+  if (letterSpacingPx === undefined) return undefined;
+  return Math.round(pxToPt(letterSpacingPx) * 100);
+}
+
+function toTextGradientInput(
+  value: string | undefined,
+): AddTextBoxGradientFillInput | undefined {
+  if (!value) return undefined;
+  const linear = parseLinearGradient(value);
+  if (!linear) return undefined;
+  const dmlAngle = (((linear.angle - 90) % 360) + 360) % 360;
+  return {
+    angle: asOoxmlAngle(Math.round(dmlAngle * 60000)),
+    stops: linear.stops.map((stop) => ({
+      position: asOoxmlPercent(Math.round(stop.position * 1000)),
+      color: toColorInput(stop.color)!,
+    })),
+  };
+}
+
+function stripUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+function buildRunProperties(
+  node: TextPositionedNode,
+  run: NonNullable<TextPositionedNode["runs"]>[number] | undefined,
+  gradientFill: AddTextBoxGradientFillInput | undefined,
+): AddTextBoxRunPropertiesInput {
+  const fontSizePx = run?.fontSize ?? node.fontSize ?? 24;
+  const letterSpacingPx = run?.letterSpacing ?? node.letterSpacing;
+  const subSup = run ? resolveSubSup(run, node) : node;
+  const color = gradientFill
+    ? undefined
+    : toColorInput(run?.color ?? node.color);
+
+  return stripUndefined({
+    fontFace: run?.fontFamily ?? node.fontFamily ?? "Noto Sans JP",
+    fontSize: asPt(pxToPt(fontSizePx)),
+    color,
+    gradientFill,
+    bold: run?.bold ?? node.bold,
+    italic: run?.italic ?? node.italic,
+    underline: toUnderlineInput(run?.underline ?? node.underline),
+    strike: run?.strike ?? node.strike,
+    baseline: toBaselineInput(subSup.subscript, subSup.superscript),
+    highlight: toColorInput(run?.highlight ?? node.highlight),
+    glow: toGlowInput(node.glow),
+    outline: toOutlineInput(node.outline),
+    charSpacing: toCharSpacing(letterSpacingPx),
+  });
+}
+
+function createParagraphProperties(
+  node: TextPositionedNode,
+): AddTextBoxParagraphInput["properties"] {
+  const lineHeight = node.lineHeight ?? 1.3;
+  const fontSizePx = node.fontSize ?? 24;
+  return stripUndefined({
+    align: node.textAlign,
+    lineSpacing: asHundredthPt(
+      Math.round(pxToPt(fontSizePx * lineHeight) * 100),
+    ),
+  });
+}
+
+function buildParagraphs(node: TextPositionedNode): {
+  paragraphs: readonly AddTextBoxParagraphInput[];
+  hyperlinks: readonly (string | undefined)[];
+} {
+  const gradientFill = toTextGradientInput(node.textGradient);
+  const sourceRuns: GlimpseTextRun[] =
+    node.runs && node.runs.length > 0
+      ? node.runs.map((run) => ({
+          text: run.text,
+          properties: buildRunProperties(node, run, gradientFill),
+          href: run.href,
+        }))
+      : [
+          {
+            text: node.text ?? "",
+            properties: buildRunProperties(node, undefined, gradientFill),
+          },
+        ];
+  const paragraphRuns: GlimpseTextRun[][] = [[]];
+  for (const run of sourceRuns) {
+    const lines = run.text.replace(/\r*\n/g, "\n").split("\n");
+    lines.forEach((line, index) => {
+      if (index > 0) {
+        paragraphRuns.push([]);
+      }
+      paragraphRuns[paragraphRuns.length - 1]?.push({
+        ...run,
+        text: line,
+      });
+    });
+  }
+
+  return {
+    paragraphs: paragraphRuns.map((runs) => ({
+      properties: createParagraphProperties(node),
+      runs,
+    })),
+    hyperlinks: paragraphRuns.flatMap((runs) =>
+      runs.map((run) => (run.text ? run.href : undefined)),
+    ),
+  };
+}
+
+function withGlowAlpha(xml: string, node: TextPositionedNode): string {
+  const glow = node.glow;
+  if (!glow || glow.opacity === undefined) return xml;
+  const alpha = Math.round(glow.opacity * 100000);
+  const color = cleanHex(glow.color ?? "FFFFFF");
+  const target = `<a:glow rad="${Math.round(pxToEmu(glow.size ?? 8))}"><a:srgbClr val="${color}"/></a:glow>`;
+  const replacement = `<a:glow rad="${Math.round(pxToEmu(glow.size ?? 8))}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:glow>`;
+  return xml.replaceAll(target, replacement);
+}
+
+function withPptxGenParagraphDefaults(xml: string): string {
+  let result = xml.replaceAll('baseline="-25000"', 'baseline="-40000"');
+  result = result.replace(/<a:bodyPr\b([^>]*)\/>/g, (_match, attrs) => {
+    const attrText = attrs as string;
+    const withRtl = /(?:^|\s)rtlCol=/.test(attrText)
+      ? attrText
+      : `${attrText} rtlCol="0"`;
+    const withAnchor = /(?:^|\s)anchor=/.test(withRtl)
+      ? withRtl
+      : `${withRtl} anchor="t"`;
+    return `<a:bodyPr${withAnchor}/>`;
+  });
+  result = result.replace(
+    /<a:pPr([^>]*)>([\s\S]*?)<\/a:pPr>/g,
+    (match, attrs, body) => {
+      const attrText = attrs as string;
+      const nextAttrs = /(?:^|\s)indent=/.test(attrText)
+        ? attrText
+        : `${attrText} indent="0" marL="0"`;
+      const bodyText = body as string;
+      const nextBody = bodyText.includes("<a:buNone/>")
+        ? bodyText
+        : `${bodyText}<a:buNone/>`;
+      return `<a:pPr${nextAttrs}>${nextBody}</a:pPr>`;
+    },
+  );
+  result = result.replace(
+    /<a:p>(?!<a:pPr)/g,
+    '<a:p><a:pPr indent="0" marL="0"><a:buNone/></a:pPr>',
+  );
+  return result;
+}
+
+function createTextBoxXml(
+  node: TextPositionedNode,
+  name: string,
+): { xml: string; hyperlinks: readonly (string | undefined)[] } {
+  const source = createPptx();
+  const slideHandle = source.slides[0]?.handle;
+  if (!slideHandle) {
+    throw new Error("createPptx did not create an editable slide");
+  }
+
+  const textOptions = createTextOptions(node);
+  const { paragraphs, hyperlinks } = buildParagraphs(node);
+  const input: AddTextBoxInput = {
+    offsetX: asEmu(Math.round(textOptions.x * EMU_PER_IN)),
+    offsetY: asEmu(Math.round(textOptions.y * EMU_PER_IN)),
+    width: asEmu(Math.round(textOptions.w * EMU_PER_IN)),
+    height: asEmu(Math.round(textOptions.h * EMU_PER_IN)),
+    rotation:
+      node.rotate !== undefined
+        ? asOoxmlAngle(Math.round(node.rotate * 60000))
+        : undefined,
+    name,
+    body: {
+      marginLeft: asEmu(0),
+      marginRight: asEmu(0),
+      marginTop: asEmu(0),
+      marginBottom: asEmu(0),
+    },
+    paragraphs,
+  };
+  const edited = addTextBox(source, slideHandle, input);
+  const edit = edited.edits?.at(-1) as
+    PptxSourceModelAddTextBoxEdit | undefined;
+  if (edit?.kind !== "addTextBox") {
+    throw new Error("addTextBox did not produce an addTextBox edit");
+  }
+  return {
+    xml: withPptxGenParagraphDefaults(withGlowAlpha(edit.xml, node)),
+    hyperlinks,
+  };
+}
+
+interface RegisteredTextBox {
+  marker: string;
+  name: string;
+  xml: string;
+  hyperlinks: readonly (string | undefined)[];
+}
+
+export class GlimpseTextBoxRegistry {
+  private readonly registered: RegisteredTextBox[] = [];
+
+  register(node: TextPositionedNode): string {
+    const index = this.registered.length;
+    const marker = `${MARKER_PREFIX}${index}`;
+    const name = `Text ${index + 1}`;
+    const { xml, hyperlinks } = createTextBoxXml(node, name);
+    this.registered.push({ marker, name, xml, hyperlinks });
+    return marker;
+  }
+
+  get isEmpty(): boolean {
+    return this.registered.length === 0;
+  }
+
+  get entries(): readonly RegisteredTextBox[] {
+    return this.registered;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceShapeId(xml: string, id: string, name: string): string {
+  return xml.replace(
+    /<p:cNvPr id="[^"]+" name="[^"]*"/,
+    `<p:cNvPr id="${id}" name="${name}"`,
+  );
+}
+
+function xmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function slideRelsPath(slidePath: string): string {
+  const fileName = slidePath.split("/").at(-1);
+  return `ppt/slides/_rels/${fileName}.rels`;
+}
+
+class SlideRelationshipEditor {
+  private nextId: number;
+
+  private changed = false;
+
+  constructor(private xml: string) {
+    const ids = Array.from(xml.matchAll(/\bId="rId(\d+)"/g), (match) =>
+      Number(match[1]),
+    );
+    this.nextId = Math.max(0, ...ids) + 1;
+  }
+
+  addHyperlink(href: string): string {
+    const id = `rId${this.nextId++}`;
+    const rel =
+      `<Relationship Id="${id}" Type="${HYPERLINK_REL_TYPE}" ` +
+      `Target="${xmlAttr(href)}" TargetMode="External"/>`;
+    this.xml = this.xml.replace("</Relationships>", `${rel}</Relationships>`);
+    this.changed = true;
+    return id;
+  }
+
+  get result(): { xml: string; changed: boolean } {
+    return { xml: this.xml, changed: this.changed };
+  }
+}
+
+function createRelationshipEditor(xml: string | undefined) {
+  return new SlideRelationshipEditor(
+    xml ??
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>',
+  );
+}
+
+function withHyperlinkRelationships(
+  xml: string,
+  hyperlinks: readonly (string | undefined)[],
+  addRelationship: (href: string) => string,
+): string {
+  if (!hyperlinks.some(Boolean)) return xml;
+  let index = 0;
+  return xml.replace(
+    /<a:rPr\b([^>]*)>([\s\S]*?)<\/a:rPr>/g,
+    (match, attrs, body) => {
+      const href = hyperlinks[index++];
+      if (!href) return match;
+      const id = addRelationship(href);
+      return `<a:rPr${attrs as string}>${body as string}<a:hlinkClick r:id="${id}"/></a:rPr>`;
+    },
+  );
+}
+
+function applyGlimpseTextBoxesToXml(
+  xml: string,
+  registry: GlimpseTextBoxRegistry,
+  addRelationship: (href: string) => string,
+): string {
+  let result = xml;
+  for (const entry of registry.entries) {
+    const re = new RegExp(
+      `<p:sp><p:nvSpPr><p:cNvPr id="([^"]+)" name="${escapeRegExp(
+        entry.marker,
+      )}"[\\s\\S]*?</p:sp>`,
+      "g",
+    );
+    result = result.replace(re, (_match, id: string) => {
+      const xmlWithIds = replaceShapeId(entry.xml, id, entry.name);
+      return withHyperlinkRelationships(
+        xmlWithIds,
+        entry.hyperlinks,
+        addRelationship,
+      );
+    });
+  }
+  return result;
+}
+
+async function applyGlimpseTextBoxes(
+  data: Uint8Array | ArrayBuffer,
+  registry: GlimpseTextBoxRegistry,
+): Promise<import("jszip")> {
+  const JSZip = await loadJSZip();
+  const zip = await JSZip.loadAsync(data);
+
+  const slidePaths = Object.keys(zip.files).filter((path) =>
+    /^ppt\/slides\/slide\d+\.xml$/.test(path),
+  );
+  for (const path of slidePaths) {
+    const file = zip.file(path);
+    if (!file) continue;
+    const original = await file.async("text");
+    const relsPath = slideRelsPath(path);
+    const relsFile = zip.file(relsPath);
+    const relationshipEditor = createRelationshipEditor(
+      relsFile ? await relsFile.async("text") : undefined,
+    );
+    const replaced = applyGlimpseTextBoxesToXml(original, registry, (href) =>
+      relationshipEditor.addHyperlink(href),
+    );
+    if (replaced !== original) {
+      zip.file(path, replaced);
+    }
+    const relationships = relationshipEditor.result;
+    if (relationships.changed) {
+      zip.file(relsPath, relationships.xml);
+    }
+  }
+  return zip;
+}
+
+export function patchPptxWriteForGlimpseTextBoxes(
+  pptx: PptxGenJSInstance,
+  registry: GlimpseTextBoxRegistry,
+): void {
+  if (registry.isEmpty) return;
+
+  const originalWrite = pptx.write.bind(pptx);
+  const originalWriteFile = pptx.writeFile.bind(pptx);
+
+  const patchedWrite = async (rawProps?: WriteProps | string) => {
+    const props: WriteProps | undefined =
+      typeof rawProps === "string"
+        ? ({ outputType: rawProps } as WriteProps)
+        : rawProps;
+    const data = (await originalWrite({
+      outputType: "uint8array",
+    })) as Uint8Array;
+    const zip = await applyGlimpseTextBoxes(data, registry);
+
+    const outputType = props?.outputType;
+    if (outputType === "STREAM") {
+      return zip.generateAsync({
+        type: "nodebuffer",
+        compression: props?.compression ? "DEFLATE" : "STORE",
+      });
+    }
+    if (outputType) {
+      return zip.generateAsync({ type: outputType });
+    }
+    return zip.generateAsync({
+      type: "blob",
+      compression: props?.compression ? "DEFLATE" : "STORE",
+    });
+  };
+  pptx.write = patchedWrite;
+
+  const patchedWriteFile = async (rawProps?: WriteFileProps | string) => {
+    const props: WriteFileProps | undefined =
+      typeof rawProps === "string" ? { fileName: rawProps } : rawProps;
+    const isNode =
+      typeof process !== "undefined" && Boolean(process.versions?.node);
+    if (!isNode) {
+      return originalWriteFile(props);
+    }
+    const rawName = props?.fileName ?? "Presentation.pptx";
+    const fileName = rawName.toLowerCase().endsWith(".pptx")
+      ? rawName
+      : `${rawName}.pptx`;
+    const buffer = (await patchedWrite({
+      outputType: "nodebuffer",
+      compression: props?.compression,
+    })) as Buffer;
+    const fs = await import("fs");
+    await fs.promises.writeFile(fileName, buffer);
+    return fileName;
+  };
+  pptx.writeFile = patchedWriteFile;
+}

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -518,7 +518,7 @@ export function patchPptxWriteForGlimpseTextBoxes(
   pptx.write = patchedWrite;
 
   const patchedStream = async (props?: StreamProps) =>
-    patchedWrite({
+    pptx.write({
       outputType: "STREAM",
       compression: props?.compression,
     });

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -44,6 +44,9 @@ type WriteProps = NonNullable<Parameters<PptxGenJSInstance["write"]>[0]>;
 type WriteFileProps = NonNullable<
   Parameters<PptxGenJSInstance["writeFile"]>[0]
 >;
+type BrowserWritablePptx = PptxGenJSInstance & {
+  writeFileToBrowser?: (fileName: string, blobContent: Blob) => Promise<string>;
+};
 type TextPositionedNode = Extract<PositionedNode, { type: "text" }>;
 
 const MARKER_PREFIX = "pom-text:";
@@ -220,8 +223,8 @@ function buildParagraphs(node: TextPositionedNode): {
 
 function withGlowAlpha(xml: string, node: TextPositionedNode): string {
   const glow = node.glow;
-  if (!glow || glow.opacity === undefined) return xml;
-  const alpha = Math.round(glow.opacity * 100000);
+  if (!glow) return xml;
+  const alpha = Math.round((glow.opacity ?? 0.75) * 100000);
   const color = cleanHex(glow.color ?? "FFFFFF");
   const target = `<a:glow rad="${Math.round(pxToEmu(glow.size ?? 8))}"><a:srgbClr val="${color}"/></a:glow>`;
   const replacement = `<a:glow rad="${Math.round(pxToEmu(glow.size ?? 8))}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:glow>`;
@@ -473,7 +476,6 @@ export function patchPptxWriteForGlimpseTextBoxes(
   if (registry.isEmpty) return;
 
   const originalWrite = pptx.write.bind(pptx);
-  const originalWriteFile = pptx.writeFile.bind(pptx);
 
   const patchedWrite = async (rawProps?: WriteProps | string) => {
     const props: WriteProps | undefined =
@@ -493,7 +495,10 @@ export function patchPptxWriteForGlimpseTextBoxes(
       });
     }
     if (outputType) {
-      return zip.generateAsync({ type: outputType });
+      return zip.generateAsync({
+        type: outputType,
+        compression: props?.compression ? "DEFLATE" : "STORE",
+      });
     }
     return zip.generateAsync({
       type: "blob",
@@ -508,7 +513,22 @@ export function patchPptxWriteForGlimpseTextBoxes(
     const isNode =
       typeof process !== "undefined" && Boolean(process.versions?.node);
     if (!isNode) {
-      return originalWriteFile(props);
+      const browserWriter = pptx as BrowserWritablePptx;
+      if (typeof browserWriter.writeFileToBrowser !== "function") {
+        throw new Error(
+          "pptx.writeFile browser download helper is unavailable; use pptx.write({ outputType: 'blob' }) instead",
+        );
+      }
+      const rawName = props?.fileName ?? "Presentation.pptx";
+      const fileName = rawName.toLowerCase().endsWith(".pptx")
+        ? rawName
+        : `${rawName}.pptx`;
+      const blob = (await patchedWrite({
+        outputType: "blob",
+        compression: props?.compression,
+      })) as Blob;
+      await browserWriter.writeFileToBrowser(fileName, blob);
+      return fileName;
     }
     const rawName = props?.fileName ?? "Presentation.pptx";
     const fileName = rawName.toLowerCase().endsWith(".pptx")

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -40,6 +40,7 @@ import { EMU_PER_IN, pxToEmu, pxToPt } from "./units.ts";
 import { createTextOptions, resolveSubSup } from "./textOptions.ts";
 
 type PptxGenJSInstance = import("pptxgenjs").default;
+type StreamProps = NonNullable<Parameters<PptxGenJSInstance["stream"]>[0]>;
 type WriteProps = NonNullable<Parameters<PptxGenJSInstance["write"]>[0]>;
 type WriteFileProps = NonNullable<
   Parameters<PptxGenJSInstance["writeFile"]>[0]
@@ -155,7 +156,7 @@ function buildRunProperties(
     gradientFill,
     bold: run?.bold ?? node.bold,
     italic: run?.italic ?? node.italic,
-    underline: toUnderlineInput(run?.underline ?? node.underline),
+    underline: toUnderlineInput(resolveUnderline(node, run)),
     strike: run?.strike ?? node.strike,
     baseline: toBaselineInput(subSup.subscript, subSup.superscript),
     highlight: toColorInput(run?.highlight ?? node.highlight),
@@ -163,6 +164,15 @@ function buildRunProperties(
     outline: toOutlineInput(node.outline),
     charSpacing: toCharSpacing(letterSpacingPx),
   });
+}
+
+function resolveUnderline(
+  node: TextPositionedNode,
+  run: NonNullable<TextPositionedNode["runs"]>[number] | undefined,
+): Underline | undefined {
+  if (run?.underline !== undefined) return run.underline;
+  if (node.underline !== undefined) return node.underline;
+  return run?.href ? true : undefined;
 }
 
 function createParagraphProperties(
@@ -506,6 +516,13 @@ export function patchPptxWriteForGlimpseTextBoxes(
     });
   };
   pptx.write = patchedWrite;
+
+  const patchedStream = async (props?: StreamProps) =>
+    patchedWrite({
+      outputType: "STREAM",
+      compression: props?.compression,
+    });
+  pptx.stream = patchedStream;
 
   const patchedWriteFile = async (rawProps?: WriteFileProps | string) => {
     const props: WriteFileProps | undefined =

--- a/packages/pom/src/renderPptx/glowEffects.test.ts
+++ b/packages/pom/src/renderPptx/glowEffects.test.ts
@@ -177,6 +177,20 @@ describe("buildPptx with Shape glow", () => {
     expect(slideXml).toContain("<a:glow");
   });
 
+  it("Text glimpse writer と Shape glow を併用しても stream 経路で双方が出力される", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Text fontSize="24">Hello</Text>
+      <Shape shapeType="ellipse" w="100" h="100" fill.color="FF0000" glow.size="8" glow.color="00FF00"/>
+    </VStack></Slide>`;
+    const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+    const buffer = (await pptx.stream({ compression: true })) as Uint8Array;
+    const slideXml = await readSlideXml(buffer);
+
+    expect(slideXml).toContain("<a:t>Hello</a:t>");
+    expect(slideXml).toContain("<a:glow");
+    expect(slideXml).not.toContain("pom-text:");
+  });
+
   it("shadow と glow を併用した shape で effectLst が 1 つに統合される", async () => {
     // pptxgenjs は shadow 指定時に <a:spPr> 配下に <a:effectLst><a:outerShdw/></a:effectLst>
     // を出力する。glow を追加する際に新たな <a:effectLst> を別途並べると

--- a/packages/pom/src/renderPptx/glowEffects.test.ts
+++ b/packages/pom/src/renderPptx/glowEffects.test.ts
@@ -58,6 +58,17 @@ describe("buildPptx with Shape glow", () => {
     expect(slideXml).toContain('name="pom-glow:0"');
   });
 
+  it("Shape glow 単独でも stream 経路で effectLst として出力される", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Shape shapeType="ellipse" w="100" h="100" fill.color="FF0000" glow.size="8" glow.color="00FF00"/>
+    </VStack></Slide>`;
+    const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+    const buffer = (await pptx.stream({ compression: true })) as Uint8Array;
+    const slideXml = await readSlideXml(buffer);
+
+    expect(slideXml).toContain("<a:effectLst><a:glow");
+  });
+
   it("Shape の outline は line のエイリアスとして反映される", async () => {
     const xml = `<Slide><VStack w="100%" h="max">
       <Shape shapeType="rect" w="100" h="100" outline.size="3" outline.color="0088CC"/>

--- a/packages/pom/src/renderPptx/glowEffects.test.ts
+++ b/packages/pom/src/renderPptx/glowEffects.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { buildPptx } from "../buildPptx.ts";
 import { GlowEffectRegistry } from "./glowEffects.ts";
 
-async function readSlideXml(buffer: Uint8Array): Promise<string> {
+async function readSlideXml(buffer: Uint8Array | ArrayBuffer): Promise<string> {
   const zip = await JSZip.loadAsync(buffer);
   return zip.file("ppt/slides/slide1.xml")!.async("text");
 }
@@ -65,6 +65,17 @@ describe("buildPptx with Shape glow", () => {
     const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
     const buffer = (await pptx.stream({ compression: true })) as Uint8Array;
     const slideXml = await readSlideXml(buffer);
+
+    expect(slideXml).toContain("<a:effectLst><a:glow");
+  });
+
+  it("Shape glow 単独でも default write 経路で effectLst として出力される", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Shape shapeType="ellipse" w="100" h="100" fill.color="FF0000" glow.size="8" glow.color="00FF00"/>
+    </VStack></Slide>`;
+    const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+    const blob = (await pptx.write()) as Blob;
+    const slideXml = await readSlideXml(await blob.arrayBuffer());
 
     expect(slideXml).toContain("<a:effectLst><a:glow");
   });

--- a/packages/pom/src/renderPptx/glowEffects.ts
+++ b/packages/pom/src/renderPptx/glowEffects.ts
@@ -17,6 +17,7 @@ import type { TextGlow } from "../types.ts";
 import { pxToEmu } from "./units.ts";
 
 type PptxGenJSInstance = import("pptxgenjs").default;
+type StreamProps = NonNullable<Parameters<PptxGenJSInstance["stream"]>[0]>;
 type WriteProps = NonNullable<Parameters<PptxGenJSInstance["write"]>[0]>;
 type WriteFileProps = NonNullable<
   Parameters<PptxGenJSInstance["writeFile"]>[0]
@@ -199,6 +200,13 @@ export function patchPptxWriteForGlowEffects(
     });
   };
   pptx.write = patchedWrite;
+
+  const patchedStream = async (props?: StreamProps) =>
+    pptx.write({
+      outputType: "STREAM",
+      compression: props?.compression,
+    });
+  pptx.stream = patchedStream;
 
   const patchedWriteFile = async (rawProps?: WriteFileProps | string) => {
     const props: WriteFileProps | undefined =

--- a/packages/pom/src/renderPptx/gradientFills.test.ts
+++ b/packages/pom/src/renderPptx/gradientFills.test.ts
@@ -8,7 +8,7 @@ import { ParseXmlError } from "../parseXml/parseXml.ts";
 import type { Gradient } from "../shared/gradient.ts";
 import { GradientFillRegistry } from "./gradientFills.ts";
 
-async function readSlideXml(buffer: Uint8Array): Promise<string> {
+async function readSlideXml(buffer: Uint8Array | ArrayBuffer): Promise<string> {
   const zip = await JSZip.loadAsync(buffer);
   return zip.file("ppt/slides/slide1.xml")!.async("text");
 }
@@ -72,6 +72,18 @@ describe("buildPptx with backgroundGradient", () => {
     const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
     const buffer = (await pptx.stream({ compression: true })) as Uint8Array;
     const slideXml = await readSlideXml(buffer);
+
+    expect(slideXml).toContain("<a:gradFill");
+    expect(slideXml).not.toContain('<a:solidFill><a:srgbClr val="0F7A3D"/>');
+  });
+
+  it("backgroundGradient 単独でも default write 経路で gradFill として出力される", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Shape shapeType="rect" w="200" h="100" backgroundGradient="linear-gradient(45deg, #FF0000 0%, #0000FF 100%)"/>
+    </VStack></Slide>`;
+    const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+    const blob = (await pptx.write()) as Blob;
+    const slideXml = await readSlideXml(await blob.arrayBuffer());
 
     expect(slideXml).toContain("<a:gradFill");
     expect(slideXml).not.toContain('<a:solidFill><a:srgbClr val="0F7A3D"/>');

--- a/packages/pom/src/renderPptx/gradientFills.test.ts
+++ b/packages/pom/src/renderPptx/gradientFills.test.ts
@@ -322,11 +322,12 @@ describe("buildPptx with textGradient", () => {
     // text run 内に gradFill が描画される (a:rPr 配下)
     expect(slideXml).toMatch(/<a:rPr[^>]*><a:gradFill/);
     expect(slideXml).toContain(
-      '<a:gradFill flip="none" rotWithShape="1"><a:gsLst>' +
+      "<a:gradFill><a:gsLst>" +
         '<a:gs pos="0"><a:srgbClr val="38BDF8"/></a:gs>' +
         '<a:gs pos="100000"><a:srgbClr val="A78BFA"/></a:gs>' +
-        '</a:gsLst><a:lin ang="0" scaled="0"/></a:gradFill>',
+        '</a:gsLst><a:lin ang="0" scaled="1"/></a:gradFill>',
     );
+    expect(slideXml).not.toContain("pom-text:");
   });
 
   it("textGradient 指定時は node の color よりも gradient が優先される", async () => {

--- a/packages/pom/src/renderPptx/gradientFills.test.ts
+++ b/packages/pom/src/renderPptx/gradientFills.test.ts
@@ -65,6 +65,18 @@ describe("buildPptx with backgroundGradient", () => {
     );
   });
 
+  it("backgroundGradient 単独でも stream 経路で gradFill として出力される", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Shape shapeType="rect" w="200" h="100" backgroundGradient="linear-gradient(45deg, #FF0000 0%, #0000FF 100%)"/>
+    </VStack></Slide>`;
+    const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+    const buffer = (await pptx.stream({ compression: true })) as Uint8Array;
+    const slideXml = await readSlideXml(buffer);
+
+    expect(slideXml).toContain("<a:gradFill");
+    expect(slideXml).not.toContain('<a:solidFill><a:srgbClr val="0F7A3D"/>');
+  });
+
   it("ルートノードの backgroundGradient はスライド背景 (p:bgPr) に適用される", async () => {
     const xml = `<Slide><VStack w="100%" h="max" backgroundGradient="linear-gradient(to right, #11998E, #38EF7D)">
       <Text fontSize="24">test</Text>

--- a/packages/pom/src/renderPptx/gradientFills.ts
+++ b/packages/pom/src/renderPptx/gradientFills.ts
@@ -10,12 +10,14 @@
  *    `<a:solidFill><a:srgbClr val="マーカー色"/></a:solidFill>` を
  *    DrawingML ネイティブの `<a:gradFill>` に置換する
  *
+ * Text の textGradient は glimpseTextBoxes.ts の TextBox native XML 生成へ移行済み。
+ *
  * 置換は pptxgenjs が生成する固定パターンに対する完全一致の文字列置換で行う。
  * スライド XML 全体をパーサーで往復させると無関係な要素の表現が変わり得るため、
  * 意図的に文字列置換を採用している。
  */
 import type { Gradient } from "../shared/gradient.ts";
-import { parseGradient, parseLinearGradient } from "../shared/gradient.ts";
+import { parseGradient } from "../shared/gradient.ts";
 
 type PptxGenJSInstance = import("pptxgenjs").default;
 type WriteProps = NonNullable<Parameters<PptxGenJSInstance["write"]>[0]>;
@@ -99,25 +101,6 @@ export function registerBackgroundGradient(
   const gradient = parseGradient(value);
   if (!gradient) return undefined;
   return registry.register(gradient, opacity);
-}
-
-/**
- * textGradient 属性値をパースしてレジストリに登録し、マーカー色を返す。
- * 戻り値のマーカー色を text run の color に渡すと、pptxgenjs が出力する
- * `<a:rPr><a:solidFill><a:srgbClr val="マーカー色"/></a:solidFill></a:rPr>` が
- * 後処理で gradFill に置換され、PowerPoint 上ネイティブの文字グラデーションとして
- * 表示・編集可能になる。
- *
- * textGradient は radial-gradient を受け付けない (linear-gradient のみ)。
- * パースできない場合 (スキーマ検証済みのため通常発生しない) は undefined を返す。
- */
-export function registerTextGradient(
-  value: string,
-  registry: GradientFillRegistry,
-): string | undefined {
-  const linear = parseLinearGradient(value);
-  if (!linear) return undefined;
-  return registry.register({ kind: "linear", value: linear });
 }
 
 /**

--- a/packages/pom/src/renderPptx/gradientFills.ts
+++ b/packages/pom/src/renderPptx/gradientFills.ts
@@ -20,6 +20,7 @@ import type { Gradient } from "../shared/gradient.ts";
 import { parseGradient } from "../shared/gradient.ts";
 
 type PptxGenJSInstance = import("pptxgenjs").default;
+type StreamProps = NonNullable<Parameters<PptxGenJSInstance["stream"]>[0]>;
 type WriteProps = NonNullable<Parameters<PptxGenJSInstance["write"]>[0]>;
 type WriteFileProps = NonNullable<
   Parameters<PptxGenJSInstance["writeFile"]>[0]
@@ -219,6 +220,13 @@ export function patchPptxWriteForGradientFills(
     });
   };
   pptx.write = patchedWrite;
+
+  const patchedStream = async (props?: StreamProps) =>
+    pptx.write({
+      outputType: "STREAM",
+      compression: props?.compression,
+    });
+  pptx.stream = patchedStream;
 
   const patchedWriteFile = async (rawProps?: WriteFileProps | string) => {
     // DEPRECATED: pptxgenjs は writeFile(fileName) の文字列 overload を

--- a/packages/pom/src/renderPptx/nodes/text.ts
+++ b/packages/pom/src/renderPptx/nodes/text.ts
@@ -1,15 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import {
-  createTextOptions,
-  convertUnderline,
-  convertStrike,
-  convertGlow,
-  convertOutline,
-  resolveSubSup,
-} from "../textOptions.ts";
-import { registerTextGradient } from "../gradientFills.ts";
-import { pxToPt } from "../units.ts";
+import { createTextOptions } from "../textOptions.ts";
 
 type TextPositionedNode = Extract<PositionedNode, { type: "text" }>;
 
@@ -18,58 +9,15 @@ export function renderTextNode(
   ctx: RenderContext,
 ): void {
   const textOptions = createTextOptions(node);
+  const marker = ctx.buildContext.glimpseTextBoxes.register(node);
 
-  // textGradient はマーカー色で text run color に適用し、
-  // 出力時の後処理で gradFill に置換される (gradientFills.ts 参照)。
-  // node 単位の指定として全 run の color を上書きする (run 単位指定はスコープ外)。
-  const textGradientMarker = node.textGradient
-    ? registerTextGradient(node.textGradient, ctx.buildContext.gradientFills)
-    : undefined;
-
-  if (node.runs && node.runs.length > 0) {
-    const fontSizePx = node.fontSize ?? 24;
-    const fontFamily = node.fontFamily ?? "Noto Sans JP";
-    const textItems = node.runs.map((run) => {
-      const letterSpacingPx = run.letterSpacing ?? node.letterSpacing;
-      const runFontSizePx = run.fontSize ?? fontSizePx;
-      const subSup = resolveSubSup(run, node);
-      return {
-        text: run.text,
-        options: {
-          fontSize: pxToPt(runFontSizePx),
-          fontFace: run.fontFamily ?? fontFamily,
-          color: textGradientMarker ?? run.color ?? node.color,
-          bold: run.bold ?? node.bold,
-          italic: run.italic ?? node.italic,
-          underline: convertUnderline(run.underline ?? node.underline),
-          strike: convertStrike(run.strike ?? node.strike),
-          subscript: subSup.subscript,
-          superscript: subSup.superscript,
-          highlight: run.highlight ?? node.highlight,
-          // glow / outline はノード単位指定のみ (run 単位はスコープ外)
-          glow: convertGlow(node.glow),
-          outline: convertOutline(node.outline),
-          charSpacing:
-            letterSpacingPx !== undefined ? pxToPt(letterSpacingPx) : undefined,
-          ...(run.href ? { hyperlink: { url: run.href } } : {}),
-        },
-      };
-    });
-    ctx.slide.addText(textItems, {
-      x: textOptions.x,
-      y: textOptions.y,
-      w: textOptions.w,
-      h: textOptions.h,
-      rotate: textOptions.rotate,
-      align: textOptions.align,
-      valign: textOptions.valign,
-      margin: textOptions.margin,
-      lineSpacing: textOptions.lineSpacing,
-    });
-  } else {
-    ctx.slide.addText(node.text ?? "", {
-      ...textOptions,
-      color: textGradientMarker ?? textOptions.color,
-    });
-  }
+  ctx.slide.addShape(ctx.pptx.ShapeType.rect, {
+    x: textOptions.x,
+    y: textOptions.y,
+    w: textOptions.w,
+    h: textOptions.h,
+    fill: { color: "FFFFFF", transparency: 100 },
+    line: { color: "FFFFFF", transparency: 100 },
+    objectName: marker,
+  });
 }

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -7,7 +7,7 @@
  * ことを保証する。
  */
 import JSZip from "jszip";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderPptx } from "./renderPptx.ts";
 import { createBuildContext } from "../buildContext.ts";
 import { patchPptxWriteForGlimpseTextBoxes } from "./glimpseTextBoxes.ts";
@@ -194,6 +194,105 @@ describe("renderTextNode", () => {
 
     expect(slideXml).toContain("<a:t>streamed</a:t>");
     expect(slideXml).not.toContain("pom-text:");
+  });
+
+  it("pptx.write の default output でも glimpse text box XML に置換する", async () => {
+    const buildContext = createBuildContext();
+    const pptx = await renderPptx(
+      [
+        vstackPage([
+          {
+            type: "text",
+            text: "blob output",
+            x: 0,
+            y: 0,
+            w: 160,
+            h: 40,
+          },
+        ]),
+      ],
+      { w: 1280, h: 720 },
+      buildContext,
+    );
+    patchPptxWriteForGlimpseTextBoxes(pptx, buildContext.glimpseTextBoxes);
+
+    const blob = (await pptx.write()) as Blob;
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+
+    expect(slideXml).toContain("<a:t>blob output</a:t>");
+    expect(slideXml).not.toContain("pom-text:");
+  });
+
+  it("browser writeFile helper が無い場合は marker を残さず利用案内エラーにする", async () => {
+    const buildContext = createBuildContext();
+    buildContext.glimpseTextBoxes.register({
+      type: "text",
+      text: "browser",
+      x: 0,
+      y: 0,
+      w: 160,
+      h: 40,
+    });
+    const originalWrite = vi.fn();
+    const pptx = {
+      write: originalWrite,
+      writeFile: vi.fn(),
+    } as unknown as Parameters<typeof patchPptxWriteForGlimpseTextBoxes>[0];
+
+    vi.stubGlobal("process", { platform: "browser", versions: {} });
+    try {
+      patchPptxWriteForGlimpseTextBoxes(pptx, buildContext.glimpseTextBoxes);
+
+      await expect(pptx.writeFile({ fileName: "browser" })).rejects.toThrow(
+        "pptx.writeFile browser download helper is unavailable",
+      );
+      expect(originalWrite).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("browser writeFile helper がある場合は置換済み blob を渡す", async () => {
+    const buildContext = createBuildContext();
+    buildContext.glimpseTextBoxes.register({
+      type: "text",
+      text: "browser",
+      x: 0,
+      y: 0,
+      w: 160,
+      h: 40,
+    });
+    const inputZip = new JSZip();
+    inputZip.file("ppt/slides/slide1.xml", "<p:sld/>");
+    const originalWrite = vi
+      .fn()
+      .mockResolvedValue(await inputZip.generateAsync({ type: "uint8array" }));
+    const writeFileToBrowser = vi.fn().mockResolvedValue("browser.pptx");
+    const pptx = {
+      write: originalWrite,
+      writeFile: vi.fn(),
+      writeFileToBrowser,
+    } as unknown as Parameters<typeof patchPptxWriteForGlimpseTextBoxes>[0];
+
+    vi.stubGlobal("process", { platform: "browser", versions: {} });
+    try {
+      patchPptxWriteForGlimpseTextBoxes(pptx, buildContext.glimpseTextBoxes);
+
+      const writeFileWithRuntimeOverload = (fileName: string) =>
+        (pptx.writeFile as unknown as (fileName: string) => Promise<string>)(
+          fileName,
+        );
+      await expect(writeFileWithRuntimeOverload("browser")).resolves.toBe(
+        "browser.pptx",
+      );
+      expect(writeFileToBrowser).toHaveBeenCalledWith(
+        "browser.pptx",
+        expect.any(Blob),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -6,9 +6,11 @@
  * renderer 内部のリファクタリングで public な出力挙動が変わっていない
  * ことを保証する。
  */
+import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
 import { renderPptx } from "./renderPptx.ts";
 import { createBuildContext } from "../buildContext.ts";
+import { patchPptxWriteForGlimpseTextBoxes } from "./glimpseTextBoxes.ts";
 import { pxToIn, pxToPt } from "./units.ts";
 import type { PositionedNode } from "../types.ts";
 
@@ -26,6 +28,21 @@ async function renderPage(page: PositionedNode) {
     pptx as unknown as { _slides: { _slideObjects: SlideObject[] }[] }
   )._slides;
   return { objects: slides[0]._slideObjects, buildContext };
+}
+
+async function renderPageSlideXml(page: PositionedNode) {
+  const zip = await renderPagePptxZip(page);
+  return zip.file("ppt/slides/slide1.xml")!.async("text");
+}
+
+async function renderPagePptxZip(page: PositionedNode) {
+  const buildContext = createBuildContext();
+  const pptx = await renderPptx([page], { w: 1280, h: 720 }, buildContext);
+  patchPptxWriteForGlimpseTextBoxes(pptx, buildContext.glimpseTextBoxes);
+  const buffer = (await pptx.write({
+    outputType: "uint8array",
+  })) as Uint8Array;
+  return JSZip.loadAsync(buffer);
 }
 
 function vstackPage(children: PositionedNode[]): PositionedNode {
@@ -80,8 +97,8 @@ describe("renderShapeNode", () => {
 });
 
 describe("renderTextNode", () => {
-  it("rotate を通常テキストの pptxgenjs options に渡す", async () => {
-    const { objects } = await renderPage(
+  it("rotate を通常テキストの glimpse text box XML に渡す", async () => {
+    const slideXml = await renderPageSlideXml(
       vstackPage([
         {
           type: "text",
@@ -95,11 +112,13 @@ describe("renderTextNode", () => {
       ]),
     );
 
-    expect(objects[0].options.rotate).toBe(15);
+    expect(slideXml).toContain('<a:xfrm rot="900000">');
+    expect(slideXml).toContain("<a:t>rotated</a:t>");
+    expect(slideXml).not.toContain("pom-text:");
   });
 
-  it("rotate を inline runs テキストの pptxgenjs options に渡す", async () => {
-    const { objects } = await renderPage(
+  it("rotate を inline runs テキストの glimpse text box XML に渡す", async () => {
+    const slideXml = await renderPageSlideXml(
       vstackPage([
         {
           type: "text",
@@ -114,7 +133,39 @@ describe("renderTextNode", () => {
       ]),
     );
 
-    expect(objects[0].options.rotate).toBe(-15);
+    expect(slideXml).toContain('<a:xfrm rot="-900000">');
+    expect(slideXml).toContain("<a:t>rotated</a:t>");
+    expect(slideXml).not.toContain("pom-text:");
+  });
+
+  it("inline run の hyperlink を slide XML と relationships に出力する", async () => {
+    const zip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "text",
+          text: "Visit site",
+          runs: [
+            { text: "Visit " },
+            { text: "site", href: "https://example.com?a=1&b=2" },
+          ],
+          x: 0,
+          y: 0,
+          w: 240,
+          h: 40,
+        },
+      ]),
+    );
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+    const relsXml = await zip
+      .file("ppt/slides/_rels/slide1.xml.rels")!
+      .async("text");
+
+    expect(slideXml).toMatch(/<a:hlinkClick r:id="rId\d+"\/>/);
+    expect(relsXml).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"',
+    );
+    expect(relsXml).toContain('Target="https://example.com?a=1&amp;b=2"');
+    expect(relsXml).toContain('TargetMode="External"');
   });
 });
 

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -167,6 +167,34 @@ describe("renderTextNode", () => {
     expect(relsXml).toContain('Target="https://example.com?a=1&amp;b=2"');
     expect(relsXml).toContain('TargetMode="External"');
   });
+
+  it("pptx.stream でも glimpse text box XML に置換する", async () => {
+    const buildContext = createBuildContext();
+    const pptx = await renderPptx(
+      [
+        vstackPage([
+          {
+            type: "text",
+            text: "streamed",
+            x: 0,
+            y: 0,
+            w: 160,
+            h: 40,
+          },
+        ]),
+      ],
+      { w: 1280, h: 720 },
+      buildContext,
+    );
+    patchPptxWriteForGlimpseTextBoxes(pptx, buildContext.glimpseTextBoxes);
+
+    const buffer = (await pptx.stream({ compression: true })) as Uint8Array;
+    const zip = await JSZip.loadAsync(buffer);
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+
+    expect(slideXml).toContain("<a:t>streamed</a:t>");
+    expect(slideXml).not.toContain("pom-text:");
+  });
 });
 
 describe("renderImageNode", () => {

--- a/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
@@ -210,6 +210,36 @@ describe("renderTextNode (runs 分岐)", () => {
     expect(xml.match(/<a:srgbClr val="0088CC"\/>/g)).toHaveLength(2);
   });
 
+  it("href を持つ run は underline 未指定時に旧 addText と同じ既定 underline を出力する", () => {
+    const addShape = vi.fn();
+    const registry = new GlimpseTextBoxRegistry();
+    const ctx = {
+      slide: { addShape },
+      pptx: { ShapeType: { rect: "rect" } },
+      buildContext: { glimpseTextBoxes: registry },
+    } as unknown as RenderContext;
+
+    renderTextNode(
+      {
+        type: "text",
+        text: "Link",
+        runs: [
+          { text: "Link", href: "https://example.com" },
+          { text: "Plain" },
+        ],
+        x: 0,
+        y: 0,
+        w: 100,
+        h: 50,
+      },
+      ctx,
+    );
+
+    const xml = registry.entries[0].xml;
+    expect(xml).toContain('<a:rPr u="sng"');
+    expect(xml.match(/<a:rPr/g)).toHaveLength(2);
+  });
+
   it("Text glow の opacity 未指定時は既定値 0.75 を XML に反映する", () => {
     const addShape = vi.fn();
     const registry = new GlimpseTextBoxRegistry();

--- a/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
@@ -209,6 +209,32 @@ describe("renderTextNode (runs 分岐)", () => {
     expect(xml.match(/<a:ln w="19050">/g)).toHaveLength(2);
     expect(xml.match(/<a:srgbClr val="0088CC"\/>/g)).toHaveLength(2);
   });
+
+  it("Text glow の opacity 未指定時は既定値 0.75 を XML に反映する", () => {
+    const addShape = vi.fn();
+    const registry = new GlimpseTextBoxRegistry();
+    const ctx = {
+      slide: { addShape },
+      pptx: { ShapeType: { rect: "rect" } },
+      buildContext: { glimpseTextBoxes: registry },
+    } as unknown as RenderContext;
+
+    renderTextNode(
+      {
+        type: "text",
+        text: "Glow",
+        x: 0,
+        y: 0,
+        w: 100,
+        h: 50,
+        glow: { size: 8, color: "FF3399" },
+      },
+      ctx,
+    );
+
+    const xml = registry.entries[0].xml;
+    expect(xml).toContain('<a:alpha val="75000"/>');
+  });
 });
 
 describe("convertGlow", () => {

--- a/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
@@ -6,6 +6,7 @@ import {
   convertOutline,
 } from "./textOptions.ts";
 import { renderTextNode } from "./nodes/text.ts";
+import { GlimpseTextBoxRegistry } from "./glimpseTextBoxes.ts";
 import type { RenderContext } from "./types.ts";
 import { pxToIn, pxToPt } from "./units.ts";
 
@@ -146,9 +147,13 @@ describe("calcGlyphCenteringShiftPx", () => {
 
 describe("renderTextNode (runs 分岐)", () => {
   it("run に fontSize 指定があれば run 単位で適用され、未指定なら親 Text の fontSize を継承する", () => {
-    const addText =
-      vi.fn<(items: { options: { fontSize?: number } }[]) => void>();
-    const ctx = { slide: { addText } } as unknown as RenderContext;
+    const addShape = vi.fn();
+    const registry = new GlimpseTextBoxRegistry();
+    const ctx = {
+      slide: { addShape },
+      pptx: { ShapeType: { rect: "rect" } },
+      buildContext: { glimpseTextBoxes: registry },
+    } as unknown as RenderContext;
 
     renderTextNode(
       {
@@ -164,19 +169,23 @@ describe("renderTextNode (runs 分岐)", () => {
       ctx,
     );
 
-    expect(addText).toHaveBeenCalledTimes(1);
-    const textItems = addText.mock.calls[0][0];
-    expect(textItems).toHaveLength(2);
-    expect(textItems[0].options.fontSize).toBe(pxToPt(52));
-    expect(textItems[1].options.fontSize).toBe(pxToPt(18));
+    expect(addShape).toHaveBeenCalledTimes(1);
+    expect(addShape.mock.calls[0][1]).toMatchObject({
+      objectName: "pom-text:0",
+    });
+    const xml = registry.entries[0].xml;
+    expect(xml).toContain('<a:rPr sz="3900">');
+    expect(xml).toContain('<a:rPr sz="1350">');
   });
 
   it("runs ありの Text でノード単位の glow / outline が各 run に適用される", () => {
-    const addText =
-      vi.fn<
-        (items: { options: { glow?: unknown; outline?: unknown } }[]) => void
-      >();
-    const ctx = { slide: { addText } } as unknown as RenderContext;
+    const addShape = vi.fn();
+    const registry = new GlimpseTextBoxRegistry();
+    const ctx = {
+      slide: { addShape },
+      pptx: { ShapeType: { rect: "rect" } },
+      buildContext: { glimpseTextBoxes: registry },
+    } as unknown as RenderContext;
 
     renderTextNode(
       {
@@ -193,20 +202,12 @@ describe("renderTextNode (runs 分岐)", () => {
       ctx,
     );
 
-    expect(addText).toHaveBeenCalledTimes(1);
-    const textItems = addText.mock.calls[0][0];
-    expect(textItems).toHaveLength(2);
-    for (const item of textItems) {
-      expect(item.options.glow).toEqual({
-        size: pxToPt(8),
-        opacity: 0.5,
-        color: "FF3399",
-      });
-      expect(item.options.outline).toEqual({
-        size: pxToPt(2),
-        color: "0088CC",
-      });
-    }
+    expect(addShape).toHaveBeenCalledTimes(1);
+    const xml = registry.entries[0].xml;
+    expect(xml.match(/<a:glow rad="76200">/g)).toHaveLength(2);
+    expect(xml.match(/<a:alpha val="50000"\/>/g)).toHaveLength(2);
+    expect(xml.match(/<a:ln w="19050">/g)).toHaveLength(2);
+    expect(xml.match(/<a:srgbClr val="0088CC"\/>/g)).toHaveLength(2);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
   packages/pom:
     dependencies:
       '@pptx-glimpse/document':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.5.0
+        version: 0.5.0
       '@resvg/resvg-wasm':
         specifier: ^2.6.2
         version: 2.6.2
@@ -2074,6 +2074,10 @@ packages:
 
   '@pptx-glimpse/document@0.2.0':
     resolution: {integrity: sha512-1cbw9h76rHXJ76Qv1TOdYf8xZobUJbBEacViNfy2AONNuq9D1d4walMZu4rq7Wgvx3KTc0wCO+ph49npaMG7iw==}
+    engines: {node: '>=22'}
+
+  '@pptx-glimpse/document@0.5.0':
+    resolution: {integrity: sha512-lTGK2L00XlE+BZR50A7Z0Fyi+dMCNOdSFj0u9wAXGb4LumbFeEdDpMmWdI4sVyItjJ0vG8HcwezFfD1yqPdcfg==}
     engines: {node: '>=22'}
 
   '@quansync/fs@1.0.0':
@@ -9543,6 +9547,11 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@pptx-glimpse/document@0.2.0':
+    dependencies:
+      fast-xml-parser: 5.9.3
+      fflate: 0.8.3
+
+  '@pptx-glimpse/document@0.5.0':
     dependencies:
       fast-xml-parser: 5.9.3
       fflate: 0.8.3


### PR DESCRIPTION
close #933

## 概要
- Text primitive の描画を pptxgenjs addText から @pptx-glimpse/document の TextBox writer 生成へ移行
- pptxgenjs 出力 zip をベースに marker shape を glimpse XML で置換する混在方式を追加
- textGradient を marker 後処理から native gradFill 生成へ移行し、Text 系 XML 構造テストを更新
- write / writeFile / stream の後処理チェーンを整え、gradient / glow / glimpse text の stream 経路も検証

## 検証
- pnpm --filter @hirokisakabe/pom run build
- pnpm --filter @hirokisakabe/pom run lint
- pnpm --filter @hirokisakabe/pom run typecheck
- pnpm --filter @hirokisakabe/pom run lint:deps
- pnpm --filter @hirokisakabe/pom run test:run
- pnpm --filter @hirokisakabe/pom run vrt:docker（55 pages checked, No visual differences）
- pnpm --filter @hirokisakabe/pom run knip（既存 unused exports/types のレポートあり、exit 0）
- unzip -t packages/pom/vrt/output/actual.pptx
- VRT 出力 PPTX に pom-text marker が残っていないことを確認
- Microsoft PowerPoint で packages/pom/vrt/output/actual.pptx を修復なしで open 確認

## レビュー
- cross-review の指摘に対応済み
  - browser writeFile fallback
  - glow opacity default
  - write output compression
  - stream 経路の後処理チェーン
  - hyperlink underline 既定挙動
