### PR TITLE
shape primitive を glimpse shape writer 経由に swap

### DIFF
--- a/.changeset/shape-glimpse-writer.md
+++ b/.changeset/shape-glimpse-writer.md
@@ -1,5 +1,5 @@
 ---
-"@hirokisakabe/pom": minor
+"@hirokisakabe/pom": patch
 ---
 
-Shape / Line / Arrow primitive generation now uses @pptx-glimpse/document shape writer XML replacement.
+Improve Shape, Line, and Arrow PPTX XML generation by using the @pptx-glimpse/document shape writer.

--- a/.changeset/shape-glimpse-writer.md
+++ b/.changeset/shape-glimpse-writer.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": minor
+---
+
+Shape / Line / Arrow primitive generation now uses @pptx-glimpse/document shape writer XML replacement.

--- a/packages/pom/package.json
+++ b/packages/pom/package.json
@@ -89,7 +89,7 @@
     "tsx": "4.23.0"
   },
   "dependencies": {
-    "@pptx-glimpse/document": "0.5.0",
+    "@pptx-glimpse/document": "0.6.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "fast-xml-parser": "^5.9.3",
     "image-size": "2.0.2",

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -334,15 +334,13 @@ function withRoundRectAdjust(
 
 function shadowXml(shadow: ShadowStyle | undefined): string | undefined {
   if (!shadow) return undefined;
-  const blur = Math.round(pxToPt(shadow.blur ?? 0) * 12700);
-  const dist = Math.round(pxToPt(shadow.offset ?? 0) * 12700);
-  const dir = Math.round((shadow.angle ?? 45) * 60000);
+  const blur = Math.round((shadow.blur ?? 3) * 12700);
+  const dist = Math.round((shadow.offset ?? 23000 / 12700) * 12700);
+  const dir = Math.round((shadow.angle ?? 90) * 60000);
   const color = cleanHex(shadow.color ?? "000000") ?? "000000";
   const alpha = Math.round((shadow.opacity ?? 0.35) * 100000);
-  if (shadow.type === "inner") {
-    return `<a:innerShdw blurRad="${blur}" dist="${dist}" dir="${dir}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:innerShdw>`;
-  }
-  return `<a:outerShdw sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0" blurRad="${blur}" dist="${dist}" dir="${dir}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:outerShdw>`;
+  const type = shadow.type ?? "outer";
+  return `<a:${type}Shdw sx="100000" sy="100000" kx="0" ky="0" algn="bl" blurRad="${blur}" rotWithShape="1" dist="${dist}" dir="${dir}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:${type}Shdw>`;
 }
 
 function withShadow(xml: string, shadow: ShadowStyle | undefined): string {
@@ -378,7 +376,8 @@ function withLineZeroExtent(
   if (preset !== "line" || (!zeroWidth && !zeroHeight)) return xml;
   return xml.replace(
     /<a:ext cx="(\d+)" cy="(\d+)"\/>/,
-    `<a:ext cx="${zeroWidth ? "0" : "$1"}" cy="${zeroHeight ? "0" : "$2"}"/>`,
+    (_match, cx: string, cy: string) =>
+      `<a:ext cx="${zeroWidth ? "0" : cx}" cy="${zeroHeight ? "0" : cy}"/>`,
   );
 }
 
@@ -575,7 +574,7 @@ function escapeRegExp(value: string): string {
 function replaceShapeId(xml: string, id: string, name: string): string {
   return xml.replace(
     /<p:cNvPr id="[^"]+" name="[^"]*"/,
-    `<p:cNvPr id="${id}" name="${name}"`,
+    `<p:cNvPr id="${xmlAttr(id)}" name="${xmlAttr(name)}"`,
   );
 }
 

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -16,6 +16,7 @@
  * を経由しない。
  */
 import {
+  addShape,
   addTextBox,
   asEmu,
   asHundredthPt,
@@ -24,18 +25,21 @@ import {
   asPt,
   createPptx,
   type AddTextBoxGradientFillInput,
+  type AddShapeInput,
   type AddTextBoxInput,
   type AddTextBoxParagraphInput,
   type AddTextBoxRunPropertiesInput,
+  type PptxSourceModelAddShapeEdit,
   type PptxSourceModelAddTextBoxEdit,
 } from "@pptx-glimpse/document";
 import type {
   PositionedNode,
+  ShadowStyle,
   TextGlow,
   TextOutline,
   Underline,
 } from "../types.ts";
-import { parseLinearGradient } from "../shared/gradient.ts";
+import { parseGradient, parseLinearGradient } from "../shared/gradient.ts";
 import { EMU_PER_IN, pxToEmu, pxToPt } from "./units.ts";
 import { createTextOptions, resolveSubSup } from "./textOptions.ts";
 
@@ -51,6 +55,7 @@ type BrowserWritablePptx = PptxGenJSInstance & {
 type TextPositionedNode = Extract<PositionedNode, { type: "text" }>;
 
 const MARKER_PREFIX = "pom-text:";
+const SHAPE_MARKER_PREFIX = "pom-shape:";
 const HYPERLINK_REL_TYPE =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
 
@@ -67,11 +72,11 @@ async function loadJSZip(): Promise<typeof import("jszip")> {
   /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
 }
 
-function cleanHex(color: string | undefined): string | undefined {
+export function cleanHex(color: string | undefined): string | undefined {
   return color?.replace(/^#/, "").toUpperCase();
 }
 
-function toColorInput(color: string | undefined) {
+export function toColorInput(color: string | undefined) {
   const hex = cleanHex(color);
   return hex ? { kind: "srgb" as const, hex } : undefined;
 }
@@ -241,6 +246,161 @@ function withGlowAlpha(xml: string, node: TextPositionedNode): string {
   return xml.replaceAll(target, replacement);
 }
 
+function withShapeGlowAlpha(xml: string, glow: TextGlow | undefined): string {
+  if (!glow) return xml;
+  const alpha = Math.round((glow.opacity ?? 0.75) * 100000);
+  const color = cleanHex(glow.color ?? "FFFFFF");
+  const target = `<a:glow rad="${Math.round(pxToEmu(glow.size ?? 8))}"><a:srgbClr val="${color}"/></a:glow>`;
+  const replacement = `<a:glow rad="${Math.round(pxToEmu(glow.size ?? 8))}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:glow>`;
+  return xml.replaceAll(target, replacement);
+}
+
+function colorWithOptionalAlphaXml(
+  color: string,
+  opacity: number | undefined,
+): string {
+  const clean = cleanHex(color) ?? color;
+  if (opacity === undefined) return `<a:srgbClr val="${clean}"/>`;
+  return `<a:srgbClr val="${clean}"><a:alpha val="${Math.round(opacity * 100000)}"/></a:srgbClr>`;
+}
+
+function buildGradFillXml(value: string, opacity?: number): string | undefined {
+  const gradient = parseGradient(value);
+  if (!gradient) return undefined;
+  const gsXml = gradient.value.stops
+    .map(
+      (stop) =>
+        `<a:gs pos="${Math.round(stop.position * 1000)}">${colorWithOptionalAlphaXml(
+          stop.color,
+          opacity,
+        )}</a:gs>`,
+    )
+    .join("");
+
+  if (gradient.kind === "linear") {
+    const dmlAngle = (((gradient.value.angle - 90) % 360) + 360) % 360;
+    const ang = Math.round(dmlAngle * 60000);
+    return `<a:gradFill flip="none" rotWithShape="1"><a:gsLst>${gsXml}</a:gsLst><a:lin ang="${ang}" scaled="0"/></a:gradFill>`;
+  }
+
+  const { centerX, centerY } = gradient.value;
+  const l = Math.round(centerX * 1000);
+  const t = Math.round(centerY * 1000);
+  const r = Math.round((100 - centerX) * 1000);
+  const b = Math.round((100 - centerY) * 1000);
+  return `<a:gradFill flip="none" rotWithShape="1"><a:gsLst>${gsXml}</a:gsLst><a:path path="circle"><a:fillToRect l="${l}" t="${t}" r="${r}" b="${b}"/></a:path></a:gradFill>`;
+}
+
+function withSolidFillAlpha(
+  xml: string,
+  color: string | undefined,
+  opacity: number | undefined,
+): string {
+  if (color === undefined || opacity === undefined) return xml;
+  const clean = cleanHex(color);
+  return xml.replaceAll(
+    `<a:solidFill><a:srgbClr val="${clean}"/></a:solidFill>`,
+    `<a:solidFill>${colorWithOptionalAlphaXml(clean ?? color, opacity)}</a:solidFill>`,
+  );
+}
+
+function withGradientFill(
+  xml: string,
+  backgroundGradient: string | undefined,
+  opacity: number | undefined,
+): string {
+  if (!backgroundGradient) return xml;
+  const gradFill = buildGradFillXml(backgroundGradient, opacity);
+  if (!gradFill) return xml;
+  return xml.replace(
+    /<a:(?:solidFill|gradFill)\b[\s\S]*?<\/a:(?:solidFill|gradFill)>|<a:noFill\/>/,
+    gradFill,
+  );
+}
+
+function withRoundRectAdjust(
+  xml: string,
+  input: AddShapeInput,
+  rectRadius: number | undefined,
+): string {
+  if (input.preset !== "roundRect" || rectRadius === undefined) return xml;
+  const minDimensionIn = Math.min(input.width, input.height) / EMU_PER_IN;
+  const adj = Math.round((rectRadius / minDimensionIn) * 100000);
+  return xml.replace(
+    /<a:prstGeom prst="roundRect"><a:avLst\/><\/a:prstGeom>/,
+    `<a:prstGeom prst="roundRect"><a:avLst><a:gd name="adj" fmla="val ${adj}"/></a:avLst></a:prstGeom>`,
+  );
+}
+
+function shadowXml(shadow: ShadowStyle | undefined): string | undefined {
+  if (!shadow) return undefined;
+  const blur = Math.round(pxToPt(shadow.blur ?? 0) * 12700);
+  const dist = Math.round(pxToPt(shadow.offset ?? 0) * 12700);
+  const dir = Math.round((shadow.angle ?? 45) * 60000);
+  const color = cleanHex(shadow.color ?? "000000") ?? "000000";
+  const alpha = Math.round((shadow.opacity ?? 0.35) * 100000);
+  if (shadow.type === "inner") {
+    return `<a:innerShdw blurRad="${blur}" dist="${dist}" dir="${dir}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:innerShdw>`;
+  }
+  return `<a:outerShdw sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0" blurRad="${blur}" dist="${dist}" dir="${dir}"><a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr></a:outerShdw>`;
+}
+
+function withShadow(xml: string, shadow: ShadowStyle | undefined): string {
+  const effect = shadowXml(shadow);
+  if (!effect) return xml;
+  if (xml.includes("<a:effectLst>")) {
+    return xml.replace("</a:effectLst>", `${effect}</a:effectLst>`);
+  }
+  return xml.replace(
+    "</p:spPr>",
+    `<a:effectLst>${effect}</a:effectLst></p:spPr>`,
+  );
+}
+
+function withLineFlip(
+  xml: string,
+  flipH: boolean | undefined,
+  flipV: boolean | undefined,
+): string {
+  if (!flipH && !flipV) return xml;
+  return xml.replace(
+    "<a:xfrm",
+    `<a:xfrm${flipH ? ' flipH="1"' : ""}${flipV ? ' flipV="1"' : ""}`,
+  );
+}
+
+function withLineZeroExtent(
+  xml: string,
+  preset: string,
+  zeroWidth: boolean | undefined,
+  zeroHeight: boolean | undefined,
+): string {
+  if (preset !== "line" || (!zeroWidth && !zeroHeight)) return xml;
+  return xml.replace(
+    /<a:ext cx="(\d+)" cy="(\d+)"\/>/,
+    `<a:ext cx="${zeroWidth ? "0" : "$1"}" cy="${zeroHeight ? "0" : "$2"}"/>`,
+  );
+}
+
+function withPptxGenLineArrowDefaults(xml: string, preset: string): string {
+  if (preset !== "line") return xml;
+  const withoutDefaultSizes = xml.replace(
+    /<a:(headEnd|tailEnd) type="([^"]+)" w="med" len="med"\/>/g,
+    '<a:$1 type="$2"/>',
+  );
+  return withoutDefaultSizes.replace(
+    /<a:ln\b([^>]*)>([\s\S]*?)<\/a:ln>/g,
+    (match, attrs, body) => {
+      const bodyText = body as string;
+      if (bodyText.includes("<a:prstDash")) return match;
+      return `<a:ln${attrs as string}>${bodyText.replace(
+        /(<a:(?:solidFill|noFill\/)>[\s\S]*?<\/a:solidFill>|<a:noFill\/>)/,
+        '$1<a:prstDash val="solid"/>',
+      )}</a:ln>`;
+    },
+  );
+}
+
 function withPptxGenParagraphDefaults(xml: string): string {
   let result = xml.replaceAll('baseline="-25000"', 'baseline="-40000"');
   result = result.replace(/<a:bodyPr\b([^>]*)\/>/g, (_match, attrs) => {
@@ -316,6 +476,56 @@ function createTextBoxXml(
   };
 }
 
+export type GlimpseShapeXmlOptions = {
+  fillColor?: string;
+  fillOpacity?: number;
+  backgroundGradient?: string;
+  glow?: TextGlow;
+  shadow?: ShadowStyle;
+  rectRadius?: number;
+  flipH?: boolean;
+  flipV?: boolean;
+  zeroWidth?: boolean;
+  zeroHeight?: boolean;
+};
+
+function createShapeXml(
+  input: AddShapeInput,
+  options: GlimpseShapeXmlOptions | undefined,
+): string {
+  const source = createPptx();
+  const slideHandle = source.slides[0]?.handle;
+  if (!slideHandle) {
+    throw new Error("createPptx did not create an editable slide");
+  }
+
+  const edited = addShape(source, slideHandle, input);
+  const edit = edited.edits?.at(-1) as PptxSourceModelAddShapeEdit | undefined;
+  if (edit?.kind !== "addShape") {
+    throw new Error("addShape did not produce an addShape edit");
+  }
+
+  let xml = edit.xml;
+  xml = withShapeGlowAlpha(xml, options?.glow);
+  xml = withSolidFillAlpha(xml, options?.fillColor, options?.fillOpacity);
+  xml = withGradientFill(
+    xml,
+    options?.backgroundGradient,
+    options?.fillOpacity,
+  );
+  xml = withRoundRectAdjust(xml, input, options?.rectRadius);
+  xml = withShadow(xml, options?.shadow);
+  xml = withLineFlip(xml, options?.flipH, options?.flipV);
+  xml = withLineZeroExtent(
+    xml,
+    input.preset,
+    options?.zeroWidth,
+    options?.zeroHeight,
+  );
+  xml = withPptxGenLineArrowDefaults(xml, input.preset);
+  return xml;
+}
+
 interface RegisteredTextBox {
   marker: string;
   name: string;
@@ -325,13 +535,27 @@ interface RegisteredTextBox {
 
 export class GlimpseTextBoxRegistry {
   private readonly registered: RegisteredTextBox[] = [];
+  private textCount = 0;
+  private shapeCount = 0;
 
   register(node: TextPositionedNode): string {
-    const index = this.registered.length;
+    const index = this.textCount++;
     const marker = `${MARKER_PREFIX}${index}`;
     const name = `Text ${index + 1}`;
     const { xml, hyperlinks } = createTextBoxXml(node, name);
     this.registered.push({ marker, name, xml, hyperlinks });
+    return marker;
+  }
+
+  registerShape(
+    input: AddShapeInput,
+    options?: GlimpseShapeXmlOptions & { name?: string },
+  ): string {
+    const index = this.shapeCount++;
+    const marker = `${SHAPE_MARKER_PREFIX}${index}`;
+    const name = options?.name ?? `Shape ${index + 1}`;
+    const xml = createShapeXml({ ...input, name }, options);
+    this.registered.push({ marker, name, xml, hyperlinks: [] });
     return marker;
   }
 

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -33,6 +33,7 @@ import {
   type PptxSourceModelAddTextBoxEdit,
 } from "@pptx-glimpse/document";
 import type {
+  BorderStyle,
   PositionedNode,
   ShadowStyle,
   TextGlow,
@@ -324,8 +325,11 @@ function withRoundRectAdjust(
   rectRadius: number | undefined,
 ): string {
   if (input.preset !== "roundRect" || rectRadius === undefined) return xml;
-  const minDimensionIn = Math.min(input.width, input.height) / EMU_PER_IN;
-  const adj = Math.round((rectRadius / minDimensionIn) * 100000);
+  // `rectRadius` is the pptxgenjs-compatible option value already resolved by
+  // visualStyle.resolveRectRadius. Keep the same formula pptxgenjs uses.
+  const adj = Math.round(
+    (rectRadius * EMU_PER_IN * 100000) / Math.min(input.width, input.height),
+  );
   return xml.replace(
     /<a:prstGeom prst="roundRect"><a:avLst\/><\/a:prstGeom>/,
     `<a:prstGeom prst="roundRect"><a:avLst><a:gd name="adj" fmla="val ${adj}"/></a:avLst></a:prstGeom>`,
@@ -381,23 +385,35 @@ function withLineZeroExtent(
   );
 }
 
-function withPptxGenLineArrowDefaults(xml: string, preset: string): string {
-  if (preset !== "line") return xml;
-  const withoutDefaultSizes = xml.replace(
-    /<a:(headEnd|tailEnd) type="([^"]+)" w="med" len="med"\/>/g,
-    '<a:$1 type="$2"/>',
-  );
-  return withoutDefaultSizes.replace(
+function withPrstDash(xml: string, dashType: string): string {
+  return xml.replace(
     /<a:ln\b([^>]*)>([\s\S]*?)<\/a:ln>/g,
     (match, attrs, body) => {
       const bodyText = body as string;
       if (bodyText.includes("<a:prstDash")) return match;
       return `<a:ln${attrs as string}>${bodyText.replace(
         /(<a:(?:solidFill|noFill\/)>[\s\S]*?<\/a:solidFill>|<a:noFill\/>)/,
-        '$1<a:prstDash val="solid"/>',
+        `$1<a:prstDash val="${dashType}"/>`,
       )}</a:ln>`;
     },
   );
+}
+
+function withUnsupportedDashStyle(
+  xml: string,
+  dashType: BorderStyle["dashType"] | undefined,
+): string {
+  if (dashType !== "lgDashDotDot") return xml;
+  return withPrstDash(xml, dashType);
+}
+
+function withPptxGenLineArrowDefaults(xml: string, preset: string): string {
+  if (preset !== "line") return xml;
+  const withoutDefaultSizes = xml.replace(
+    /<a:(headEnd|tailEnd) type="([^"]+)" w="med" len="med"\/>/g,
+    '<a:$1 type="$2"/>',
+  );
+  return withPrstDash(withoutDefaultSizes, "solid");
 }
 
 function withPptxGenParagraphDefaults(xml: string): string {
@@ -482,6 +498,7 @@ export type GlimpseShapeXmlOptions = {
   glow?: TextGlow;
   shadow?: ShadowStyle;
   rectRadius?: number;
+  dashType?: BorderStyle["dashType"];
   flipH?: boolean;
   flipV?: boolean;
   zeroWidth?: boolean;
@@ -514,6 +531,7 @@ function createShapeXml(
   );
   xml = withRoundRectAdjust(xml, input, options?.rectRadius);
   xml = withShadow(xml, options?.shadow);
+  xml = withUnsupportedDashStyle(xml, options?.dashType);
   xml = withLineFlip(xml, options?.flipH, options?.flipV);
   xml = withLineZeroExtent(
     xml,

--- a/packages/pom/src/renderPptx/glowEffects.test.ts
+++ b/packages/pom/src/renderPptx/glowEffects.test.ts
@@ -108,7 +108,7 @@ describe("buildPptx with Shape glow", () => {
     expect(slideXml).not.toContain('<a:srgbClr val="111111"/>');
   });
 
-  it("複数 Shape で同じ glow を指定した場合に同じ marker / effectLst が複数挿入される", async () => {
+  it("複数 Shape で同じ glow を指定した場合に effectLst が複数出力され、marker は残らない", async () => {
     const xml = `<Slide><VStack w="100%" h="max">
       <Shape shapeType="ellipse" w="50" h="50" fill.color="AAAAAA" glow.size="8" glow.color="FF0000"/>
       <Shape shapeType="ellipse" w="50" h="50" fill.color="BBBBBB" glow.size="8" glow.color="FF0000"/>
@@ -231,7 +231,9 @@ describe("buildPptx with Shape glow", () => {
     const glowStart = slideXml.indexOf("<a:glow");
     expect(glowStart).toBeGreaterThanOrEqual(0);
     const spStart = slideXml.lastIndexOf("<p:sp>", glowStart);
+    expect(spStart).toBeGreaterThanOrEqual(0);
     const spEnd = slideXml.indexOf("</p:sp>", spStart);
+    expect(spEnd).toBeGreaterThan(spStart);
     const spBlock = slideXml.substring(spStart, spEnd);
     expect(spBlock.match(/<a:effectLst[^>]*>/g)).toHaveLength(1);
     expect(spBlock).toContain("<a:outerShdw");

--- a/packages/pom/src/renderPptx/glowEffects.test.ts
+++ b/packages/pom/src/renderPptx/glowEffects.test.ts
@@ -53,9 +53,7 @@ describe("buildPptx with Shape glow", () => {
     expect(slideXml).toContain(
       '<a:effectLst><a:glow rad="114300"><a:srgbClr val="00FF00"><a:alpha val="50000"/></a:srgbClr></a:glow></a:effectLst>',
     );
-    // マーカー文字列は最終出力に残してよい (PowerPoint で shape の name として
-    // 編集できる) が、ここでは存在のみ確認する
-    expect(slideXml).toContain('name="pom-glow:0"');
+    expect(slideXml).not.toContain("pom-glow:");
   });
 
   it("Shape glow 単独でも stream 経路で effectLst として出力される", async () => {
@@ -122,7 +120,7 @@ describe("buildPptx with Shape glow", () => {
     const slideXml = await readSlideXml(buffer);
 
     expect(slideXml.match(/<a:effectLst><a:glow/g)).toHaveLength(2);
-    expect(slideXml.match(/name="pom-glow:0"/g)).toHaveLength(2);
+    expect(slideXml).not.toContain("pom-glow:");
   });
 
   it("glow / outline 未指定時は effectLst / 余計な ln が挿入されない", async () => {
@@ -150,7 +148,7 @@ describe("buildPptx with Shape glow", () => {
     const slideXml = await readSlideXml(buffer);
 
     expect(slideXml).toContain("<a:effectLst><a:glow");
-    expect(slideXml).toContain('name="pom-glow:0"');
+    expect(slideXml).not.toContain("pom-glow:");
   });
 
   it("Icon variant の背景図形に glow / outline が適用される", async () => {
@@ -230,8 +228,9 @@ describe("buildPptx with Shape glow", () => {
 
     // 該当 shape の <p:spPr> に effectLst は 1 つだけ存在し、その中に
     // outerShdw と glow の両方が含まれる
-    const spStart = slideXml.indexOf('name="pom-glow:0"');
-    expect(spStart).toBeGreaterThanOrEqual(0);
+    const glowStart = slideXml.indexOf("<a:glow");
+    expect(glowStart).toBeGreaterThanOrEqual(0);
+    const spStart = slideXml.lastIndexOf("<p:sp>", glowStart);
     const spEnd = slideXml.indexOf("</p:sp>", spStart);
     const spBlock = slideXml.substring(spStart, spEnd);
     expect(spBlock.match(/<a:effectLst[^>]*>/g)).toHaveLength(1);

--- a/packages/pom/src/renderPptx/nodes/shape.ts
+++ b/packages/pom/src/renderPptx/nodes/shape.ts
@@ -137,6 +137,7 @@ export function renderShapeNode(
       fillOpacity,
       glow: node.glow,
       shadow: node.shadow,
+      dashType: lineSpec?.dashType,
     },
   );
 }

--- a/packages/pom/src/renderPptx/nodes/shape.ts
+++ b/packages/pom/src/renderPptx/nodes/shape.ts
@@ -1,9 +1,24 @@
-import type { BorderStyle, PositionedNode } from "../../types.ts";
+import {
+  asEmu,
+  asHundredthPt,
+  asPt,
+  type AddShapeParagraphInput,
+  type AddShapeRunPropertiesInput,
+} from "@pptx-glimpse/document";
+import type { BorderStyle, PositionedNode, Underline } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToPt } from "../units.ts";
-import { convertUnderline, convertStrike } from "../textOptions.ts";
-import { getContentAreaIn } from "../utils/contentArea.ts";
-import { convertBorderLine, convertShadow } from "../utils/visualStyle.ts";
+import { getContentArea } from "../utils/contentArea.ts";
+import { pxToEmu } from "../units.ts";
+import { toColorInput } from "../glimpseTextBoxes.ts";
+import {
+  addGlimpseShape,
+  createShapeBoundsInput,
+  createShapeRotationInput,
+  noneShapeFill,
+  shapeOutline,
+  solidShapeFill,
+} from "../utils/glimpseShape.ts";
 
 type ShapePositionedNode = Extract<PositionedNode, { type: "shape" }>;
 
@@ -30,56 +45,98 @@ function resolveShapeLine(
   };
 }
 
+function toUnderlineInput(underline: Underline | undefined) {
+  if (underline === undefined || underline === false) return undefined;
+  if (underline === true) return true;
+  return {
+    style: underline.style,
+    color: toColorInput(underline.color),
+  };
+}
+
+function buildShapeTextProperties(
+  node: ShapePositionedNode,
+): AddShapeRunPropertiesInput {
+  return {
+    fontFace: node.fontFamily ?? "Noto Sans JP",
+    fontSize: asPt(pxToPt(node.fontSize ?? 24)),
+    color: toColorInput(node.color),
+    bold: node.bold,
+    italic: node.italic,
+    underline: toUnderlineInput(node.underline),
+    strike: node.strike,
+    baseline: node.subscript
+      ? "subscript"
+      : node.superscript
+        ? "superscript"
+        : undefined,
+    highlight: toColorInput(node.highlight),
+  };
+}
+
+function buildShapeParagraphs(
+  node: ShapePositionedNode,
+): AddShapeParagraphInput[] | undefined {
+  if (!node.text) return undefined;
+  const fontSizePx = node.fontSize ?? 24;
+  const lineHeight = node.lineHeight ?? 1.3;
+  const properties = buildShapeTextProperties(node);
+  return node.text
+    .replace(/\r*\n/g, "\n")
+    .split("\n")
+    .map((text) => ({
+      properties: {
+        align: node.textAlign ?? "center",
+        lineSpacing: asHundredthPt(
+          Math.round(pxToPt(fontSizePx * lineHeight) * 100),
+        ),
+      },
+      runs: [{ text, properties }],
+    }));
+}
+
 export function renderShapeNode(
   node: ShapePositionedNode,
   ctx: RenderContext,
 ): void {
   const lineSpec = resolveShapeLine(node.line, node.outline);
-  const glowMarker = node.glow
-    ? ctx.buildContext.glowEffects.register(node.glow)
-    : undefined;
+  const boundsPx = getContentArea(node);
+  const fillOpacity =
+    node.fill?.transparency !== undefined
+      ? 1 - node.fill.transparency / 100
+      : undefined;
 
-  const shapeOptions = {
-    ...getContentAreaIn(node),
-    fill: node.fill
-      ? {
-          color: node.fill.color,
-          transparency: node.fill.transparency,
-        }
-      : undefined,
-    line: lineSpec ? convertBorderLine(lineSpec) : undefined,
-    shadow: convertShadow(node.shadow),
-    rotate: node.rotate,
-    objectName: glowMarker,
-  };
-
-  if (node.text) {
-    const fontSizePx = node.fontSize ?? 24;
-    const lineHeight = node.lineHeight ?? 1.3;
-    // テキストがある場合：addTextでshapeを指定
-    ctx.slide.addText(node.text, {
-      ...shapeOptions,
-      shape: node.shapeType,
-      fontSize: pxToPt(fontSizePx),
-      fontFace: node.fontFamily ?? "Noto Sans JP",
-      color: node.color,
-      bold: node.bold,
-      italic: node.italic,
-      underline: convertUnderline(node.underline),
-      strike: convertStrike(node.strike),
-      subscript: node.subscript,
-      superscript: node.superscript,
-      highlight: node.highlight,
-      align: node.textAlign ?? "center",
-      valign: "middle" as const,
-      // Text と同じく行送りを固定値 (spcPts) で指定し、計測高さ
-      // (行数 × fontSize × lineHeight) と実描画の行高さを一致させる (#846)。
-      // valign middle のためテキストブロックは枠内中央に配置され、
-      // Text のような描画 y 補正は不要
-      lineSpacing: pxToPt(fontSizePx * lineHeight),
-    });
-  } else {
-    // テキストがない場合：addShapeを使用
-    ctx.slide.addShape(node.shapeType, shapeOptions);
-  }
+  addGlimpseShape(
+    ctx,
+    {
+      preset: node.shapeType,
+      ...createShapeBoundsInput(boundsPx),
+      rotation: createShapeRotationInput(node.rotate),
+      fill: node.fill?.color
+        ? solidShapeFill(node.fill.color)
+        : noneShapeFill(),
+      outline: shapeOutline(lineSpec),
+      effects: node.glow
+        ? {
+            glow: {
+              radius: asEmu(Math.round(pxToEmu(node.glow.size ?? 8))),
+              color: toColorInput(node.glow.color ?? "FFFFFF")!,
+            },
+          }
+        : undefined,
+      body: node.text
+        ? {
+            anchor: "middle",
+          }
+        : undefined,
+      paragraphs: buildShapeParagraphs(node),
+    },
+    boundsPx,
+    {
+      fillColor: node.fill?.color,
+      fillOpacity,
+      glow: node.glow,
+      shadow: node.shadow,
+    },
+  );
 }

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -50,8 +50,8 @@ function vstackPage(children: PositionedNode[]): PositionedNode {
 }
 
 describe("renderShapeNode", () => {
-  it("padding を除いたコンテンツ領域に inch 変換して描画される", async () => {
-    const { objects } = await renderPage(
+  it("padding を除いたコンテンツ領域に EMU 変換して glimpse shape XML で描画される", async () => {
+    const slideXml = await renderPageSlideXml(
       vstackPage([
         {
           type: "shape",
@@ -66,19 +66,15 @@ describe("renderShapeNode", () => {
       ]),
     );
 
-    expect(objects).toHaveLength(1);
-    expect(objects[0].shape).toBe("rect");
-    expect(objects[0].options).toMatchObject({
-      x: pxToIn(96 + 24),
-      y: pxToIn(96 + 24),
-      w: pxToIn(192 - 48),
-      h: pxToIn(96 - 48),
-      fill: { color: "FF0000" },
-    });
+    expect(slideXml).toContain('<a:off x="1143000" y="1143000"/>');
+    expect(slideXml).toContain('<a:ext cx="1371600" cy="457200"/>');
+    expect(slideXml).toContain('<a:prstGeom prst="rect">');
+    expect(slideXml).toContain('<a:srgbClr val="FF0000"/>');
+    expect(slideXml).not.toContain("pom-shape:");
   });
 
-  it("rotate を pptxgenjs options に渡す", async () => {
-    const { objects } = await renderPage(
+  it("rotate を glimpse shape XML に渡す", async () => {
+    const slideXml = await renderPageSlideXml(
       vstackPage([
         {
           type: "shape",
@@ -92,7 +88,7 @@ describe("renderShapeNode", () => {
       ]),
     );
 
-    expect(objects[0].options.rotate).toBe(45);
+    expect(slideXml).toContain('<a:xfrm rot="2700000">');
   });
 });
 
@@ -609,7 +605,7 @@ describe("renderPyramidNode", () => {
 
 describe("ルートノードの background + border", () => {
   it("backgroundColor は slide.background に逃がし、border のみノード全体に fill なしで描画する", async () => {
-    const { objects } = await renderPage({
+    const slideXml = await renderPageSlideXml({
       type: "vstack",
       x: 0,
       y: 0,
@@ -620,15 +616,13 @@ describe("ルートノードの background + border", () => {
       children: [],
     });
 
-    expect(objects).toHaveLength(1);
-    expect(objects[0].options).toMatchObject({
-      x: 0,
-      y: 0,
-      w: pxToIn(1280),
-      h: pxToIn(720),
-      fill: { type: "none" },
-    });
-    expect(objects[0].options.line).toMatchObject({ color: "FF0000" });
+    expect(slideXml).toContain("<p:bg>");
+    expect(slideXml).toContain('<a:srgbClr val="EEEEEE"/>');
+    expect(slideXml).toContain('<a:off x="0" y="0"/>');
+    expect(slideXml).toContain('<a:ext cx="12192000" cy="6858000"/>');
+    expect(slideXml).toContain("<a:noFill/>");
+    expect(slideXml).toContain('<a:srgbClr val="FF0000"/>');
+    expect(slideXml).not.toContain("pom-shape:");
   });
 });
 
@@ -737,7 +731,7 @@ describe("renderChartNode", () => {
 
 describe("renderLineNode / renderArrowNode", () => {
   it("line: 逆向き座標は左上原点 + flip で表現される", async () => {
-    const { objects } = await renderPage(
+    const slideXml = await renderPageSlideXml(
       vstackPage([
         {
           type: "line",
@@ -754,20 +748,16 @@ describe("renderLineNode / renderArrowNode", () => {
       ]),
     );
 
-    expect(objects[0].shape).toBe("line");
-    expect(objects[0].options).toMatchObject({
-      x: pxToIn(100),
-      y: pxToIn(50),
-      w: pxToIn(200),
-      h: pxToIn(50),
-      flipH: true,
-      flipV: true,
-    });
-    expect(objects[0].options.line).toMatchObject({ color: "00FF00" });
+    expect(slideXml).toContain('<a:xfrm flipH="1" flipV="1">');
+    expect(slideXml).toContain('<a:off x="952500" y="476250"/>');
+    expect(slideXml).toContain('<a:ext cx="1905000" cy="476250"/>');
+    expect(slideXml).toContain('<a:prstGeom prst="line">');
+    expect(slideXml).toContain('<a:srgbClr val="00FF00"/>');
+    expect(slideXml).not.toContain("pom-shape:");
   });
 
   it("arrow: 参照ノードの中心同士を結ぶ線を描画する", async () => {
-    const { objects } = await renderPage({
+    const slideXml = await renderPageSlideXml({
       type: "layer",
       x: 0,
       y: 0,
@@ -806,18 +796,11 @@ describe("renderLineNode / renderArrowNode", () => {
       ],
     });
 
-    const line = objects.find((o) => o.shape === "line");
-    expect(line?.options).toMatchObject({
-      x: pxToIn(100),
-      y: pxToIn(100),
-      w: pxToIn(200),
-      h: pxToIn(100),
-      flipH: false,
-      flipV: false,
-    });
-    expect(line?.options.line).toMatchObject({
-      color: "0000FF",
-      endArrowType: "triangle",
-    });
+    expect(slideXml).toContain('<a:off x="952500" y="952500"/>');
+    expect(slideXml).toContain('<a:ext cx="1905000" cy="952500"/>');
+    expect(slideXml).toContain('<a:prstGeom prst="line">');
+    expect(slideXml).toContain('<a:srgbClr val="0000FF"/>');
+    expect(slideXml).toContain('<a:tailEnd type="triangle"/>');
+    expect(slideXml).not.toContain("pom-shape:");
   });
 });

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -90,6 +90,31 @@ describe("renderShapeNode", () => {
 
     expect(slideXml).toContain('<a:xfrm rot="2700000">');
   });
+
+  it("shape text underline を glimpse shape run properties に渡す", async () => {
+    const slideXml = await renderPageSlideXml(
+      vstackPage([
+        {
+          type: "shape",
+          shapeType: "rect",
+          text: "underlined",
+          x: 0,
+          y: 0,
+          w: 160,
+          h: 80,
+          underline: {
+            style: "sng",
+            color: "FF0000",
+          },
+        },
+      ]),
+    );
+
+    expect(slideXml).toContain("<a:t>underlined</a:t>");
+    expect(slideXml).toContain(
+      '<a:uFill><a:solidFill><a:srgbClr val="FF0000"/>',
+    );
+  });
 });
 
 describe("renderTextNode", () => {

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -756,6 +756,28 @@ describe("renderLineNode / renderArrowNode", () => {
     expect(slideXml).not.toContain("pom-shape:");
   });
 
+  it("line: lgDashDotDot を solid に落とさず prstDash に保持する", async () => {
+    const slideXml = await renderPageSlideXml(
+      vstackPage([
+        {
+          type: "line",
+          x: 0,
+          y: 0,
+          w: 0,
+          h: 0,
+          x1: 100,
+          y1: 100,
+          x2: 300,
+          y2: 100,
+          color: "00FF00",
+          dashType: "lgDashDotDot",
+        },
+      ]),
+    );
+
+    expect(slideXml).toContain('<a:prstDash val="lgDashDotDot"/>');
+  });
+
   it("arrow: 参照ノードの中心同士を結ぶ線を描画する", async () => {
     const slideXml = await renderPageSlideXml({
       type: "layer",

--- a/packages/pom/src/renderPptx/renderPptx.ts
+++ b/packages/pom/src/renderPptx/renderPptx.ts
@@ -265,8 +265,8 @@ export async function renderPptx(
       : undefined;
     const rootHasOpacity =
       !isLinelike && "opacity" in data && data.opacity !== undefined;
-    // backgroundGradient はマーカー色で slide.background に適用し、
-    // 出力時の後処理で gradFill に置換される (gradientFills.ts 参照)
+    // backgroundGradient はスライド背景では従来の p:bgPr 後処理を維持する。
+    // root を full-slide shape にすると slide master のオブジェクトを覆うため。
     const rootGradientMarker =
       rootBackgroundGradient && !rootHasOpacity
         ? registerBackgroundGradient(

--- a/packages/pom/src/renderPptx/utils/backgroundBorder.test.ts
+++ b/packages/pom/src/renderPptx/utils/backgroundBorder.test.ts
@@ -51,6 +51,28 @@ describe("renderBackgroundAndBorder の辺ごと border", () => {
     expect(countLineShapes(slideXml)).toBe(0);
   });
 
+  it("backgroundGradient + shadow は legacy gradient 後処理と shadow XML を共存させる", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Text w="200" h="100" backgroundGradient="linear-gradient(90deg, #FF0000, #0000FF)" shadow.type="outer" shadow.blur="4" shadow.offset="2">test</Text>
+    </VStack></Slide>`;
+    const slideXml = await buildSlideXml(xml);
+
+    expect(slideXml).toContain("<a:gradFill");
+    expect(slideXml).toContain("<a:outerShdw");
+    expect(slideXml).not.toContain("pom-gradient:");
+  });
+
+  it("backgroundGradient + borderRadius + shadow は roundRect geometry と effectLst を共存させる", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Text w="200" h="100" borderRadius="12" backgroundGradient="linear-gradient(90deg, #FF0000, #0000FF)" shadow.type="outer">test</Text>
+    </VStack></Slide>`;
+    const slideXml = await buildSlideXml(xml);
+
+    expect(slideXml).toContain("<a:gradFill");
+    expect(slideXml).toContain("<a:outerShdw");
+    expect(slideXml).toContain('<a:prstGeom prst="roundRect">');
+  });
+
   it("背景付きルートノード (slide.background 最適化パス) でも辺ごとの border が描画される", async () => {
     const xml = `<Slide><VStack w="100%" h="max" backgroundColor="F8FAFC" borderLeft.color="FF0000" borderLeft.width="6">
       <Text w="200" h="100">test</Text>

--- a/packages/pom/src/renderPptx/utils/backgroundBorder.test.ts
+++ b/packages/pom/src/renderPptx/utils/backgroundBorder.test.ts
@@ -93,6 +93,17 @@ describe("renderBackgroundAndBorder の辺ごと border", () => {
     expect(slideXml).toContain('<a:srgbClr val="FF0000"/>');
   });
 
+  it("backgroundImage と背景色・一律 border の分割描画でも glimpse marker は残らない", async () => {
+    const xml = `<Slide><VStack w="100%" h="max">
+      <Text w="200" h="100" backgroundColor="F8FAFC" backgroundImage.src="https://example.com/bg.png" border.color="FF0000" border.width="3">test</Text>
+    </VStack></Slide>`;
+    const slideXml = await buildSlideXml(xml);
+
+    expect(slideXml).toContain('<a:srgbClr val="F8FAFC"/>');
+    expect(slideXml).toContain('<a:srgbClr val="FF0000"/>');
+    expect(slideXml).not.toContain("pom-shape:");
+  });
+
   it("borderRadius と併用した場合は辺ごとの指定を無視して一律 border で描画する", async () => {
     const xml = `<Slide><VStack w="100%" h="max">
       <Text w="200" h="100" borderRadius="8" border.color="000000" borderLeft.color="FF0000">test</Text>

--- a/packages/pom/src/renderPptx/utils/backgroundBorder.ts
+++ b/packages/pom/src/renderPptx/utils/backgroundBorder.ts
@@ -13,6 +13,14 @@ import {
   resolveRectRadius,
   type PerSideBorders,
 } from "./visualStyle.ts";
+import {
+  addGlimpseShape,
+  backgroundShapeFill,
+  createShapeBoundsInput,
+  noShapeOutline,
+  noneShapeFill,
+  shapeOutline,
+} from "./glimpseShape.ts";
 
 /**
  * ノードの背景色・背景画像・ボーダー・影を描画する
@@ -33,20 +41,9 @@ export function renderBackgroundAndBorder(
     shadow,
   } = node;
 
-  // backgroundGradient はマーカー色の solidFill として描画し、
-  // 出力時の後処理で gradFill に置換される (gradientFills.ts 参照)。
-  // opacity はマーカー側ではなく gradFill のカラーストップの alpha で表現する
-  const gradientMarker = backgroundGradient
-    ? registerBackgroundGradient(
-        backgroundGradient,
-        node.opacity,
-        ctx.buildContext.gradientFills,
-      )
-    : undefined;
-
   const perSideBorders = resolveEffectivePerSideBorders(node, ctx);
 
-  const hasBackground = Boolean(backgroundColor) || Boolean(gradientMarker);
+  const hasBackground = Boolean(backgroundColor) || Boolean(backgroundGradient);
   const hasBackgroundImage = Boolean(backgroundImage);
   // 辺ごとの指定がある場合、一律 border は各辺へのマージで反映済みのため
   // shape の line としては描画しない
@@ -64,7 +61,8 @@ export function renderBackgroundAndBorder(
   }
 
   // borderRadius がある場合は roundRect を使用し、rectRadius を計算
-  const shapeType = borderRadius
+  const shapeType = borderRadius ? "roundRect" : "rect";
+  const legacyShapeType = borderRadius
     ? ctx.pptx.ShapeType.roundRect
     : ctx.pptx.ShapeType.rect;
 
@@ -73,21 +71,55 @@ export function renderBackgroundAndBorder(
   // backgroundImage がない場合は従来通り1回の addShape で処理
   if (!hasBackgroundImage) {
     if (hasBackground || hasUniformBorder || hasShadow) {
-      const fill = hasBackground
-        ? resolveBackgroundFill(backgroundColor, node.opacity, gradientMarker)
-        : { type: "none" as const };
+      if (hasShadow) {
+        const gradientMarker = backgroundGradient
+          ? registerBackgroundGradient(
+              backgroundGradient,
+              node.opacity,
+              ctx.buildContext.gradientFills,
+            )
+          : undefined;
+        ctx.slide.addShape(legacyShapeType, {
+          ...rectPxToIn(node),
+          fill: hasBackground
+            ? resolveBackgroundFill(
+                backgroundColor,
+                node.opacity,
+                gradientMarker,
+              )
+            : { type: "none" as const },
+          line: hasUniformBorder
+            ? convertBorderLine(border, "000000")
+            : { type: "none" as const },
+          rectRadius,
+          shadow: convertShadow(shadow),
+        });
+      } else {
+        const fill = hasBackground
+          ? backgroundShapeFill(backgroundColor, backgroundGradient)
+          : noneShapeFill();
 
-      const line = hasUniformBorder
-        ? convertBorderLine(border, "000000")
-        : { type: "none" as const };
+        const line = hasUniformBorder
+          ? shapeOutline(border, "000000")
+          : noShapeOutline();
 
-      ctx.slide.addShape(shapeType, {
-        ...rectPxToIn(node),
-        fill,
-        line,
-        rectRadius,
-        shadow: convertShadow(shadow),
-      });
+        addGlimpseShape(
+          ctx,
+          {
+            preset: shapeType,
+            ...createShapeBoundsInput(node),
+            fill,
+            outline: line,
+          },
+          node,
+          {
+            fillColor: backgroundColor,
+            fillOpacity: node.opacity,
+            backgroundGradient,
+            rectRadius,
+          },
+        );
+      }
     }
 
     renderPerSideBorderLines(node, perSideBorders, ctx);
@@ -98,16 +130,22 @@ export function renderBackgroundAndBorder(
 
   // 1. 背景色
   if (hasBackground) {
-    ctx.slide.addShape(shapeType, {
-      ...rectPxToIn(node),
-      fill: resolveBackgroundFill(
-        backgroundColor,
-        node.opacity,
-        gradientMarker,
-      ),
-      line: { type: "none" as const },
-      rectRadius,
-    });
+    addGlimpseShape(
+      ctx,
+      {
+        preset: shapeType,
+        ...createShapeBoundsInput(node),
+        fill: backgroundShapeFill(backgroundColor, backgroundGradient),
+        outline: noShapeOutline(),
+      },
+      node,
+      {
+        fillColor: backgroundColor,
+        fillOpacity: node.opacity,
+        backgroundGradient,
+        rectRadius,
+      },
+    );
   }
 
   // 2. 背景画像
@@ -135,15 +173,33 @@ export function renderBackgroundAndBorder(
 
   // 3. ボーダー
   if (hasUniformBorder || hasShadow) {
-    ctx.slide.addShape(shapeType, {
-      ...rectPxToIn(node),
-      fill: { type: "none" as const },
-      line: hasUniformBorder
-        ? convertBorderLine(border, "000000")
-        : { type: "none" as const },
-      rectRadius,
-      shadow: convertShadow(shadow),
-    });
+    if (hasShadow) {
+      ctx.slide.addShape(legacyShapeType, {
+        ...rectPxToIn(node),
+        fill: { type: "none" as const },
+        line: hasUniformBorder
+          ? convertBorderLine(border, "000000")
+          : { type: "none" as const },
+        rectRadius,
+        shadow: convertShadow(shadow),
+      });
+    } else {
+      addGlimpseShape(
+        ctx,
+        {
+          preset: shapeType,
+          ...createShapeBoundsInput(node),
+          fill: noneShapeFill(),
+          outline: hasUniformBorder
+            ? shapeOutline(border, "000000")
+            : noShapeOutline(),
+        },
+        node,
+        {
+          rectRadius,
+        },
+      );
+    }
   }
 
   renderPerSideBorderLines(node, perSideBorders, ctx);
@@ -188,16 +244,21 @@ export function renderBorderOnly(
 
   if (!hasVisibleBorder(border)) return;
 
-  const shapeType = borderRadius
-    ? ctx.pptx.ShapeType.roundRect
-    : ctx.pptx.ShapeType.rect;
+  const shapeType = borderRadius ? "roundRect" : "rect";
 
-  ctx.slide.addShape(shapeType, {
-    ...rectPxToIn(node),
-    fill: { type: "none" as const },
-    line: convertBorderLine(border, "000000"),
-    rectRadius: resolveRectRadius(borderRadius, node.w, node.h),
-  });
+  addGlimpseShape(
+    ctx,
+    {
+      preset: shapeType,
+      ...createShapeBoundsInput(node),
+      fill: noneShapeFill(),
+      outline: shapeOutline(border, "000000"),
+    },
+    node,
+    {
+      rectRadius: resolveRectRadius(borderRadius, node.w, node.h),
+    },
+  );
 }
 
 /**
@@ -223,9 +284,15 @@ function renderPerSideBorderLines(
     const style = perSideBorders[side];
     if (!style) continue;
 
-    ctx.slide.addShape(ctx.pptx.ShapeType.line, {
-      ...rectPxToIn(edges[side]),
-      line: convertBorderLine(style, "000000"),
-    });
+    addGlimpseShape(
+      ctx,
+      {
+        preset: "line",
+        ...createShapeBoundsInput(edges[side]),
+        fill: noneShapeFill(),
+        outline: shapeOutline(style, "000000"),
+      },
+      edges[side],
+    );
   }
 }

--- a/packages/pom/src/renderPptx/utils/backgroundBorder.ts
+++ b/packages/pom/src/renderPptx/utils/backgroundBorder.ts
@@ -117,6 +117,7 @@ export function renderBackgroundAndBorder(
             fillOpacity: node.opacity,
             backgroundGradient,
             rectRadius,
+            dashType: border?.dashType,
           },
         );
       }
@@ -144,6 +145,7 @@ export function renderBackgroundAndBorder(
         fillOpacity: node.opacity,
         backgroundGradient,
         rectRadius,
+        dashType: border?.dashType,
       },
     );
   }
@@ -197,6 +199,7 @@ export function renderBackgroundAndBorder(
         node,
         {
           rectRadius,
+          dashType: border?.dashType,
         },
       );
     }
@@ -257,6 +260,7 @@ export function renderBorderOnly(
     node,
     {
       rectRadius: resolveRectRadius(borderRadius, node.w, node.h),
+      dashType: border.dashType,
     },
   );
 }
@@ -293,6 +297,9 @@ function renderPerSideBorderLines(
         outline: shapeOutline(style, "000000"),
       },
       edges[side],
+      {
+        dashType: style.dashType,
+      },
     );
   }
 }

--- a/packages/pom/src/renderPptx/utils/glimpseShape.test.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseShape.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  backgroundShapeFill,
+  noneShapeFill,
+  shapeOutline,
+  solidShapeFill,
+} from "./glimpseShape.ts";
+
+describe("glimpse shape helpers", () => {
+  it("solid / none fill を glimpse writer input に変換する", () => {
+    expect(solidShapeFill("#ff00aa")).toEqual({
+      kind: "solid",
+      color: { kind: "srgb", hex: "FF00AA" },
+    });
+    expect(solidShapeFill(undefined)).toBeUndefined();
+    expect(noneShapeFill()).toEqual({ kind: "none" });
+  });
+
+  it("backgroundGradient は先頭 stop を fallback solid fill として渡す", () => {
+    expect(
+      backgroundShapeFill(
+        undefined,
+        "linear-gradient(90deg, #112233, #445566)",
+      ),
+    ).toEqual({
+      kind: "solid",
+      color: { kind: "srgb", hex: "112233" },
+    });
+    expect(backgroundShapeFill(undefined, undefined)).toBeUndefined();
+  });
+
+  it("outline 未指定・空指定は undefined にし、lgDashDotDot は保持する", () => {
+    expect(shapeOutline(undefined)).toBeUndefined();
+    expect(shapeOutline({})).toBeUndefined();
+    expect(shapeOutline({ dashType: "lgDashDotDot" })).toMatchObject({
+      dash: "lgDashDotDot",
+    });
+  });
+});

--- a/packages/pom/src/renderPptx/utils/glimpseShape.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseShape.ts
@@ -1,0 +1,144 @@
+import {
+  asEmu,
+  asOoxmlAngle,
+  type AddShapeFillInput,
+  type AddShapeInput,
+  type AddShapeOutlineInput,
+  type SourceArrowEndpoint,
+  type SourceDashStyle,
+} from "@pptx-glimpse/document";
+import type { BorderStyle, ShadowStyle, TextGlow } from "../../types.ts";
+import { parseGradient } from "../../shared/gradient.ts";
+import { toColorInput } from "../glimpseTextBoxes.ts";
+import { pxToEmu, rectPxToIn } from "../units.ts";
+import type { RenderContext } from "../types.ts";
+
+type ShapeBoundsPx = { x: number; y: number; w: number; h: number };
+
+export type GlimpseShapeStyleOptions = {
+  fillColor?: string;
+  fillOpacity?: number;
+  backgroundGradient?: string;
+  glow?: TextGlow;
+  shadow?: ShadowStyle;
+  rectRadius?: number;
+  flipH?: boolean;
+  flipV?: boolean;
+  zeroWidth?: boolean;
+  zeroHeight?: boolean;
+};
+
+const TRANSPARENT_MARKER_STYLE = {
+  fill: { color: "FFFFFF", transparency: 100 },
+  line: { color: "FFFFFF", transparency: 100 },
+} as const;
+
+function positiveEmu(valuePx: number) {
+  return asEmu(Math.max(1, Math.round(pxToEmu(valuePx))));
+}
+
+export function createShapeBoundsInput(bounds: ShapeBoundsPx) {
+  return {
+    offsetX: asEmu(Math.round(pxToEmu(bounds.x))),
+    offsetY: asEmu(Math.round(pxToEmu(bounds.y))),
+    width: positiveEmu(bounds.w),
+    height: positiveEmu(bounds.h),
+  };
+}
+
+export function createShapeRotationInput(rotate: number | undefined) {
+  return rotate !== undefined
+    ? asOoxmlAngle(Math.round(rotate * 60000))
+    : undefined;
+}
+
+export function solidShapeFill(
+  color: string | undefined,
+): AddShapeFillInput | undefined {
+  const clean = toColorInput(color);
+  return clean ? { kind: "solid", color: clean } : undefined;
+}
+
+export function noneShapeFill(): AddShapeFillInput {
+  return { kind: "none" };
+}
+
+function gradientFallbackColor(value: string): string | undefined {
+  const gradient = parseGradient(value);
+  return gradient?.value.stops[0]?.color;
+}
+
+export function backgroundShapeFill(
+  backgroundColor: string | undefined,
+  backgroundGradient: string | undefined,
+): AddShapeFillInput | undefined {
+  if (backgroundGradient) {
+    const color = gradientFallbackColor(backgroundGradient);
+    return solidShapeFill(color);
+  }
+  return solidShapeFill(backgroundColor);
+}
+
+function dashStyle(
+  dashType: BorderStyle["dashType"],
+): SourceDashStyle | undefined {
+  if (dashType === "lgDashDotDot") return undefined;
+  return dashType;
+}
+
+export function shapeOutline(
+  border: BorderStyle | undefined,
+  fallbackColor?: string,
+): AddShapeOutlineInput | undefined {
+  if (!border) return undefined;
+  const fill = solidShapeFill(border.color ?? fallbackColor);
+  if (
+    border.width === undefined &&
+    fill === undefined &&
+    border.dashType === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    width:
+      border.width !== undefined
+        ? asEmu(Math.round(pxToEmu(border.width)))
+        : undefined,
+    fill,
+    dash: dashStyle(border.dashType),
+  };
+}
+
+export function noShapeOutline(): AddShapeOutlineInput {
+  return { fill: noneShapeFill() };
+}
+
+export function arrowEndpoint(
+  type:
+    "none" | "arrow" | "diamond" | "oval" | "stealth" | "triangle" | undefined,
+): SourceArrowEndpoint | undefined {
+  if (type === undefined || type === "none") return undefined;
+  return { type, width: "med", length: "med" };
+}
+
+export function addGlimpseShape(
+  ctx: RenderContext,
+  input: AddShapeInput,
+  markerBounds: ShapeBoundsPx,
+  options?: GlimpseShapeStyleOptions & { name?: string },
+): void {
+  const marker = ctx.buildContext.glimpseTextBoxes.registerShape(input, {
+    ...options,
+    zeroWidth: markerBounds.w === 0,
+    zeroHeight: markerBounds.h === 0,
+  });
+  ctx.slide.addShape(ctx.pptx.ShapeType.rect, {
+    ...rectPxToIn({
+      ...markerBounds,
+      w: Math.max(markerBounds.w, 1),
+      h: Math.max(markerBounds.h, 1),
+    }),
+    ...TRANSPARENT_MARKER_STYLE,
+    objectName: marker,
+  });
+}

--- a/packages/pom/src/renderPptx/utils/glimpseShape.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseShape.ts
@@ -22,6 +22,7 @@ export type GlimpseShapeStyleOptions = {
   glow?: TextGlow;
   shadow?: ShadowStyle;
   rectRadius?: number;
+  dashType?: BorderStyle["dashType"];
   flipH?: boolean;
   flipV?: boolean;
   zeroWidth?: boolean;
@@ -82,8 +83,7 @@ export function backgroundShapeFill(
 function dashStyle(
   dashType: BorderStyle["dashType"],
 ): SourceDashStyle | undefined {
-  if (dashType === "lgDashDotDot") return undefined;
-  return dashType;
+  return dashType as SourceDashStyle | undefined;
 }
 
 export function shapeOutline(

--- a/packages/pom/src/renderPptx/utils/straightLine.ts
+++ b/packages/pom/src/renderPptx/utils/straightLine.ts
@@ -79,6 +79,6 @@ export function addStraightLine(
       },
     },
     { x: minX, y: minY, w: lineW, h: lineH },
-    { flipH, flipV },
+    { flipH, flipV, dashType },
   );
 }

--- a/packages/pom/src/renderPptx/utils/straightLine.ts
+++ b/packages/pom/src/renderPptx/utils/straightLine.ts
@@ -7,7 +7,15 @@
  */
 import type { LineArrow, LineNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { pxToIn, pxToPt } from "../units.ts";
+import { asEmu } from "@pptx-glimpse/document";
+import { pxToEmu } from "../units.ts";
+import {
+  addGlimpseShape,
+  arrowEndpoint,
+  createShapeBoundsInput,
+  noneShapeFill,
+  solidShapeFill,
+} from "./glimpseShape.ts";
 
 /**
  * boolean | LineArrowOptions から pptxgenjs の arrow type を取得
@@ -53,19 +61,24 @@ export function addStraightLine(
   const flipH = x2 < x1;
   const flipV = y2 < y1;
 
-  ctx.slide.addShape(ctx.pptx.ShapeType.line, {
-    x: pxToIn(minX),
-    y: pxToIn(minY),
-    w: pxToIn(lineW),
-    h: pxToIn(lineH),
-    flipH,
-    flipV,
-    line: {
-      color: color ?? "000000",
-      width: lineWidth !== undefined ? pxToPt(lineWidth) : 1,
-      dashType,
-      beginArrowType: resolveArrowType(beginArrow),
-      endArrowType: resolveArrowType(endArrow),
+  addGlimpseShape(
+    ctx,
+    {
+      preset: "line",
+      ...createShapeBoundsInput({ x: minX, y: minY, w: lineW, h: lineH }),
+      fill: noneShapeFill(),
+      outline: {
+        fill: solidShapeFill(color ?? "000000"),
+        width:
+          lineWidth !== undefined
+            ? asEmu(Math.round(pxToEmu(lineWidth)))
+            : asEmu(12700),
+        dash: dashType === "lgDashDotDot" ? undefined : dashType,
+        headEnd: arrowEndpoint(resolveArrowType(beginArrow)),
+        tailEnd: arrowEndpoint(resolveArrowType(endArrow)),
+      },
     },
-  });
+    { x: minX, y: minY, w: lineW, h: lineH },
+    { flipH, flipV },
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
   packages/pom:
     dependencies:
       '@pptx-glimpse/document':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       '@resvg/resvg-wasm':
         specifier: ^2.6.2
         version: 2.6.2
@@ -2076,8 +2076,8 @@ packages:
     resolution: {integrity: sha512-1cbw9h76rHXJ76Qv1TOdYf8xZobUJbBEacViNfy2AONNuq9D1d4walMZu4rq7Wgvx3KTc0wCO+ph49npaMG7iw==}
     engines: {node: '>=22'}
 
-  '@pptx-glimpse/document@0.5.0':
-    resolution: {integrity: sha512-lTGK2L00XlE+BZR50A7Z0Fyi+dMCNOdSFj0u9wAXGb4LumbFeEdDpMmWdI4sVyItjJ0vG8HcwezFfD1yqPdcfg==}
+  '@pptx-glimpse/document@0.6.0':
+    resolution: {integrity: sha512-sqZGBnqZb4CzI771UVfG2EI+vyTVMlwQXVZocemkEVVrxQ9kOUtmdIbIPciKdPPT1nph9qarzYdKppAqmgMcbw==}
     engines: {node: '>=22'}
 
   '@quansync/fs@1.0.0':
@@ -9551,7 +9551,7 @@ snapshots:
       fast-xml-parser: 5.9.3
       fflate: 0.8.3
 
-  '@pptx-glimpse/document@0.5.0':
+  '@pptx-glimpse/document@0.6.0':
     dependencies:
       fast-xml-parser: 5.9.3
       fflate: 0.8.3


### PR DESCRIPTION
close #936

## 概要
- Shape / Line / Arrow primitive と background/border の非 shadow 経路を @pptx-glimpse/document shape writer の XML 置換経路へ移行
- shape 用 marker 登録を glimpseTextBoxes に追加し、swap 対象経路の gradient / glow は旧 marker registry を経由しない生成に変更
- @pptx-glimpse/document を 0.6.0 に更新し、XML assertion と edge case テストを追加

## 補足
- background/border の shadow 付き経路は VRT 互換性維持のため legacy pptxgenjs 経路に残しています
- PowerPoint 実機での修復なし確認はローカル自動化できないため、PR 上の手動確認対象です

## 検証
- pnpm --filter @hirokisakabe/pom run fmt:check
- pnpm --filter @hirokisakabe/pom run lint
- pnpm --filter @hirokisakabe/pom run typecheck
- pnpm --filter @hirokisakabe/pom run test:run
- pnpm --filter @hirokisakabe/pom run build
- pnpm --filter @hirokisakabe/pom run lint:deps
- pnpm --filter @hirokisakabe/pom run vrt:docker
