### PR TITLE
chore: coverage 生成物を fmt/lint 対象外にする

### DIFF
--- a/eslint.config.shared.mjs
+++ b/eslint.config.shared.mjs
@@ -24,7 +24,7 @@ export function defineSharedConfig({
 }) {
   return defineConfig([
     {
-      ignores: ["dist/**", "node_modules/**", ...ignores],
+      ignores: ["dist/**", "coverage/**", "node_modules/**", ...ignores],
     },
     {
       files,

--- a/packages/pom-cli/.prettierignore
+++ b/packages/pom-cli/.prettierignore
@@ -1,1 +1,2 @@
 dist
+coverage

--- a/packages/pom-editor/.prettierignore
+++ b/packages/pom-editor/.prettierignore
@@ -1,1 +1,2 @@
 dist
+coverage

--- a/packages/pom-jsx/.prettierignore
+++ b/packages/pom-jsx/.prettierignore
@@ -1,1 +1,2 @@
 dist
+coverage

--- a/packages/pom-md/.prettierignore
+++ b/packages/pom-md/.prettierignore
@@ -1,1 +1,2 @@
 dist
+coverage

--- a/packages/pom-vscode/.prettierignore
+++ b/packages/pom-vscode/.prettierignore
@@ -1,2 +1,3 @@
 dist
+coverage
 .vscode-test

--- a/packages/pom/.prettierignore
+++ b/packages/pom/.prettierignore
@@ -1,1 +1,2 @@
 dist
+coverage


### PR DESCRIPTION
## 概要
- ESLint の共通 ignore に coverage 生成物を追加
- 各パッケージの .prettierignore に coverage を追加

## 確認
- pnpm --filter @hirokisakabe/pom run fmt:check
- pnpm --filter @hirokisakabe/pom run lint