### PR TITLE
Ignore docs image VRT output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,4 +195,4 @@ dist
 
 *sample.pptx
 tmp-fonts/
-docs/images/output/
+packages/pom/docs/images/output/


### PR DESCRIPTION
## 概要

- docs 画像 VRT の一時出力ディレクトリ `packages/pom/docs/images/output/` を Git の ignore 対象に修正
- 既存の `docs/images/output/` はルート相対の別パスを指しており、実際の一時出力に効いていなかったため実パスへ変更

## 確認

- `git check-ignore -v packages/pom/docs/images/output/example.png`
- codex review: 指摘なし