### PR TITLE
feat: Table / Chart を glimpse native writer に移行

### DIFF
--- a/.changeset/native-table-chart-writer.md
+++ b/.changeset/native-table-chart-writer.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+Table と Chart の PPTX 生成を `@pptx-glimpse/document` の native writer へ移行しました。

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -1,10 +1,9 @@
 /**
- * Text primitive の @pptx-glimpse/document writer への段階的 swap。
+ * Primitive の @pptx-glimpse/document writer への段階的 swap。
  *
- * 混在期間の合成方式は「pptxgenjs 出力 zip をベースに、swap 済み Text
- * primitive の shape XML だけを glimpse writer で生成して該当 marker shape と
- * 差し替える」方式を採用する。pptxgenjs 側にはまだ Shape / Image / Table /
- * Chart など未 swap primitive と slide master 生成が残っているため、既存 zip を
+ * 混在期間の合成方式は「pptxgenjs 出力 zip をベースに、swap 済み primitive
+ * の XML / package part を glimpse writer で生成して該当 marker shape と
+ * 差し替える」方式を採用する。pptxgenjs 側には slide master 生成が残っているため、既存 zip を
  * ベースにすると [Content_Types].xml / rels / media parts の管理を現行実装へ
  * 寄せられる。代替案として glimpse の package をベースに未 swap primitive を
  * pptxgenjs から取り込む方式も検討したが、初回スライス時点では pptxgenjs 側の
@@ -12,12 +11,14 @@
  * primitive swap より先に package 合成の複雑さが大きくなるため採用しない。
  *
  * marker shape は描画順を保持するためだけに pptxgenjs へ追加し、write 時に
- * glimpse の `<p:sp>` で丸ごと置換する。Text content 自体は pptxgenjs `addText`
- * を経由しない。
+ * glimpse の `<p:sp>` / `<p:graphicFrame>` で丸ごと置換する。swap 済み primitive
+ * 自体は対応する pptxgenjs API を経由しない。
  */
 import {
+  addChart,
   addPicture,
   addShape,
+  addTable,
   addTextBox,
   asEmu,
   asHundredthPt,
@@ -25,9 +26,11 @@ import {
   asOoxmlPercent,
   asPt,
   createPptx,
+  type AddChartInput,
   type AddTextBoxGradientFillInput,
   type AddShapeInput,
   type AddPictureInput,
+  type AddTableInput,
   type AddTextBoxInput,
   type AddTextBoxParagraphInput,
   type AddTextBoxRunPropertiesInput,
@@ -36,8 +39,11 @@ import {
   type PptxSourceModel,
   type PptxSourceModelAddPictureEdit,
   type PptxSourceModelAddShapeEdit,
+  type PptxSourceModelAddChartEdit,
+  type PptxSourceModelAddTableEdit,
   type PptxSourceModelAddTextBoxEdit,
   readPptx,
+  writePptx,
 } from "@pptx-glimpse/document";
 import type {
   BorderStyle,
@@ -67,6 +73,8 @@ type XmlTransform = (xml: string) => string;
 const MARKER_PREFIX = "pom-text:";
 const SHAPE_MARKER_PREFIX = "pom-shape:";
 const PICTURE_MARKER_PREFIX = "pom-picture:";
+const TABLE_MARKER_PREFIX = "pom-table:";
+const CHART_MARKER_PREFIX = "pom-chart:";
 const SLIDE_BACKGROUND_MARKER_BASE = 0x0f7a3d;
 const HYPERLINK_REL_TYPE =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
@@ -688,6 +696,30 @@ interface RegisteredPicture {
   shadow?: ShadowStyle;
 }
 
+interface RegisteredTable {
+  kind: "table";
+  marker: string;
+  name: string;
+  input: AddTableInput;
+  runProperties?: readonly TableRunCompatibility[];
+}
+
+export type TableRunCompatibility = {
+  strike?: boolean;
+  baseline?: "subscript" | "superscript";
+  highlight?: string;
+  underlineStyle?: string;
+  underlineColor?: string;
+};
+
+interface RegisteredChart {
+  kind: "chart";
+  marker: string;
+  name: string;
+  input: AddChartInput;
+  pointColors?: readonly string[];
+}
+
 interface RegisteredSlideBackground {
   kind: "slideBackground";
   marker: string;
@@ -696,13 +728,19 @@ interface RegisteredSlideBackground {
 }
 
 type RegisteredDrawing =
-  RegisteredTextBox | RegisteredPicture | RegisteredSlideBackground;
+  | RegisteredTextBox
+  | RegisteredPicture
+  | RegisteredTable
+  | RegisteredChart
+  | RegisteredSlideBackground;
 
 export class GlimpseTextBoxRegistry {
   private readonly registered: RegisteredDrawing[] = [];
   private textCount = 0;
   private shapeCount = 0;
   private pictureCount = 0;
+  private tableCount = 0;
+  private chartCount = 0;
   private slideBackgroundCount = 0;
 
   register(node: TextPositionedNode): string {
@@ -761,6 +799,43 @@ export class GlimpseTextBoxRegistry {
       name,
       input: { ...input, name },
       shadow: options?.shadow,
+    });
+    return marker;
+  }
+
+  registerTable(
+    input: AddTableInput,
+    options?: {
+      name?: string;
+      runProperties?: readonly TableRunCompatibility[];
+    },
+  ): string {
+    const index = this.tableCount++;
+    const marker = `${TABLE_MARKER_PREFIX}${index}`;
+    const name = options?.name ?? `Table ${index + 1}`;
+    this.registered.push({
+      kind: "table",
+      marker,
+      name,
+      input: { ...input, name },
+      runProperties: options?.runProperties,
+    });
+    return marker;
+  }
+
+  registerChart(
+    input: AddChartInput,
+    options?: { name?: string; pointColors?: readonly string[] },
+  ): string {
+    const index = this.chartCount++;
+    const marker = `${CHART_MARKER_PREFIX}${index}`;
+    const name = options?.name ?? `Chart ${index + 1}`;
+    this.registered.push({
+      kind: "chart",
+      marker,
+      name,
+      input: { ...input, name },
+      pointColors: options?.pointColors,
     });
     return marker;
   }
@@ -882,6 +957,395 @@ function withHyperlinkRelationships(
 
 function findSlideHandle(source: PptxSourceModel, slidePath: string) {
   return source.slides.find((slide) => slide.partPath === slidePath)?.handle;
+}
+
+type AddedGraphicFrame = {
+  marker: string;
+  name: string;
+  slidePath: string;
+  xml: string;
+  chartPartPath?: PartPath;
+  chartInput?: AddChartInput;
+  pointColors?: readonly string[];
+};
+
+function withPptxGenTableDefaults(
+  xml: string,
+  runProperties: readonly TableRunCompatibility[] | undefined,
+): string {
+  let runIndex = 0;
+  return xml
+    .replace(/<a:tblPr\b[^>]*>[\s\S]*?<\/a:tblPr>/, "<a:tblPr/>")
+    .replace(
+      /<a:tcPr(?=[\s/>])/g,
+      '<a:tcPr marL="0" marR="0" marT="0" marB="0"',
+    )
+    .replace(
+      /<a:rPr\b([^>]*?)(?:\/>|>([\s\S]*?)<\/a:rPr>)/g,
+      (_match, rawAttrs: string, rawBody: string | undefined) => {
+        const compatibility = runProperties?.[runIndex++];
+        if (!compatibility) return _match;
+        let attrs = rawAttrs;
+        const setAttr = (name: string, value: string) => {
+          const pattern = new RegExp(`\\s${name}="[^"]*"`);
+          attrs = pattern.test(attrs)
+            ? attrs.replace(pattern, ` ${name}="${value}"`)
+            : `${attrs} ${name}="${value}"`;
+        };
+        if (compatibility.strike) setAttr("strike", "sngStrike");
+        if (compatibility.baseline === "subscript")
+          setAttr("baseline", "-40000");
+        if (compatibility.baseline === "superscript")
+          setAttr("baseline", "30000");
+        if (compatibility.underlineStyle) {
+          setAttr("u", compatibility.underlineStyle);
+        }
+        let body = rawBody ?? "";
+        if (compatibility.underlineColor) {
+          body += `<a:uFill><a:solidFill><a:srgbClr val="${cleanHex(compatibility.underlineColor)}"/></a:solidFill></a:uFill>`;
+        }
+        if (compatibility.highlight) {
+          body += `<a:highlight><a:srgbClr val="${cleanHex(compatibility.highlight)}"/></a:highlight>`;
+        }
+        return body ? `<a:rPr${attrs}>${body}</a:rPr>` : `<a:rPr${attrs}/>`;
+      },
+    )
+    .replace(
+      /<a:tcPr\b([^>]*)>([\s\S]*?)<\/a:tcPr>/g,
+      (_match, attrs: string, body: string) => {
+        const borders =
+          body.match(/<a:ln(?:L|R|T|B)\b[\s\S]*?<\/a:ln(?:L|R|T|B)>/g) ?? [];
+        if (borders.length === 0) return _match;
+        const bodyWithoutBorders = body.replace(
+          /<a:ln(?:L|R|T|B)\b[\s\S]*?<\/a:ln(?:L|R|T|B)>/g,
+          "",
+        );
+        return `<a:tcPr${attrs}>${borders.join("")}${bodyWithoutBorders}</a:tcPr>`;
+      },
+    );
+}
+
+const CHART_AXIS_LINE_XML =
+  '<c:spPr><a:ln w="12700" cap="flat"><a:solidFill><a:srgbClr val="888888"/></a:solidFill><a:prstDash val="solid"/><a:round/></a:ln></c:spPr>';
+const CHART_AXIS_TEXT_XML =
+  '<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200" b="0" i="0" u="none" strike="noStrike"><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>';
+const CHART_NO_FILL_XML =
+  "<c:spPr><a:noFill/><a:ln><a:noFill/></a:ln><a:effectLst/></c:spPr>";
+const CHART_TRANSPARENT_FILL_XML =
+  '<c:spPr><a:solidFill><a:srgbClr val="FFFFFF"><a:alpha val="0"/></a:srgbClr></a:solidFill><a:ln w="12700" cap="flat"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:ln><a:effectLst/></c:spPr>';
+const CHART_HIDDEN_AXIS_LINE_XML =
+  '<c:spPr><a:ln w="12700" cap="flat"><a:noFill/><a:prstDash val="solid"/><a:round/></a:ln></c:spPr>';
+
+function withPptxGenChartDefaults(
+  xml: string,
+  input: AddChartInput,
+  pointColors: readonly string[] | undefined,
+): string {
+  const isSparkline = input.plotLayout !== undefined;
+  const chartAreaShape = isSparkline
+    ? CHART_TRANSPARENT_FILL_XML
+    : CHART_NO_FILL_XML;
+  let result = xml
+    .replace(/<c:lang\b[^>]*\/>/, "")
+    .replace('<c:dispBlanksAs val="gap"/>', '<c:dispBlanksAs val="span"/>')
+    .replace(/(<c:legend>.*?)<c:layout\/>/g, "$1")
+    .replace("</c:plotArea>", `${chartAreaShape}</c:plotArea>`)
+    .replace(
+      "</c:chart><c:externalData",
+      `</c:chart>${chartAreaShape}<c:externalData`,
+    );
+  if (!isSparkline) {
+    result = result.replace(
+      '<c:roundedCorners val="0"/>',
+      '<c:roundedCorners val="1"/>',
+    );
+  }
+
+  if (input.title !== undefined) {
+    result = result.replace(/<c:title>[\s\S]*?<\/c:title>/, (titleXml) =>
+      titleXml
+        .replace(
+          "<a:p><a:r>",
+          '<a:p><a:pPr><a:defRPr sz="1800" b="0" i="0" u="none" strike="noStrike"><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:pPr><a:r>',
+        )
+        .replace(
+          /<a:rPr\b[^>]*\/>/,
+          '<a:rPr sz="1800" b="0" i="0" u="none" strike="noStrike"><a:solidFill><a:srgbClr val="000000"/></a:solidFill><a:latin typeface="Arial"/></a:rPr>',
+        ),
+    );
+  }
+
+  if (isSparkline) {
+    result = result.replace(
+      '<c:xMode val="factor"/><c:yMode val="factor"/><c:wMode val="factor"/><c:hMode val="factor"/>',
+      '<c:xMode val="edge"/><c:yMode val="edge"/>',
+    );
+    result = withPptxGenChartAxisDefaults(result, "catAx", true, true);
+    result = withPptxGenChartAxisDefaults(result, "valAx", false, true);
+  } else {
+    result = withPptxGenChartAxisDefaults(result, "catAx", true, false);
+    result = withPptxGenChartAxisDefaults(result, "valAx", false, false);
+  }
+
+  let seriesIndex = 0;
+  result = result.replace(
+    /<c:ser>([\s\S]*?)<\/c:ser>/g,
+    (_match, body: string) => {
+      const color = cleanHex(input.series[seriesIndex]?.color) ?? "C0504D";
+      seriesIndex += 1;
+      let seriesBody = body;
+      const solidFill = `<a:solidFill><a:srgbClr val="${color}"/></a:solidFill>`;
+      const seriesShape =
+        input.chartType === "pie" || input.chartType === "doughnut"
+          ? '<c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill><a:ln w="9525" cap="flat"><a:solidFill><a:srgbClr val="F9F9F9"/></a:solidFill><a:prstDash val="solid"/><a:round/></a:ln><a:effectLst/></c:spPr>'
+          : input.chartType === "line" || input.chartType === "radar"
+            ? `<c:spPr>${solidFill}<a:ln w="25400" cap="flat">${solidFill}<a:prstDash val="solid"/><a:round/></a:ln><a:effectLst/></c:spPr>`
+            : `<c:spPr>${solidFill}<a:effectLst/></c:spPr>`;
+      seriesBody = seriesBody.replace(
+        /<c:spPr>[\s\S]*?<\/c:spPr>/,
+        seriesShape,
+      );
+      if (input.chartType === "line" || input.chartType === "radar") {
+        const markerShape = `<c:marker><c:symbol val="circle"/><c:size val="6"/><c:spPr>${solidFill}<a:ln w="9525" cap="flat">${solidFill}<a:prstDash val="solid"/><a:round/></a:ln><a:effectLst/></c:spPr></c:marker>`;
+        seriesBody = seriesBody.replace(
+          /<c:marker>[\s\S]*?<\/c:marker>/,
+          markerShape,
+        );
+      }
+      return `<c:ser>${seriesBody}</c:ser>`;
+    },
+  );
+  if (
+    pointColors?.length &&
+    (input.chartType === "pie" || input.chartType === "doughnut")
+  ) {
+    const points = pointColors
+      .map(
+        (color, index) =>
+          `<c:dPt><c:idx val="${index}"/><c:bubble3D val="0"/><c:spPr><a:solidFill><a:srgbClr val="${cleanHex(color)}"/></a:solidFill><a:effectLst/></c:spPr></c:dPt>`,
+      )
+      .join("");
+    result = result.replace(/(<c:ser>[\s\S]*?<\/c:spPr>)/, `$1${points}`);
+  }
+  return result;
+}
+
+function withPptxGenChartAxisDefaults(
+  xml: string,
+  tag: "catAx" | "valAx",
+  category: boolean,
+  hidden: boolean,
+): string {
+  return xml.replace(
+    new RegExp(`<c:${tag}>([\\s\\S]*?)</c:${tag}>`),
+    (_match, rawBody: string) => {
+      let body = rawBody
+        .replace(
+          '<c:majorTickMark val="none"/>',
+          '<c:majorTickMark val="out"/>',
+        )
+        .replace(
+          /<c:tickLblPos val="[^"]+"\/>/,
+          `<c:tickLblPos val="${category ? "low" : "nextTo"}"/>`,
+        )
+        .replace(
+          '<c:numFmt formatCode="General" sourceLinked="1"/>',
+          `<c:numFmt formatCode="General" sourceLinked="${category ? 1 : 0}"/>`,
+        )
+        .replace(
+          /<c:spPr><a:ln><a:noFill\/><\/a:ln><\/c:spPr>/,
+          hidden ? CHART_HIDDEN_AXIS_LINE_XML : "",
+        );
+      if (tag === "valAx") {
+        body = body.replace(
+          "<c:majorGridlines/>",
+          `<c:majorGridlines>${CHART_AXIS_LINE_XML}</c:majorGridlines>`,
+        );
+      }
+      body = body.replace(
+        "<c:crossAx",
+        `${hidden ? "" : CHART_AXIS_LINE_XML}${CHART_AXIS_TEXT_XML}<c:crossAx`,
+      );
+      if (category) {
+        body = body
+          .replace(/<c:lblOffset\b[^>]*\/>/, "")
+          .replace("</c:catAx>", "</c:catAx>");
+        body += '<c:noMultiLvlLbl val="1"/>';
+      }
+      return `<c:${tag}>${body}</c:${tag}>`;
+    },
+  );
+}
+
+function markerShapePattern(marker: string): RegExp {
+  return new RegExp(
+    `<p:sp><p:nvSpPr><p:cNvPr id="([^"]+)" name="${escapeRegExp(
+      marker,
+    )}"[\\s\\S]*?</p:sp>`,
+  );
+}
+
+async function addGlimpseGraphicFrames(
+  data: Uint8Array | ArrayBuffer,
+  registry: GlimpseTextBoxRegistry,
+): Promise<Uint8Array> {
+  const entries = registry.entries.filter(
+    (entry): entry is RegisteredTable | RegisteredChart =>
+      entry.kind === "table" || entry.kind === "chart",
+  );
+  if (entries.length === 0) {
+    return data instanceof Uint8Array ? data : new Uint8Array(data);
+  }
+
+  const JSZip = await loadJSZip();
+  const inputZip = await JSZip.loadAsync(data);
+  const slidePaths = Object.keys(inputZip.files).filter((path) =>
+    /^ppt\/slides\/slide\d+\.xml$/.test(path),
+  );
+  const slideXmlByPath = new Map<string, string>();
+  for (const path of slidePaths) {
+    const file = inputZip.file(path);
+    if (file) slideXmlByPath.set(path, await file.async("text"));
+  }
+
+  let source = readPptx(
+    data instanceof Uint8Array ? data : new Uint8Array(data),
+  );
+  const added: AddedGraphicFrame[] = [];
+  for (const entry of entries) {
+    const slidePath = slidePaths.find((path) =>
+      markerShapePattern(entry.marker).test(slideXmlByPath.get(path) ?? ""),
+    );
+    if (!slidePath) {
+      throw new Error(`graphic frame marker was not found: ${entry.marker}`);
+    }
+    const slideHandle = findSlideHandle(source, slidePath);
+    if (!slideHandle) {
+      throw new Error(`slide handle was not found: ${slidePath}`);
+    }
+    source =
+      entry.kind === "table"
+        ? addTable(source, slideHandle, entry.input)
+        : addChart(source, slideHandle, entry.input);
+    const edit = source.edits?.at(-1) as
+      PptxSourceModelAddTableEdit | PptxSourceModelAddChartEdit | undefined;
+    if (!edit || (edit.kind !== "addTable" && edit.kind !== "addChart")) {
+      throw new Error(`${entry.kind} did not produce an add edit`);
+    }
+    added.push({
+      marker: entry.marker,
+      name: entry.name,
+      slidePath,
+      xml:
+        entry.kind === "table"
+          ? withPptxGenTableDefaults(edit.xml, entry.runProperties)
+          : edit.xml,
+      chartPartPath: edit.kind === "addChart" ? edit.chartPartPath : undefined,
+      chartInput: entry.kind === "chart" ? entry.input : undefined,
+      pointColors: entry.kind === "chart" ? entry.pointColors : undefined,
+    });
+  }
+
+  const writtenZip = await JSZip.loadAsync(writePptx(source));
+  for (const [path, file] of Object.entries(writtenZip.files)) {
+    if (file.dir || inputZip.file(path)) continue;
+    inputZip.file(path, await file.async("uint8array"));
+  }
+  for (const entry of added) {
+    if (!entry.chartPartPath || !entry.chartInput) continue;
+    const chartFile = writtenZip.file(entry.chartPartPath);
+    if (!chartFile) {
+      throw new Error(`chart part was not found: ${entry.chartPartPath}`);
+    }
+    inputZip.file(
+      entry.chartPartPath,
+      withPptxGenChartDefaults(
+        await chartFile.async("text"),
+        entry.chartInput,
+        entry.pointColors,
+      ),
+    );
+  }
+
+  const contentTypes = inputZip.file("[Content_Types].xml");
+  const writtenContentTypes = writtenZip.file("[Content_Types].xml");
+  if (contentTypes && writtenContentTypes) {
+    inputZip.file(
+      "[Content_Types].xml",
+      mergePackageDeclarations(
+        await contentTypes.async("text"),
+        await writtenContentTypes.async("text"),
+        "Default",
+        "Extension",
+      ),
+    );
+    const current = await inputZip.file("[Content_Types].xml")!.async("text");
+    inputZip.file(
+      "[Content_Types].xml",
+      mergePackageDeclarations(
+        current,
+        await writtenContentTypes.async("text"),
+        "Override",
+        "PartName",
+      ),
+    );
+  }
+
+  for (const path of new Set(added.map((entry) => entry.slidePath))) {
+    const file = inputZip.file(path);
+    if (!file) throw new Error(`slide XML was not found: ${path}`);
+    let xml = await file.async("text");
+    for (const entry of added.filter(
+      (candidate) => candidate.slidePath === path,
+    )) {
+      const marker = markerShapePattern(entry.marker);
+      if (!marker.test(xml))
+        throw new Error(`graphic frame marker was not found: ${entry.marker}`);
+      xml = xml.replace(marker, (_match, id: string) =>
+        replaceShapeId(entry.xml, id, entry.name),
+      );
+    }
+    inputZip.file(path, xml);
+
+    const relsPath = slideRelsPath(path);
+    const rels = inputZip.file(relsPath);
+    const writtenRels = writtenZip.file(relsPath);
+    if (writtenRels) {
+      inputZip.file(
+        relsPath,
+        mergePackageDeclarations(
+          rels
+            ? await rels.async("text")
+            : createRelationshipEditor(undefined).result.xml,
+          await writtenRels.async("text"),
+          "Relationship",
+          "Id",
+        ),
+      );
+    }
+  }
+  return inputZip.generateAsync({ type: "uint8array" });
+}
+
+function mergePackageDeclarations(
+  target: string,
+  source: string,
+  tag: "Default" | "Override" | "Relationship",
+  key: "Extension" | "PartName" | "Id",
+): string {
+  let result = target;
+  const closeTag = tag === "Relationship" ? "Relationships" : "Types";
+  const entries = source.match(new RegExp(`<${tag}\\b[^>]*/>`, "g")) ?? [];
+  for (const entry of entries) {
+    const value = entry.match(new RegExp(`\\b${key}="([^"]+)"`))?.[1];
+    if (!value) continue;
+    const exists = new RegExp(
+      `<${tag}\\b[^>]*\\b${key}="${escapeRegExp(value)}"`,
+    ).test(result);
+    if (!exists)
+      result = result.replace(`</${closeTag}>`, `${entry}</${closeTag}>`);
+  }
+  return result;
 }
 
 function findMediaPart(source: PptxSourceModel, partPath: PartPath): MediaPart {
@@ -1046,6 +1510,7 @@ async function applyGlimpseTextBoxes(
   data: Uint8Array | ArrayBuffer,
   registry: GlimpseTextBoxRegistry,
 ): Promise<import("jszip")> {
+  data = await addGlimpseGraphicFrames(data, registry);
   const JSZip = await loadJSZip();
   const zip = await JSZip.loadAsync(data);
   const hasPictures = registry.entries.some(

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -702,6 +702,7 @@ interface RegisteredTable {
   name: string;
   input: AddTableInput;
   runProperties?: readonly TableRunCompatibility[];
+  borderDash?: string;
 }
 
 export type TableRunCompatibility = {
@@ -808,6 +809,7 @@ export class GlimpseTextBoxRegistry {
     options?: {
       name?: string;
       runProperties?: readonly TableRunCompatibility[];
+      borderDash?: string;
     },
   ): string {
     const index = this.tableCount++;
@@ -819,6 +821,7 @@ export class GlimpseTextBoxRegistry {
       name,
       input: { ...input, name },
       runProperties: options?.runProperties,
+      borderDash: options?.borderDash,
     });
     return marker;
   }
@@ -972,6 +975,7 @@ type AddedGraphicFrame = {
 function withPptxGenTableDefaults(
   xml: string,
   runProperties: readonly TableRunCompatibility[] | undefined,
+  borderDash: string | undefined,
 ): string {
   let runIndex = 0;
   return xml
@@ -1001,11 +1005,19 @@ function withPptxGenTableDefaults(
           setAttr("u", compatibility.underlineStyle);
         }
         let body = rawBody ?? "";
-        if (compatibility.underlineColor) {
-          body += `<a:uFill><a:solidFill><a:srgbClr val="${cleanHex(compatibility.underlineColor)}"/></a:solidFill></a:uFill>`;
-        }
+        let compatibilityChildren = "";
         if (compatibility.highlight) {
-          body += `<a:highlight><a:srgbClr val="${cleanHex(compatibility.highlight)}"/></a:highlight>`;
+          compatibilityChildren += `<a:highlight><a:srgbClr val="${cleanHex(compatibility.highlight)}"/></a:highlight>`;
+        }
+        if (compatibility.underlineColor) {
+          compatibilityChildren += `<a:uFill><a:solidFill><a:srgbClr val="${cleanHex(compatibility.underlineColor)}"/></a:solidFill></a:uFill>`;
+        }
+        if (compatibilityChildren) {
+          const lateChild =
+            /<a:(?:latin|ea|cs|sym|hlinkClick|hlinkMouseOver|rtl)\b/;
+          body = lateChild.test(body)
+            ? body.replace(lateChild, `${compatibilityChildren}$&`)
+            : `${body}${compatibilityChildren}`;
         }
         return body ? `<a:rPr${attrs}>${body}</a:rPr>` : `<a:rPr${attrs}/>`;
       },
@@ -1022,6 +1034,10 @@ function withPptxGenTableDefaults(
         );
         return `<a:tcPr${attrs}>${borders.join("")}${bodyWithoutBorders}</a:tcPr>`;
       },
+    )
+    .replace(
+      /<a:prstDash val="[^"]+"\/>/g,
+      borderDash ? `<a:prstDash val="${xmlAttr(borderDash)}"/>` : "$&",
     );
 }
 
@@ -1115,14 +1131,11 @@ function withPptxGenChartDefaults(
       return `<c:ser>${seriesBody}</c:ser>`;
     },
   );
-  if (
-    pointColors?.length &&
-    (input.chartType === "pie" || input.chartType === "doughnut")
-  ) {
+  if (pointColors?.length) {
     const points = pointColors
       .map(
         (color, index) =>
-          `<c:dPt><c:idx val="${index}"/><c:bubble3D val="0"/><c:spPr><a:solidFill><a:srgbClr val="${cleanHex(color)}"/></a:solidFill><a:effectLst/></c:spPr></c:dPt>`,
+          `<c:dPt><c:idx val="${index}"/>${input.chartType === "bar" ? '<c:invertIfNegative val="0"/>' : ""}<c:bubble3D val="0"/><c:spPr><a:solidFill><a:srgbClr val="${cleanHex(color)}"/></a:solidFill><a:effectLst/></c:spPr></c:dPt>`,
       )
       .join("");
     result = result.replace(/(<c:ser>[\s\S]*?<\/c:spPr>)/, `$1${points}`);
@@ -1238,7 +1251,11 @@ async function addGlimpseGraphicFrames(
       slidePath,
       xml:
         entry.kind === "table"
-          ? withPptxGenTableDefaults(edit.xml, entry.runProperties)
+          ? withPptxGenTableDefaults(
+              edit.xml,
+              entry.runProperties,
+              entry.borderDash,
+            )
           : edit.xml,
       chartPartPath: edit.kind === "addChart" ? edit.chartPartPath : undefined,
       chartInput: entry.kind === "chart" ? entry.input : undefined,

--- a/packages/pom/src/renderPptx/glimpseTextBoxes.ts
+++ b/packages/pom/src/renderPptx/glimpseTextBoxes.ts
@@ -1036,6 +1036,19 @@ function withPptxGenTableDefaults(
       },
     )
     .replace(
+      /<a:r>(<a:rPr\b(?:[^>]*\/>|[^>]*>[\s\S]*?<\/a:rPr>))<a:t([^>]*)>([\s\S]*?)<\/a:t><\/a:r>/g,
+      (match, runPropertiesXml: string, textAttrs: string, text: string) => {
+        const segments = text.split(/\r?\n|&#x?0*A;/i);
+        if (segments.length === 1) return match;
+        return segments
+          .map(
+            (segment, index) =>
+              `${index === 0 ? "" : "<a:br/>"}<a:r>${runPropertiesXml}<a:t${textAttrs}>${segment}</a:t></a:r>`,
+          )
+          .join("");
+      },
+    )
+    .replace(
       /<a:prstDash val="[^"]+"\/>/g,
       borderDash ? `<a:prstDash val="${xmlAttr(borderDash)}"/>` : "$&",
     );

--- a/packages/pom/src/renderPptx/nodes/chart.ts
+++ b/packages/pom/src/renderPptx/nodes/chart.ts
@@ -59,6 +59,7 @@ export function renderChartNode(
       node.chartType === "area");
 
   const content = getContentArea(node);
+  const series = normalizeChartSeries(node.data);
   const chartColors =
     node.chartColors ??
     (node.chartType === "pie" || node.chartType === "doughnut"
@@ -79,17 +80,20 @@ export function renderChartNode(
   const marker = ctx.buildContext.glimpseTextBoxes.registerChart(
     {
       chartType: node.chartType,
-      series: node.data.map((series, index) => ({
-        name: series.name,
-        categories: series.labels,
-        values: series.values,
+      series: series.map((item, index) => ({
+        name: item.name,
+        categories: item.labels,
+        values: item.values,
         color: chartColors[index % chartColors.length],
       })),
       offsetX: asEmu(Math.round(pxToEmu(content.x))),
       offsetY: asEmu(Math.round(pxToEmu(content.y))),
-      width: asEmu(Math.round(pxToEmu(content.w))),
-      height: asEmu(Math.round(pxToEmu(content.h))),
-      title: !isSparkline && node.showTitle ? node.title : undefined,
+      width: asEmu(Math.round(pxToEmu(Math.max(content.w, 1)))),
+      height: asEmu(Math.round(pxToEmu(Math.max(content.h, 1)))),
+      title:
+        !isSparkline && node.showTitle
+          ? node.title || "Chart Title"
+          : undefined,
       showLegend: isSparkline ? false : (node.showLegend ?? false),
       radarStyle: node.chartType === "radar" ? node.radarStyle : undefined,
       categoryAxis: isSparkline
@@ -103,4 +107,31 @@ export function renderChartNode(
     { pointColors },
   );
   addGlimpseGraphicFrameMarker(ctx, marker, content);
+}
+
+/**
+ * glimpse の native writer は全系列で同じ category 軸と同じ点数を要求する。
+ * pptxgenjs が受理していた不揃いな入力も生成を継続できるよう、位置ベースで
+ * category を共有し、欠けた値を 0 で補う。
+ */
+function normalizeChartSeries(data: ChartPositionedNode["data"]) {
+  const pointCount = Math.max(
+    0,
+    ...data.flatMap((series) => [series.labels.length, series.values.length]),
+  );
+  const categories = Array.from(
+    { length: pointCount },
+    (_, index) =>
+      data.find((series) => series.labels[index] !== undefined)?.labels[
+        index
+      ] ?? "",
+  );
+  return data.map((series) => ({
+    name: series.name,
+    labels: categories,
+    values: Array.from(
+      { length: pointCount },
+      (_, index) => series.values[index] ?? 0,
+    ),
+  }));
 }

--- a/packages/pom/src/renderPptx/nodes/chart.ts
+++ b/packages/pom/src/renderPptx/nodes/chart.ts
@@ -14,8 +14,27 @@ const DEFAULT_BAR_CHART_COLORS = [
   "8064A2",
   "4BACC6",
   "F79646",
+  "628FC6",
+  "C86360",
+  "C0504D",
+  "4F81BD",
+  "9BBB59",
+  "8064A2",
+  "4BACC6",
+  "F79646",
+  "628FC6",
+  "C86360",
 ];
 const DEFAULT_PIE_CHART_COLORS = [
+  "5DA5DA",
+  "FAA43A",
+  "60BD68",
+  "F17CB0",
+  "B2912F",
+  "B276B2",
+  "DECF3F",
+  "F15854",
+  "A7A7A7",
   "5DA5DA",
   "FAA43A",
   "60BD68",
@@ -45,6 +64,18 @@ export function renderChartNode(
     (node.chartType === "pie" || node.chartType === "doughnut"
       ? DEFAULT_PIE_CHART_COLORS
       : DEFAULT_BAR_CHART_COLORS);
+  const pointColors =
+    chartColors.length > 0 &&
+    (node.chartType === "pie" ||
+      node.chartType === "doughnut" ||
+      (node.chartType === "bar" &&
+        node.data.length === 1 &&
+        node.chartColors !== undefined &&
+        node.chartColors.length > 1))
+      ? node.data[0]?.values.map(
+          (_value, index) => chartColors[index % chartColors.length],
+        )
+      : undefined;
   const marker = ctx.buildContext.glimpseTextBoxes.registerChart(
     {
       chartType: node.chartType,
@@ -69,7 +100,7 @@ export function renderChartNode(
         : undefined,
       plotLayout: isSparkline ? { x: 0, y: 0, width: 1, height: 1 } : undefined,
     },
-    { pointColors: chartColors },
+    { pointColors },
   );
   addGlimpseGraphicFrameMarker(ctx, marker, content);
 }

--- a/packages/pom/src/renderPptx/nodes/chart.ts
+++ b/packages/pom/src/renderPptx/nodes/chart.ts
@@ -115,18 +115,22 @@ export function renderChartNode(
  * category を共有し、欠けた値を 0 で補う。
  */
 function normalizeChartSeries(data: ChartPositionedNode["data"]) {
+  const sourceData = data.length > 0 ? data : [{ labels: [], values: [] }];
   const pointCount = Math.max(
-    0,
-    ...data.flatMap((series) => [series.labels.length, series.values.length]),
+    1,
+    ...sourceData.flatMap((series) => [
+      series.labels.length,
+      series.values.length,
+    ]),
   );
   const categories = Array.from(
     { length: pointCount },
     (_, index) =>
-      data.find((series) => series.labels[index] !== undefined)?.labels[
+      sourceData.find((series) => series.labels[index] !== undefined)?.labels[
         index
       ] ?? "",
   );
-  return data.map((series) => ({
+  return sourceData.map((series) => ({
     name: series.name,
     labels: categories,
     values: Array.from(

--- a/packages/pom/src/renderPptx/nodes/chart.ts
+++ b/packages/pom/src/renderPptx/nodes/chart.ts
@@ -1,19 +1,36 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { getContentAreaIn } from "../utils/contentArea.ts";
+import { asEmu } from "@pptx-glimpse/document";
+import { pxToEmu } from "../units.ts";
+import { getContentArea } from "../utils/contentArea.ts";
+import { addGlimpseGraphicFrameMarker } from "../utils/glimpseGraphicFrame.ts";
 
 type ChartPositionedNode = Extract<PositionedNode, { type: "chart" }>;
+
+const DEFAULT_BAR_CHART_COLORS = [
+  "C0504D",
+  "4F81BD",
+  "9BBB59",
+  "8064A2",
+  "4BACC6",
+  "F79646",
+];
+const DEFAULT_PIE_CHART_COLORS = [
+  "5DA5DA",
+  "FAA43A",
+  "60BD68",
+  "F17CB0",
+  "B2912F",
+  "B276B2",
+  "DECF3F",
+  "F15854",
+  "A7A7A7",
+];
 
 export function renderChartNode(
   node: ChartPositionedNode,
   ctx: RenderContext,
 ): void {
-  const chartData = node.data.map((d) => ({
-    name: d.name,
-    labels: d.labels,
-    values: d.values,
-  }));
-
   // sparkline モードは bar / line / area のみ対応。pie / doughnut / radar は
   // 元々凡例 / 軸の概念が異なるため sparkline=true でも通常描画にフォールバックする。
   const isSparkline =
@@ -22,41 +39,37 @@ export function renderChartNode(
       node.chartType === "line" ||
       node.chartType === "area");
 
-  const chartOptions: Record<string, unknown> = {
-    ...getContentAreaIn(node),
-    showLegend: isSparkline ? false : (node.showLegend ?? false),
-    showTitle: isSparkline ? false : (node.showTitle ?? false),
-    title: isSparkline ? undefined : node.title,
-    chartColors: node.chartColors,
-  };
-
-  // radar専用オプション
-  if (node.chartType === "radar" && node.radarStyle) {
-    chartOptions.radarStyle = node.radarStyle;
-  }
-
-  // sparkline モード: 凡例 / 軸 / グリッド線 / マージンをすべて非表示にし、
-  // プロット領域をチャート領域いっぱいに広げて小寸法でも視認できるようにする
-  if (isSparkline) {
-    chartOptions.catAxisHidden = true;
-    chartOptions.valAxisHidden = true;
-    chartOptions.catAxisLineShow = false;
-    chartOptions.valAxisLineShow = false;
-    chartOptions.showCatAxisTitle = false;
-    chartOptions.showValAxisTitle = false;
-    chartOptions.catGridLine = { style: "none" };
-    chartOptions.valGridLine = { style: "none" };
-    chartOptions.chartArea = {
-      fill: { type: "solid", color: "FFFFFF", transparency: 100 },
-      border: { color: "FFFFFF", pt: 0 },
-      roundedCorners: false,
-    };
-    chartOptions.plotArea = {
-      fill: { type: "solid", color: "FFFFFF", transparency: 100 },
-      border: { color: "FFFFFF", pt: 0 },
-    };
-    chartOptions.layout = { x: 0, y: 0, w: 1, h: 1 };
-  }
-
-  ctx.slide.addChart(node.chartType, chartData, chartOptions);
+  const content = getContentArea(node);
+  const chartColors =
+    node.chartColors ??
+    (node.chartType === "pie" || node.chartType === "doughnut"
+      ? DEFAULT_PIE_CHART_COLORS
+      : DEFAULT_BAR_CHART_COLORS);
+  const marker = ctx.buildContext.glimpseTextBoxes.registerChart(
+    {
+      chartType: node.chartType,
+      series: node.data.map((series, index) => ({
+        name: series.name,
+        categories: series.labels,
+        values: series.values,
+        color: chartColors[index % chartColors.length],
+      })),
+      offsetX: asEmu(Math.round(pxToEmu(content.x))),
+      offsetY: asEmu(Math.round(pxToEmu(content.y))),
+      width: asEmu(Math.round(pxToEmu(content.w))),
+      height: asEmu(Math.round(pxToEmu(content.h))),
+      title: !isSparkline && node.showTitle ? node.title : undefined,
+      showLegend: isSparkline ? false : (node.showLegend ?? false),
+      radarStyle: node.chartType === "radar" ? node.radarStyle : undefined,
+      categoryAxis: isSparkline
+        ? { hidden: true, lineVisible: false, gridLinesVisible: false }
+        : undefined,
+      valueAxis: isSparkline
+        ? { hidden: true, lineVisible: false, gridLinesVisible: false }
+        : undefined,
+      plotLayout: isSparkline ? { x: 0, y: 0, width: 1, height: 1 } : undefined,
+    },
+    { pointColors: chartColors },
+  );
+  addGlimpseGraphicFrameMarker(ctx, marker, content);
 }

--- a/packages/pom/src/renderPptx/nodes/table.ts
+++ b/packages/pom/src/renderPptx/nodes/table.ts
@@ -14,7 +14,8 @@ import {
 import { pxToEmu, pxToPt } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
 import { addGlimpseGraphicFrameMarker } from "../utils/glimpseGraphicFrame.ts";
-import type { TableRunCompatibility } from "../glimpseTextBoxes.ts";
+import { cleanHex, type TableRunCompatibility } from "../glimpseTextBoxes.ts";
+import { resolveSubSup } from "../textOptions.ts";
 
 type TablePositionedNode = Extract<PositionedNode, { type: "table" }>;
 
@@ -27,7 +28,7 @@ export function renderTableNode(
   const border = node.cellBorder
     ? {
         width: asEmu(Math.round(pxToEmu(node.cellBorder.width ?? 1 / 0.75))),
-        color: node.cellBorder.color ?? "000000",
+        color: cleanHex(node.cellBorder.color) ?? "000000",
         dash: toTableDash(node.cellBorder.dashType),
       }
     : undefined;
@@ -42,7 +43,10 @@ export function renderTableNode(
       ),
       rows: buildTableRows(node, rowHeights, border),
     },
-    { runProperties: buildTableRunCompatibility(node) },
+    {
+      runProperties: buildTableRunCompatibility(node),
+      borderDash: node.cellBorder?.dashType,
+    },
   );
   addGlimpseGraphicFrameMarker(ctx, marker, content);
 }
@@ -55,14 +59,14 @@ function buildTableRunCompatibility(
       const runs = cell.runs?.length ? cell.runs : [{ text: cell.text }];
       return runs.map((run) => {
         const underline = run.underline ?? cell.underline;
+        const subSup = resolveSubSup(run, cell);
         return {
           strike: run.strike ?? cell.strike,
-          baseline:
-            (run.subscript ?? cell.subscript)
-              ? "subscript"
-              : (run.superscript ?? cell.superscript)
-                ? "superscript"
-                : undefined,
+          baseline: subSup.subscript
+            ? "subscript"
+            : subSup.superscript
+              ? "superscript"
+              : undefined,
           highlight: run.highlight ?? cell.highlight,
           underlineStyle:
             typeof underline === "object"
@@ -102,7 +106,7 @@ function buildTableRows(
       while (cells[columnIndex] !== undefined) columnIndex += 1;
       cells[columnIndex] = {
         runs: buildTableRuns(cell),
-        fill: cell.backgroundColor,
+        fill: cleanHex(cell.backgroundColor),
         align: cell.textAlign ?? "left",
         borders: border
           ? { top: border, right: border, bottom: border, left: border }
@@ -141,7 +145,7 @@ function buildTableRuns(
     properties: {
       fontSize: asPt(pxToPt(run.fontSize ?? cell.fontSize ?? 18)),
       fontFace: run.fontFamily ?? cell.fontFamily,
-      color: run.color ?? cell.color,
+      color: cleanHex(run.color ?? cell.color),
       bold: run.bold ?? cell.bold,
       italic: run.italic ?? cell.italic,
       underline: Boolean(run.underline ?? cell.underline),

--- a/packages/pom/src/renderPptx/nodes/table.ts
+++ b/packages/pom/src/renderPptx/nodes/table.ts
@@ -4,13 +4,17 @@ import {
   resolveColumnWidths,
   resolveRowHeights,
 } from "../../shared/tableUtils.ts";
-import { pxToIn, pxToPt, rectPxToIn } from "../units.ts";
 import {
-  convertUnderline,
-  convertStrike,
-  resolveSubSup,
-} from "../textOptions.ts";
+  asEmu,
+  asPt,
+  type AddTableCellInput,
+  type AddTableRowInput,
+  type AddTableRunInput,
+} from "@pptx-glimpse/document";
+import { pxToEmu, pxToPt } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
+import { addGlimpseGraphicFrameMarker } from "../utils/glimpseGraphicFrame.ts";
+import type { TableRunCompatibility } from "../glimpseTextBoxes.ts";
 
 type TablePositionedNode = Extract<PositionedNode, { type: "table" }>;
 
@@ -18,84 +22,138 @@ export function renderTableNode(
   node: TablePositionedNode,
   ctx: RenderContext,
 ): void {
-  const tableRows = node.rows.map((row) =>
-    row.cells.map((cell) => {
-      const cellFontFace = cell.fontFamily;
-      const cellOptions: Record<string, unknown> = {
-        fontSize: pxToPt(cell.fontSize ?? 18),
-        fontFace: cellFontFace,
-        color: cell.color,
-        bold: cell.bold,
-        italic: cell.italic,
-        underline: convertUnderline(cell.underline),
-        strike: convertStrike(cell.strike),
-        subscript: cell.subscript,
-        superscript: cell.superscript,
-        highlight: cell.highlight,
+  const content = getContentArea(node);
+  const rowHeights = resolveRowHeights(node);
+  const border = node.cellBorder
+    ? {
+        width: asEmu(Math.round(pxToEmu(node.cellBorder.width ?? 1 / 0.75))),
+        color: node.cellBorder.color ?? "000000",
+        dash: toTableDash(node.cellBorder.dashType),
+      }
+    : undefined;
+  const marker = ctx.buildContext.glimpseTextBoxes.registerTable(
+    {
+      offsetX: asEmu(Math.round(pxToEmu(content.x))),
+      offsetY: asEmu(Math.round(pxToEmu(content.y))),
+      width: asEmu(Math.round(pxToEmu(content.w))),
+      height: asEmu(Math.round(pxToEmu(content.h))),
+      columnWidths: resolveColumnWidths(node, content.w).map((width) =>
+        asEmu(Math.round(pxToEmu(width))),
+      ),
+      rows: buildTableRows(node, rowHeights, border),
+    },
+    { runProperties: buildTableRunCompatibility(node) },
+  );
+  addGlimpseGraphicFrameMarker(ctx, marker, content);
+}
+
+function buildTableRunCompatibility(
+  node: TablePositionedNode,
+): TableRunCompatibility[] {
+  return node.rows.flatMap((row) =>
+    row.cells.flatMap((cell) => {
+      const runs = cell.runs?.length ? cell.runs : [{ text: cell.text }];
+      return runs.map((run) => {
+        const underline = run.underline ?? cell.underline;
+        return {
+          strike: run.strike ?? cell.strike,
+          baseline:
+            (run.subscript ?? cell.subscript)
+              ? "subscript"
+              : (run.superscript ?? cell.superscript)
+                ? "superscript"
+                : undefined,
+          highlight: run.highlight ?? cell.highlight,
+          underlineStyle:
+            typeof underline === "object"
+              ? (underline.style ?? "sng")
+              : undefined,
+          underlineColor:
+            typeof underline === "object" ? underline.color : undefined,
+        } satisfies TableRunCompatibility;
+      });
+    }),
+  );
+}
+
+function buildTableRows(
+  node: TablePositionedNode,
+  rowHeights: number[],
+  border:
+    | {
+        width: ReturnType<typeof asEmu>;
+        color: string;
+        dash: "solid" | "dash" | "dot" | "dashDot" | undefined;
+      }
+    | undefined,
+): AddTableRowInput[] {
+  const columnCount = node.columns.length;
+  const continuationCells = new Set<string>();
+  return node.rows.map((row, rowIndex) => {
+    const cells: AddTableCellInput[] = Array.from({ length: columnCount });
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      if (continuationCells.has(`${rowIndex}:${columnIndex}`)) {
+        cells[columnIndex] = {};
+      }
+    }
+
+    let columnIndex = 0;
+    for (const cell of row.cells) {
+      while (cells[columnIndex] !== undefined) columnIndex += 1;
+      cells[columnIndex] = {
+        runs: buildTableRuns(cell),
+        fill: cell.backgroundColor,
         align: cell.textAlign ?? "left",
-        fill: cell.backgroundColor
-          ? { color: cell.backgroundColor }
+        borders: border
+          ? { top: border, right: border, bottom: border, left: border }
           : undefined,
         colspan: cell.colspan,
         rowspan: cell.rowspan,
       };
-
-      if (cell.runs && cell.runs.length > 0) {
-        const textItems = cell.runs.map((run) => {
-          const runSubSup = resolveSubSup(run, cell);
-          return {
-            text: run.text,
-            options: {
-              fontSize: pxToPt(run.fontSize ?? cell.fontSize ?? 18),
-              fontFace: run.fontFamily ?? cellFontFace,
-              color: run.color ?? cell.color,
-              bold: run.bold ?? cell.bold,
-              italic: run.italic ?? cell.italic,
-              underline: convertUnderline(run.underline ?? cell.underline),
-              strike: convertStrike(run.strike ?? cell.strike),
-              subscript: runSubSup.subscript,
-              superscript: runSubSup.superscript,
-              highlight: run.highlight ?? cell.highlight,
-              ...(run.href ? { hyperlink: { url: run.href } } : {}),
-            },
-          };
-        });
-        return {
-          text: textItems,
-          options: {
-            align: cell.textAlign ?? "left",
-            fill: cell.backgroundColor
-              ? { color: cell.backgroundColor }
-              : undefined,
-            colspan: cell.colspan,
-            rowspan: cell.rowspan,
-          },
-        };
+      const colspan = cell.colspan ?? 1;
+      const rowspan = cell.rowspan ?? 1;
+      for (let y = rowIndex; y < rowIndex + rowspan; y += 1) {
+        for (let x = columnIndex; x < columnIndex + colspan; x += 1) {
+          if (x === columnIndex && y === rowIndex) continue;
+          continuationCells.add(`${y}:${x}`);
+          if (y === rowIndex) cells[x] = {};
+        }
       }
+      columnIndex += colspan;
+    }
 
-      return {
-        text: cell.text,
-        options: cellOptions,
-      };
-    }),
-  );
-
-  const content = getContentArea(node);
-  const tableOptions: Record<string, unknown> = {
-    ...rectPxToIn(content),
-    colW: resolveColumnWidths(node, content.w).map((width) => pxToIn(width)),
-    rowH: resolveRowHeights(node).map((height) => pxToIn(height)),
-    margin: 0,
-  };
-
-  if (node.cellBorder) {
-    tableOptions.border = {
-      color: node.cellBorder.color ?? "000000",
-      pt:
-        node.cellBorder.width !== undefined ? pxToPt(node.cellBorder.width) : 1,
-      type: node.cellBorder.dashType ?? "solid",
+    if (cells.some((cell) => cell === undefined)) {
+      throw new Error("Table row does not fill the declared column grid");
+    }
+    return {
+      height: asEmu(Math.round(pxToEmu(rowHeights[rowIndex] ?? 0))),
+      cells,
     };
-  }
+  });
+}
 
-  ctx.slide.addTable(tableRows, tableOptions);
+function buildTableRuns(
+  cell: TablePositionedNode["rows"][number]["cells"][number],
+): AddTableRunInput[] {
+  const runs = cell.runs?.length ? cell.runs : [{ text: cell.text }];
+  return runs.map((run) => ({
+    text: run.text,
+    properties: {
+      fontSize: asPt(pxToPt(run.fontSize ?? cell.fontSize ?? 18)),
+      fontFace: run.fontFamily ?? cell.fontFamily,
+      color: run.color ?? cell.color,
+      bold: run.bold ?? cell.bold,
+      italic: run.italic ?? cell.italic,
+      underline: Boolean(run.underline ?? cell.underline),
+    },
+    hyperlink: run.href,
+  }));
+}
+
+function toTableDash(
+  dash: NonNullable<TablePositionedNode["cellBorder"]>["dashType"],
+): "solid" | "dash" | "dot" | "dashDot" | undefined {
+  if (dash === "solid" || dash === "dash" || dash === "dashDot") return dash;
+  if (dash === "sysDot") return "dot";
+  return dash ? "dash" : undefined;
 }

--- a/packages/pom/src/renderPptx/nodes/table.ts
+++ b/packages/pom/src/renderPptx/nodes/table.ts
@@ -36,10 +36,10 @@ export function renderTableNode(
     {
       offsetX: asEmu(Math.round(pxToEmu(content.x))),
       offsetY: asEmu(Math.round(pxToEmu(content.y))),
-      width: asEmu(Math.round(pxToEmu(content.w))),
-      height: asEmu(Math.round(pxToEmu(content.h))),
+      width: asEmu(Math.round(pxToEmu(Math.max(content.w, 1)))),
+      height: asEmu(Math.round(pxToEmu(Math.max(content.h, 1)))),
       columnWidths: resolveColumnWidths(node, content.w).map((width) =>
-        asEmu(Math.round(pxToEmu(width))),
+        asEmu(Math.round(pxToEmu(Math.max(width, 1)))),
       ),
       rows: buildTableRows(node, rowHeights, border),
     },
@@ -126,11 +126,13 @@ function buildTableRows(
       columnIndex += colspan;
     }
 
-    if (cells.some((cell) => cell === undefined)) {
-      throw new Error("Table row does not fill the declared column grid");
+    for (let index = 0; index < cells.length; index += 1) {
+      if (cells[index] === undefined) cells[index] = {};
     }
     return {
-      height: asEmu(Math.round(pxToEmu(rowHeights[rowIndex] ?? 0))),
+      height: asEmu(
+        Math.round(pxToEmu(Math.max(rowHeights[rowIndex] ?? 0, 1))),
+      ),
       cells,
     };
   });

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -1074,6 +1074,72 @@ describe("renderChartNode", () => {
     expect(chartXml).toContain('<c:h val="1"/>');
   });
 
+  it("既定 palette は pptxgenjs と同じ7色目以降も保持する", async () => {
+    const zip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "chart",
+          chartType: "bar",
+          data: Array.from({ length: 8 }, (_, index) => ({
+            name: `Series ${index + 1}`,
+            labels: ["Q1"],
+            values: [index + 1],
+          })),
+          x: 0,
+          y: 0,
+          w: 400,
+          h: 200,
+        },
+      ]),
+    );
+
+    const chartXml = await zip.file("ppt/charts/chart1.xml")!.async("text");
+    expect(chartXml).toContain('<a:srgbClr val="628FC6"/>');
+    expect(chartXml).toContain('<a:srgbClr val="C86360"/>');
+  });
+
+  it("単一系列 bar の複数色と pie の point 超過色をデータ点へ循環適用する", async () => {
+    const barZip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "chart",
+          chartType: "bar",
+          data: sampleData,
+          chartColors: ["111111", "222222"],
+          x: 0,
+          y: 0,
+          w: 400,
+          h: 200,
+        },
+      ]),
+    );
+    const pieZip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "chart",
+          chartType: "pie",
+          data: sampleData,
+          chartColors: ["333333", "444444"],
+          x: 0,
+          y: 0,
+          w: 400,
+          h: 200,
+        },
+      ]),
+    );
+
+    const barXml = await barZip.file("ppt/charts/chart1.xml")!.async("text");
+    const pieXml = await pieZip.file("ppt/charts/chart1.xml")!.async("text");
+    expect(barXml.match(/<c:dPt>/g)).toHaveLength(4);
+    expect(barXml.match(/<a:srgbClr val="111111"\/>/g)!.length).toBeGreaterThan(
+      1,
+    );
+    expect(pieXml.match(/<c:dPt>/g)).toHaveLength(4);
+    expect(pieXml.match(/<a:srgbClr val="333333"\/>/g)!.length).toBeGreaterThan(
+      1,
+    );
+  });
+
   it("sparkline=true でも pie などサポート外の chartType では通常描画にフォールバックする", async () => {
     const zip = await renderPagePptxZip(
       vstackPage([
@@ -1125,8 +1191,18 @@ describe("renderTableNode", () => {
                   text: "Header",
                   bold: true,
                   strike: true,
+                  subscript: true,
                   highlight: "FFFF00",
+                  fontFamily: "Aptos",
+                  underline: { style: "dbl", color: "#FF0000" },
                   backgroundColor: "E2E8F0",
+                  runs: [
+                    {
+                      text: "Header",
+                      superscript: true,
+                      href: "https://example.com/header",
+                    },
+                  ],
                 },
                 {
                   text: "Link",
@@ -1136,7 +1212,11 @@ describe("renderTableNode", () => {
               ],
             },
           ],
-          cellBorder: { color: "334155", width: 1 },
+          cellBorder: {
+            color: "#334155",
+            width: 1,
+            dashType: "lgDashDotDot",
+          },
         },
       ]),
     );
@@ -1151,12 +1231,28 @@ describe("renderTableNode", () => {
     expect(slideXml).toContain('<a:tr h="381000">');
     expect(slideXml).toContain('<a:rPr b="1"');
     expect(slideXml).toContain('strike="sngStrike"');
+    expect(slideXml).toContain('baseline="30000"');
+    expect(slideXml).not.toContain('baseline="-40000"');
     expect(slideXml).toContain(
       '<a:highlight><a:srgbClr val="FFFF00"/></a:highlight>',
     );
     expect(slideXml).toContain('<a:srgbClr val="E2E8F0"/>');
     expect(slideXml).toContain('<a:pPr algn="r"/>');
     expect(slideXml).toContain('<a:srgbClr val="334155"/>');
+    expect(slideXml).toContain('<a:prstDash val="lgDashDotDot"/>');
+    const firstRunProperties = slideXml.match(
+      /<a:rPr\b[^>]*>[\s\S]*?<\/a:rPr>/,
+    )?.[0];
+    expect(firstRunProperties).toBeDefined();
+    expect(firstRunProperties!.indexOf("<a:highlight>")).toBeLessThan(
+      firstRunProperties!.indexOf("<a:uFill>"),
+    );
+    expect(firstRunProperties!.indexOf("<a:uFill>")).toBeLessThan(
+      firstRunProperties!.indexOf("<a:latin"),
+    );
+    expect(firstRunProperties!.indexOf("<a:latin")).toBeLessThan(
+      firstRunProperties!.indexOf("<a:hlinkClick"),
+    );
     const firstCellProperties = slideXml.match(
       /<a:tcPr\b[\s\S]*?<\/a:tcPr>/,
     )?.[0];

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -47,6 +47,18 @@ function extractChartPointColors(chartXml: string) {
   );
 }
 
+function expectRelationship(
+  relationshipsXml: string,
+  expected: { id: string; type: string; target: string },
+) {
+  const attributes = Array.from(
+    relationshipsXml.matchAll(/<Relationship\b([^>]*)\/>/g),
+  ).find((match) => match[1]?.includes(`Id="${expected.id}"`))?.[1];
+  expect(attributes).toBeDefined();
+  expect(attributes).toContain(`Type="${expected.type}"`);
+  expect(attributes).toContain(`Target="${expected.target}"`);
+}
+
 function vstackPage(children: PositionedNode[]): PositionedNode {
   return { type: "vstack", x: 0, y: 0, w: 1280, h: 720, children };
 }
@@ -1032,9 +1044,15 @@ describe("renderChartNode", () => {
     expect(chartXml).not.toContain('<c:delete val="1"/>');
     expect(chartXml).not.toContain("<c:manualLayout>");
     expect(chartXml).toContain('<a:srgbClr val="123456"/>');
-    expect(slideRels).toContain(
-      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"',
-    );
+    const chartRelationshipId = slideXml.match(
+      /<c:chart\b[^>]*\br:id="([^"]+)"/,
+    )?.[1];
+    expect(chartRelationshipId).toBeDefined();
+    expectRelationship(slideRels, {
+      id: chartRelationshipId!,
+      type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart",
+      target: "../charts/chart1.xml",
+    });
     expect(chartRels).toContain(
       'Target="../embeddings/Microsoft_Excel_Worksheet1.xlsx"',
     );
@@ -1051,6 +1069,34 @@ describe("renderChartNode", () => {
     expect(worksheetXml).toContain("<t>Sales</t>");
     expect(worksheetXml).toContain("<t>Q1</t>");
     expect(worksheetXml).toContain("<v>100</v>");
+  });
+
+  it("不揃いな系列を共有 category 軸へ正規化し、既定タイトルと最小寸法を保持する", async () => {
+    const zip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "chart",
+          chartType: "bar",
+          data: [
+            { name: "A", labels: ["Q1", "Q2"], values: [100, 200] },
+            { name: "B", labels: ["other"], values: [300] },
+          ],
+          x: 0,
+          y: 0,
+          w: 0,
+          h: 0,
+          showTitle: true,
+        },
+      ]),
+    );
+
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+    const chartXml = await zip.file("ppt/charts/chart1.xml")!.async("text");
+    expect(slideXml).toContain('<a:ext cx="9525" cy="9525"/>');
+    expect(chartXml).toContain("<a:t>Chart Title</a:t>");
+    expect(chartXml).toContain("<c:v>Q1</c:v>");
+    expect(chartXml).toContain("<c:v>Q2</c:v>");
+    expect(chartXml).toContain("<c:v>0</c:v>");
   });
 
   it("sparkline=true のとき凡例 / 軸 / グリッド線を XML で非表示にする", async () => {
@@ -1274,9 +1320,41 @@ describe("renderTableNode", () => {
     );
     expect(slideXml).toMatch(/<a:hlinkClick r:id="rId\d+"\/>/);
     expect(slideXml).not.toContain("pom-table:");
-    expect(relsXml).toContain(
-      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"',
+    const hyperlinkRelationshipIds = Array.from(
+      slideXml.matchAll(/<a:hlinkClick r:id="([^"]+)"\/>/g),
+      (match) => match[1],
     );
+    expect(hyperlinkRelationshipIds).toHaveLength(2);
+    expectRelationship(relsXml, {
+      id: hyperlinkRelationshipIds[0],
+      type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+      target: "https://example.com/header",
+    });
+    expectRelationship(relsXml, {
+      id: hyperlinkRelationshipIds[1],
+      type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+      target: "https://example.com",
+    });
+  });
+
+  it("不足セルを空セルで補い、セル内改行を DrawingML break として保持する", async () => {
+    const slideXml = await renderPageSlideXml(
+      vstackPage([
+        {
+          type: "table",
+          x: 0,
+          y: 0,
+          w: 200,
+          h: 40,
+          columns: [{ width: 100 }, { width: 100 }],
+          rows: [{ cells: [{ text: "first\nsecond" }] }],
+        },
+      ]),
+    );
+
+    expect(slideXml.match(/<a:tc(?:\s|>)/g)).toHaveLength(2);
+    expect(slideXml).toContain("<a:t>first</a:t></a:r><a:br/>");
+    expect(slideXml).toContain("<a:t>second</a:t>");
   });
 });
 

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -13,24 +13,8 @@ import { createBuildContext } from "../buildContext.ts";
 import { patchPptxWriteForGlimpseTextBoxes } from "./glimpseTextBoxes.ts";
 import type { PositionedNode } from "../types.ts";
 
-type SlideObject = {
-  _type: string;
-  shape?: string;
-  options: Record<string, unknown>;
-  text?: unknown;
-};
-
 const ONE_BY_ONE_PNG =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lU9qJwAAAABJRU5ErkJggg==";
-
-async function renderPage(page: PositionedNode) {
-  const buildContext = createBuildContext();
-  const pptx = await renderPptx([page], { w: 1280, h: 720 }, buildContext);
-  const slides = (
-    pptx as unknown as { _slides: { _slideObjects: SlideObject[] }[] }
-  )._slides;
-  return { objects: slides[0]._slideObjects, buildContext };
-}
 
 async function renderPageSlideXml(page: PositionedNode) {
   const { slideXml } = await renderPageSlideXmlWithContext(page);
@@ -1003,8 +987,8 @@ describe("renderChartNode", () => {
     },
   ];
 
-  it("通常モードでは sparkline 関連オプションを渡さない (後方互換)", async () => {
-    const { objects } = await renderPage(
+  it("通常モードを glimpse chart XML と editable workbook で生成する", async () => {
+    const zip = await renderPagePptxZip(
       vstackPage([
         {
           type: "chart",
@@ -1017,24 +1001,52 @@ describe("renderChartNode", () => {
           showLegend: true,
           showTitle: true,
           title: "Sales",
+          chartColors: ["123456"],
         },
       ]),
     );
 
-    const chart = objects.find((o) => o._type === "chart");
-    expect(chart).toBeDefined();
-    expect(chart?.options).toMatchObject({
-      showLegend: true,
-      showTitle: true,
-      title: "Sales",
-    });
-    expect(chart?.options.catAxisHidden).toBeUndefined();
-    expect(chart?.options.valAxisHidden).toBeUndefined();
-    expect(chart?.options.layout).toBeUndefined();
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+    const chartXml = await zip.file("ppt/charts/chart1.xml")!.async("text");
+    const slideRels = await zip
+      .file("ppt/slides/_rels/slide1.xml.rels")!
+      .async("text");
+    const chartRels = await zip
+      .file("ppt/charts/_rels/chart1.xml.rels")!
+      .async("text");
+
+    expect(slideXml).toContain("<p:graphicFrame>");
+    expect(slideXml).toContain('name="Chart 1"');
+    expect(slideXml).not.toContain("pom-chart:");
+    expect(chartXml).toContain("<c:barChart>");
+    expect(chartXml).toContain("<a:t>Sales</a:t>");
+    expect(chartXml).toContain("<c:legend>");
+    expect(chartXml).toContain("<c:catAx>");
+    expect(chartXml).toContain("<c:valAx>");
+    expect(chartXml).toContain('<a:srgbClr val="123456"/>');
+    expect(slideRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"',
+    );
+    expect(chartRels).toContain(
+      'Target="../embeddings/Microsoft_Excel_Worksheet1.xlsx"',
+    );
+    const workbookFile = zip.file(
+      "ppt/embeddings/Microsoft_Excel_Worksheet1.xlsx",
+    );
+    expect(workbookFile).not.toBeNull();
+    const workbook = await JSZip.loadAsync(
+      await workbookFile!.async("uint8array"),
+    );
+    const worksheetXml = await workbook
+      .file("xl/worksheets/sheet1.xml")!
+      .async("text");
+    expect(worksheetXml).toContain("<t>Sales</t>");
+    expect(worksheetXml).toContain("<t>Q1</t>");
+    expect(worksheetXml).toContain("<v>100</v>");
   });
 
-  it("sparkline=true のとき凡例 / 軸 / マージンを非表示にする", async () => {
-    const { objects } = await renderPage(
+  it("sparkline=true のとき凡例 / 軸 / グリッド線を XML で非表示にする", async () => {
+    const zip = await renderPagePptxZip(
       vstackPage([
         {
           type: "chart",
@@ -1052,26 +1064,18 @@ describe("renderChartNode", () => {
       ]),
     );
 
-    const chart = objects.find((o) => o._type === "chart");
-    expect(chart).toBeDefined();
-    expect(chart?.options).toMatchObject({
-      showLegend: false,
-      showTitle: false,
-      catAxisHidden: true,
-      valAxisHidden: true,
-      catAxisLineShow: false,
-      valAxisLineShow: false,
-      showCatAxisTitle: false,
-      showValAxisTitle: false,
-      catGridLine: { style: "none" },
-      valGridLine: { style: "none" },
-      layout: { x: 0, y: 0, w: 1, h: 1 },
-    });
-    expect(chart?.options.title).toBeUndefined();
+    const chartXml = await zip.file("ppt/charts/chart1.xml")!.async("text");
+    expect(chartXml).not.toContain("<c:title>");
+    expect(chartXml).not.toContain("<c:legend>");
+    expect(chartXml.match(/<c:delete val="1"\/>/g)).toHaveLength(2);
+    expect(chartXml).not.toContain("<c:majorGridlines/>");
+    expect(chartXml).toContain("<c:manualLayout>");
+    expect(chartXml).toContain('<c:w val="1"/>');
+    expect(chartXml).toContain('<c:h val="1"/>');
   });
 
   it("sparkline=true でも pie などサポート外の chartType では通常描画にフォールバックする", async () => {
-    const { objects } = await renderPage(
+    const zip = await renderPagePptxZip(
       vstackPage([
         {
           type: "chart",
@@ -1087,13 +1091,84 @@ describe("renderChartNode", () => {
       ]),
     );
 
-    const chart = objects.find((o) => o._type === "chart");
-    expect(chart).toBeDefined();
-    expect(chart?.options).toMatchObject({
-      showLegend: true,
-    });
-    expect(chart?.options.catAxisHidden).toBeUndefined();
-    expect(chart?.options.layout).toBeUndefined();
+    const chartXml = await zip.file("ppt/charts/chart1.xml")!.async("text");
+    expect(chartXml).toContain("<c:pieChart>");
+    expect(chartXml).toContain("<c:legend>");
+    expect(chartXml).not.toContain("<c:manualLayout>");
+    const seriesXml = chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)?.[0];
+    expect(seriesXml).toBeDefined();
+    expect(seriesXml!.indexOf("<c:spPr>")).toBeLessThan(
+      seriesXml!.indexOf("<c:dPt>"),
+    );
+    expect(seriesXml!.indexOf("<c:dPt>")).toBeLessThan(
+      seriesXml!.indexOf("<c:cat>"),
+    );
+  });
+});
+
+describe("renderTableNode", () => {
+  it("glimpse table XML で列幅・行高・書式・罫線・hyperlink を生成する", async () => {
+    const zip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "table",
+          x: 96,
+          y: 96,
+          w: 300,
+          h: 40,
+          columns: [{ width: 100 }, { width: 200 }],
+          rows: [
+            {
+              height: 40,
+              cells: [
+                {
+                  text: "Header",
+                  bold: true,
+                  strike: true,
+                  highlight: "FFFF00",
+                  backgroundColor: "E2E8F0",
+                },
+                {
+                  text: "Link",
+                  runs: [{ text: "Link", href: "https://example.com" }],
+                  textAlign: "right",
+                },
+              ],
+            },
+          ],
+          cellBorder: { color: "334155", width: 1 },
+        },
+      ]),
+    );
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+    const relsXml = await zip
+      .file("ppt/slides/_rels/slide1.xml.rels")!
+      .async("text");
+
+    expect(slideXml).toContain("<a:tbl>");
+    expect(slideXml).toContain('<a:gridCol w="952500"/>');
+    expect(slideXml).toContain('<a:gridCol w="1905000"/>');
+    expect(slideXml).toContain('<a:tr h="381000">');
+    expect(slideXml).toContain('<a:rPr b="1"');
+    expect(slideXml).toContain('strike="sngStrike"');
+    expect(slideXml).toContain(
+      '<a:highlight><a:srgbClr val="FFFF00"/></a:highlight>',
+    );
+    expect(slideXml).toContain('<a:srgbClr val="E2E8F0"/>');
+    expect(slideXml).toContain('<a:pPr algn="r"/>');
+    expect(slideXml).toContain('<a:srgbClr val="334155"/>');
+    const firstCellProperties = slideXml.match(
+      /<a:tcPr\b[\s\S]*?<\/a:tcPr>/,
+    )?.[0];
+    expect(firstCellProperties).toBeDefined();
+    expect(firstCellProperties!.indexOf("<a:lnL")).toBeLessThan(
+      firstCellProperties!.indexOf("<a:solidFill>"),
+    );
+    expect(slideXml).toMatch(/<a:hlinkClick r:id="rId\d+"\/>/);
+    expect(slideXml).not.toContain("pom-table:");
+    expect(relsXml).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"',
+    );
   });
 });
 

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -1053,9 +1053,15 @@ describe("renderChartNode", () => {
       type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart",
       target: "../charts/chart1.xml",
     });
-    expect(chartRels).toContain(
-      'Target="../embeddings/Microsoft_Excel_Worksheet1.xlsx"',
-    );
+    const workbookRelationshipId = chartXml.match(
+      /<c:externalData\b[^>]*\br:id="([^"]+)"/,
+    )?.[1];
+    expect(workbookRelationshipId).toBeDefined();
+    expectRelationship(chartRels, {
+      id: workbookRelationshipId!,
+      type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/package",
+      target: "../embeddings/Microsoft_Excel_Worksheet1.xlsx",
+    });
     const workbookFile = zip.file(
       "ppt/embeddings/Microsoft_Excel_Worksheet1.xlsx",
     );
@@ -1098,6 +1104,32 @@ describe("renderChartNode", () => {
     expect(chartXml).toContain("<c:v>Q2</c:v>");
     expect(chartXml).toContain("<c:v>0</c:v>");
   });
+
+  it.each([
+    { data: [] },
+    { data: [{ name: "Empty", labels: [], values: [] }] },
+  ])(
+    "空の chart data %# でも native writer の最小系列へフォールバックする",
+    async ({ data }) => {
+      const zip = await renderPagePptxZip(
+        vstackPage([
+          {
+            type: "chart",
+            chartType: "bar",
+            data,
+            x: 0,
+            y: 0,
+            w: 200,
+            h: 100,
+          },
+        ]),
+      );
+
+      const chartXml = await zip.file("ppt/charts/chart1.xml")!.async("text");
+      expect(chartXml).toContain("<c:barChart>");
+      expect(chartXml).toContain('<c:ptCount val="1"/>');
+    },
+  );
 
   it("sparkline=true のとき凡例 / 軸 / グリッド線を XML で非表示にする", async () => {
     const zip = await renderPagePptxZip(

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -1,10 +1,9 @@
 /**
  * ノード renderer の出力回帰テスト。
  *
- * renderPptx に PositionedNode を直接渡し、pptxgenjs 内部の
- * _slideObjects (描画オブジェクトの位置・スタイル) を検証することで、
- * renderer 内部のリファクタリングで public な出力挙動が変わっていない
- * ことを保証する。
+ * renderPptx に PositionedNode を直接渡し、生成された OOXML、relationship、
+ * 埋め込み workbook を検証することで、renderer 内部のリファクタリングで
+ * public な出力挙動が変わっていないことを保証する。
  */
 import JSZip from "jszip";
 import { describe, expect, it, vi } from "vitest";
@@ -39,6 +38,13 @@ async function renderPageSlideXmlWithContext(page: PositionedNode) {
     slideXml: await zip.file("ppt/slides/slide1.xml")!.async("text"),
     buildContext,
   };
+}
+
+function extractChartPointColors(chartXml: string) {
+  return (chartXml.match(/<c:dPt>[\s\S]*?<\/c:dPt>/g) ?? []).map(
+    (dataPointXml) =>
+      dataPointXml.match(/<a:srgbClr val="([0-9A-F]{6})"\/>/)?.[1],
+  );
 }
 
 function vstackPage(children: PositionedNode[]): PositionedNode {
@@ -1023,6 +1029,8 @@ describe("renderChartNode", () => {
     expect(chartXml).toContain("<c:legend>");
     expect(chartXml).toContain("<c:catAx>");
     expect(chartXml).toContain("<c:valAx>");
+    expect(chartXml).not.toContain('<c:delete val="1"/>');
+    expect(chartXml).not.toContain("<c:manualLayout>");
     expect(chartXml).toContain('<a:srgbClr val="123456"/>');
     expect(slideRels).toContain(
       'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"',
@@ -1130,14 +1138,18 @@ describe("renderChartNode", () => {
 
     const barXml = await barZip.file("ppt/charts/chart1.xml")!.async("text");
     const pieXml = await pieZip.file("ppt/charts/chart1.xml")!.async("text");
-    expect(barXml.match(/<c:dPt>/g)).toHaveLength(4);
-    expect(barXml.match(/<a:srgbClr val="111111"\/>/g)!.length).toBeGreaterThan(
-      1,
-    );
-    expect(pieXml.match(/<c:dPt>/g)).toHaveLength(4);
-    expect(pieXml.match(/<a:srgbClr val="333333"\/>/g)!.length).toBeGreaterThan(
-      1,
-    );
+    expect(extractChartPointColors(barXml)).toEqual([
+      "111111",
+      "222222",
+      "111111",
+      "222222",
+    ]);
+    expect(extractChartPointColors(pieXml)).toEqual([
+      "333333",
+      "444444",
+      "333333",
+      "444444",
+    ]);
   });
 
   it("sparkline=true でも pie などサポート外の chartType では通常描画にフォールバックする", async () => {

--- a/packages/pom/src/renderPptx/utils/glimpseGraphicFrame.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseGraphicFrame.ts
@@ -1,0 +1,25 @@
+import type { RenderContext } from "../types.ts";
+import { rectPxToIn } from "../units.ts";
+
+type GraphicFrameBounds = { x: number; y: number; w: number; h: number };
+
+const TRANSPARENT_MARKER_STYLE = {
+  fill: { color: "FFFFFF", transparency: 100 },
+  line: { color: "FFFFFF", transparency: 100 },
+} as const;
+
+export function addGlimpseGraphicFrameMarker(
+  ctx: RenderContext,
+  marker: string,
+  bounds: GraphicFrameBounds,
+): void {
+  ctx.slide.addShape(ctx.pptx.ShapeType.rect, {
+    ...rectPxToIn({
+      ...bounds,
+      w: Math.max(bounds.w, 1),
+      h: Math.max(bounds.h, 1),
+    }),
+    ...TRANSPARENT_MARKER_STYLE,
+    objectName: marker,
+  });
+}


### PR DESCRIPTION
close #939

## 概要

Table / Chart の生成を pptxgenjs `addTable` / `addChart` から `@pptx-glimpse/document` 0.7.0 の native writer へ移行します。

## 変更内容

- Table / Chart を glimpse registry に登録し、生成した `p:graphicFrame` を z-order marker と差し替える処理を追加
- Chart part、relationship、embedded xlsx、content type を既存 PPTX package へ統合
- pptxgenjs と互換な Table 書式、Chart palette / sparkline / title / axis 表現を OOXML 後処理で保持
- 不揃いな chart series、空 data、ragged table row、セル内改行、ゼロ寸法などの境界入力を native writer 用に正規化
- pptxgenjs 内部 API の assertion を OOXML、relationship、埋め込み workbook の assertion へ置換
- `@hirokisakabe/pom` の minor changeset を追加

## 影響範囲

- `@hirokisakabe/pom` の PPTX render pipeline
- 他 package の public API 変更なし

## 検証

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:run`（638 passed / 3 skipped）
- `pnpm run build`
- `pnpm run lint:deps`
- `pnpm run knip`（既存の unused export のみ）
- `pnpm run vrt:docker`（55 pages、差分ゼロ）
- OpenXML SDK 検査で Table / Chart 由来の schema error がないことを確認
- Microsoft PowerPoint for Mac で focused fixture が修復ダイアログなしに開き、Table / Chart の native shape として認識されることを確認
- Chart の embedded xlsx と package relationship、worksheet data をテストで確認

## 手動確認の残り

ローカルの Microsoft 365 が未ライセンスのため、PowerPoint UI から Chart の「データの編集」を実行する確認のみ未実施です。embedded xlsx の生成と参照整合性は自動テストで確認しています。
