### PR TITLE
refactor(pom): renderPptx の authoring 状態管理と POM 変換責務を分離する

### DIFF
--- a/.changeset/tidy-slides-context.md
+++ b/.changeset/tidy-slides-context.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom": patch
+---
+
+PPTX authoring の状態管理を render 固有 context に分離し、POM style の glimpse input 変換を純粋 helper に整理しました。

--- a/packages/pom/src/buildContext.ts
+++ b/packages/pom/src/buildContext.ts
@@ -1,7 +1,6 @@
 import type { TextMeasurementMode } from "./calcYogaLayout/measureText.ts";
 import { FontRegistry, type FontInput } from "./calcYogaLayout/fontLoader.ts";
 import { DiagnosticCollector } from "./diagnostics.ts";
-import { PptxAuthoringRegistry } from "./renderPptx/pptxAuthoring.ts";
 
 export interface BuildContext {
   textMeasurementMode: TextMeasurementMode;
@@ -10,7 +9,6 @@ export interface BuildContext {
   imageDataCache: Map<string, string>;
   iconRasterCache: Map<string, string>;
   diagnostics: DiagnosticCollector;
-  pptxAuthoring: PptxAuthoringRegistry;
 }
 
 export function createBuildContext(
@@ -24,6 +22,5 @@ export function createBuildContext(
     imageDataCache: new Map(),
     iconRasterCache: new Map(),
     diagnostics: new DiagnosticCollector(),
-    pptxAuthoring: new PptxAuthoringRegistry(),
   };
 }

--- a/packages/pom/src/renderPptx/authoringContext.ts
+++ b/packages/pom/src/renderPptx/authoringContext.ts
@@ -1,0 +1,95 @@
+import {
+  addChart,
+  addPicture,
+  addShape,
+  addTable,
+  addTextBox,
+  setSlideBackground,
+  type AddChartInput,
+  type AddPictureInput,
+  type AddShapeInput,
+  type AddTableInput,
+  type AddTextBoxInput,
+  type PptxSourceModel,
+  type SourceHandle,
+} from "@pptx-glimpse/document";
+
+/** Mutable state needed only while authoring a PPTX. */
+export class PptxAuthoringContext {
+  private currentSlideHandle: SourceHandle | undefined;
+  private textCount = 0;
+  private shapeCount = 0;
+  private pictureCount = 0;
+  private tableCount = 0;
+  private chartCount = 0;
+
+  constructor(
+    private currentSource: PptxSourceModel,
+    readonly useLayoutTextMargins = false,
+  ) {
+    this.currentSlideHandle = currentSource.slides[0]?.handle;
+  }
+
+  selectTarget(handle: SourceHandle): void {
+    this.currentSlideHandle = handle;
+  }
+
+  get source(): PptxSourceModel {
+    return this.currentSource;
+  }
+
+  replaceSource(source: PptxSourceModel): void {
+    this.currentSource = source;
+  }
+
+  private get target(): SourceHandle {
+    if (!this.currentSlideHandle)
+      throw new Error("glimpse slide or master is not selected");
+    return this.currentSlideHandle;
+  }
+
+  addTextBox(input: AddTextBoxInput, name?: string): void {
+    this.currentSource = addTextBox(this.source, this.target, {
+      ...input,
+      name: name ?? `Text ${++this.textCount}`,
+    });
+  }
+
+  addShape(input: AddShapeInput, name?: string): void {
+    this.currentSource = addShape(this.source, this.target, {
+      ...input,
+      name: name ?? `Shape ${++this.shapeCount}`,
+    });
+  }
+
+  addPicture(input: AddPictureInput, name?: string): void {
+    this.currentSource = addPicture(this.source, this.target, {
+      ...input,
+      name: name ?? `Picture ${++this.pictureCount}`,
+    });
+  }
+
+  addTable(input: AddTableInput, name?: string): void {
+    this.currentSource = addTable(this.source, this.target, {
+      ...input,
+      name: name ?? `Table ${++this.tableCount}`,
+    });
+  }
+
+  addChart(input: AddChartInput, name?: string): void {
+    this.currentSource = addChart(this.source, this.target, {
+      ...input,
+      name: name ?? `Chart ${++this.chartCount}`,
+    });
+  }
+
+  setSlideBackground(
+    background: Parameters<typeof setSlideBackground>[2],
+  ): void {
+    this.currentSource = setSlideBackground(
+      this.source,
+      this.target,
+      background,
+    );
+  }
+}

--- a/packages/pom/src/renderPptx/authoringContext.ts
+++ b/packages/pom/src/renderPptx/authoringContext.ts
@@ -38,8 +38,9 @@ export class PptxAuthoringContext {
     return this.currentSource;
   }
 
-  replaceSource(source: PptxSourceModel): void {
+  replaceSource(source: PptxSourceModel, target: SourceHandle): void {
     this.currentSource = source;
+    this.currentSlideHandle = target;
   }
 
   private get target(): SourceHandle {

--- a/packages/pom/src/renderPptx/glimpseAdapter.ts
+++ b/packages/pom/src/renderPptx/glimpseAdapter.ts
@@ -1,17 +1,9 @@
 import {
-  addChart,
-  addPicture,
-  addShape,
-  addTable,
-  addTextBox,
   asEmu,
   asHundredthPt,
   asOoxmlAngle,
   asOoxmlPercent,
   asPt,
-  createPptx,
-  setSlideBackground,
-  type AddChartInput,
   type AddPictureInput,
   type AddShapeColorInput,
   type AddShapeCustomGeometryPathCommandInput,
@@ -20,13 +12,12 @@ import {
   type AddShapeGeometryInput,
   type AddShapeInput,
   type AddShapeOutlineInput,
-  type AddTableInput,
+  type AddShapeRunPropertiesInput,
+  type AddTableRunPropertiesInput,
   type AddTextBoxGradientFillInput,
   type AddTextBoxInput,
   type AddTextBoxParagraphInput,
   type AddTextBoxRunPropertiesInput,
-  type PptxSourceModel,
-  type SourceHandle,
 } from "@pptx-glimpse/document";
 import { parseGradient, parseLinearGradient } from "../shared/gradient.ts";
 import type {
@@ -40,13 +31,32 @@ import type {
 import { createTextOptions, resolveSubSup } from "./textOptions.ts";
 import { EMU_PER_IN, pxToEmu, pxToPt } from "./units.ts";
 
+/** Pure POM style / geometry conversions for glimpse authoring inputs. */
+
 type TextPositionedNode = Extract<PositionedNode, { type: "text" }>;
 
 interface GlimpseTextRun {
   text: string;
   properties: AddTextBoxRunPropertiesInput;
-  href?: string;
+  hyperlink?: string;
 }
+
+export type GlimpseTextRunStyle = {
+  fontSize?: number;
+  fontFace?: string;
+  color?: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: Underline;
+  strike?: boolean;
+  subscript?: boolean;
+  superscript?: boolean;
+  highlight?: string;
+  glow?: TextGlow;
+  outline?: TextOutline;
+  letterSpacing?: number;
+  gradientFill?: AddTextBoxGradientFillInput;
+};
 
 export function cleanHex(color: string | undefined): string | undefined {
   const hex = color?.replace(/^#/, "").toUpperCase();
@@ -142,12 +152,6 @@ function toTextGradientInput(
   };
 }
 
-function stripUndefined<T extends Record<string, unknown>>(value: T): T {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined),
-  ) as T;
-}
-
 function resolveUnderline(
   node: TextPositionedNode,
   run: NonNullable<TextPositionedNode["runs"]>[number] | undefined,
@@ -164,21 +168,67 @@ function buildRunProperties(
 ): AddTextBoxRunPropertiesInput {
   const fontSizePx = run?.fontSize ?? node.fontSize ?? 24;
   const subSup = run ? resolveSubSup(run, node) : node;
-  return stripUndefined({
-    fontFace: run?.fontFamily ?? node.fontFamily ?? "Noto Sans JP",
-    fontSize: asPt(pxToPt(fontSizePx)),
-    color: gradientFill ? undefined : toColorInput(run?.color ?? node.color),
+  return createGlimpseRunProperties({
+    fontFace: run?.fontFamily ?? node.fontFamily,
+    fontSize: fontSizePx,
+    color: run?.color ?? node.color,
     gradientFill,
     bold: run?.bold ?? node.bold,
     italic: run?.italic ?? node.italic,
-    underline: toUnderlineInput(resolveUnderline(node, run)),
+    underline: resolveUnderline(node, run),
     strike: run?.strike ?? node.strike,
-    baseline: toBaselineInput(subSup.subscript, subSup.superscript),
-    highlight: toColorInput(run?.highlight ?? node.highlight),
-    glow: toGlowInput(node.glow),
-    outline: toOutlineInput(node.outline),
-    charSpacing: toCharSpacing(run?.letterSpacing ?? node.letterSpacing),
+    subscript: subSup.subscript,
+    superscript: subSup.superscript,
+    highlight: run?.highlight ?? node.highlight,
+    glow: node.glow,
+    outline: node.outline,
+    letterSpacing: run?.letterSpacing ?? node.letterSpacing,
   });
+}
+
+export function createGlimpseRunProperties(
+  style: GlimpseTextRunStyle,
+): AddTextBoxRunPropertiesInput {
+  return {
+    fontFace: style.fontFace ?? "Noto Sans JP",
+    fontSize: asPt(pxToPt(style.fontSize ?? 24)),
+    color: style.gradientFill ? undefined : toColorInput(style.color),
+    gradientFill: style.gradientFill,
+    bold: style.bold,
+    italic: style.italic,
+    underline: toUnderlineInput(style.underline),
+    strike: style.strike,
+    baseline: toBaselineInput(style.subscript, style.superscript),
+    highlight: toColorInput(style.highlight),
+    glow: toGlowInput(style.glow),
+    outline: toOutlineInput(style.outline),
+    charSpacing: toCharSpacing(style.letterSpacing),
+  };
+}
+
+export function createGlimpseShapeRunProperties(
+  style: GlimpseTextRunStyle,
+): AddShapeRunPropertiesInput {
+  const properties = createGlimpseRunProperties(style);
+  return {
+    ...properties,
+    baseline: style.subscript
+      ? "subscript"
+      : style.superscript
+        ? "superscript"
+        : undefined,
+  };
+}
+
+export function createGlimpseTableRunProperties(
+  style: GlimpseTextRunStyle,
+): AddTableRunPropertiesInput {
+  const properties = createGlimpseRunProperties(style);
+  return {
+    ...properties,
+    fontFace: style.fontFace,
+    color: cleanHex(style.color),
+  };
 }
 
 function buildParagraphs(node: TextPositionedNode): AddTextBoxParagraphInput[] {
@@ -188,7 +238,7 @@ function buildParagraphs(node: TextPositionedNode): AddTextBoxParagraphInput[] {
       ? node.runs.map((run) => ({
           text: run.text,
           properties: buildRunProperties(node, run, gradientFill),
-          href: run.href,
+          hyperlink: run.href,
         }))
       : [
           {
@@ -219,9 +269,36 @@ function buildParagraphs(node: TextPositionedNode): AddTextBoxParagraphInput[] {
     runs: runs.map((run) => ({
       text: run.text,
       properties: run.properties,
-      hyperlink: run.href,
+      hyperlink: run.hyperlink,
     })),
   }));
+}
+
+export function createTextNodeInput(
+  node: TextPositionedNode,
+  useLayoutTextMargins: boolean,
+): AddTextBoxInput {
+  const textOptions = createTextOptions(node);
+  return {
+    offsetX: asEmu(Math.round(textOptions.x * EMU_PER_IN)),
+    offsetY: asEmu(Math.round(textOptions.y * EMU_PER_IN)),
+    width: asEmu(Math.round(textOptions.w * EMU_PER_IN)),
+    height: asEmu(Math.round(textOptions.h * EMU_PER_IN)),
+    rotation:
+      node.rotate === undefined
+        ? undefined
+        : asOoxmlAngle(Math.round(node.rotate * 60000)),
+    body: useLayoutTextMargins
+      ? undefined
+      : {
+          anchor: "top",
+          marginLeft: asEmu(0),
+          marginRight: asEmu(0),
+          marginTop: asEmu(0),
+          marginBottom: asEmu(0),
+        },
+    paragraphs: buildParagraphs(node),
+  };
 }
 
 export type CustomGeometryXmlInput = {
@@ -337,7 +414,7 @@ function customGeometry(
   };
 }
 
-function enrichShapeInput(
+export function enrichShapeInput(
   input: AddShapeInput,
   options: GlimpseShapeXmlOptions | undefined,
 ): AddShapeInput {
@@ -404,186 +481,34 @@ function enrichShapeInput(
   };
 }
 
-function applyHyperlinks(
-  input: AddTextBoxInput,
-  hyperlinks: readonly (string | undefined)[] | undefined,
-): AddTextBoxInput {
-  if (!hyperlinks?.some(Boolean) || !input.paragraphs) return input;
-  let index = 0;
+export function enrichPictureInput(
+  input: AddPictureInput,
+  shadow: ShadowStyle | undefined,
+): AddPictureInput {
   return {
     ...input,
-    paragraphs: input.paragraphs.map((paragraph) => ({
-      ...paragraph,
-      runs: paragraph.runs.map((run) => ({
-        ...run,
-        hyperlink: hyperlinks[index++],
-      })),
-    })),
+    effects: toShadowEffects(shadow),
   };
 }
 
-export class PptxAuthoringRegistry {
-  private currentSource: PptxSourceModel | undefined;
-  private currentSlideHandle: SourceHandle | undefined;
-  private useLayoutTextMargins = false;
-  private textCount = 0;
-  private shapeCount = 0;
-  private pictureCount = 0;
-  private tableCount = 0;
-  private chartCount = 0;
-
-  constructor() {
-    const source = createPptx();
-    this.currentSource = source;
-    this.currentSlideHandle = source.slides[0]?.handle;
-  }
-
-  initialize(source: PptxSourceModel, useLayoutTextMargins = false): void {
-    this.currentSource = source;
-    this.useLayoutTextMargins = useLayoutTextMargins;
-  }
-
-  selectSlide(handle: SourceHandle): void {
-    this.currentSlideHandle = handle;
-  }
-
-  get source(): PptxSourceModel {
-    if (!this.currentSource)
-      throw new Error("glimpse authoring is not initialized");
-    return this.currentSource;
-  }
-
-  get entries(): readonly { kind: "shape"; xml: string }[] {
-    return (this.source.edits ?? []).flatMap((edit) =>
-      (edit.kind === "addTextBox" || edit.kind === "addShape") && "xml" in edit
-        ? [{ kind: "shape" as const, xml: edit.xml }]
-        : [],
-    );
-  }
-
-  replaceSource(source: PptxSourceModel): void {
-    this.currentSource = source;
-  }
-
-  private get target(): SourceHandle {
-    if (!this.currentSlideHandle)
-      throw new Error("glimpse slide is not selected");
-    return this.currentSlideHandle;
-  }
-
-  register(node: TextPositionedNode): void {
-    const textOptions = createTextOptions(node);
-    this.registerTextBox({
-      offsetX: asEmu(Math.round(textOptions.x * EMU_PER_IN)),
-      offsetY: asEmu(Math.round(textOptions.y * EMU_PER_IN)),
-      width: asEmu(Math.round(textOptions.w * EMU_PER_IN)),
-      height: asEmu(Math.round(textOptions.h * EMU_PER_IN)),
-      rotation:
-        node.rotate === undefined
-          ? undefined
-          : asOoxmlAngle(Math.round(node.rotate * 60000)),
-      body: this.useLayoutTextMargins
-        ? undefined
-        : {
-            anchor: "top",
-            marginLeft: asEmu(0),
-            marginRight: asEmu(0),
-            marginTop: asEmu(0),
-            marginBottom: asEmu(0),
-          },
-      paragraphs: buildParagraphs(node),
-    });
-  }
-
-  registerTextBox(
-    input: AddTextBoxInput,
-    options?: {
-      name?: string;
-      hyperlinks?: readonly (string | undefined)[];
-    },
-  ): void {
-    const name = options?.name ?? `Text ${++this.textCount}`;
-    this.currentSource = addTextBox(
-      this.source,
-      this.target,
-      applyHyperlinks({ ...input, name }, options?.hyperlinks),
-    );
-  }
-
-  registerShape(
-    input: AddShapeInput,
-    options?: GlimpseShapeXmlOptions & { name?: string },
-  ): void {
-    const name = options?.name ?? `Shape ${++this.shapeCount}`;
-    this.currentSource = addShape(
-      this.source,
-      this.target,
-      enrichShapeInput({ ...input, name }, options),
-    );
-  }
-
-  registerPicture(
-    input: AddPictureInput,
-    options?: { name?: string; shadow?: ShadowStyle },
-  ): void {
-    const name = options?.name ?? `Picture ${++this.pictureCount}`;
-    this.currentSource = addPicture(this.source, this.target, {
-      ...input,
-      name,
-      effects: toShadowEffects(options?.shadow),
-    });
-  }
-
-  registerTable(input: AddTableInput, options?: { name?: string }): void {
-    const name = options?.name ?? `Table ${++this.tableCount}`;
-    this.currentSource = addTable(this.source, this.target, { ...input, name });
-  }
-
-  registerChart(input: AddChartInput, options?: { name?: string }): void {
-    const name = options?.name ?? `Chart ${++this.chartCount}`;
-    this.currentSource = addChart(this.source, this.target, { ...input, name });
-  }
-
-  setSlideBackgroundGradient(
-    backgroundGradient: string,
-    opacity?: number,
-  ): boolean {
-    const fill = toGradientFill(backgroundGradient, opacity);
-    if (!fill || fill.kind !== "gradient") return false;
-    const background =
-      fill.gradientType === "linear"
-        ? {
-            kind: "gradient" as const,
-            gradientType: "linear" as const,
-            stops: fill.stops,
-            angle: fill.angle ?? asOoxmlAngle(0),
-          }
-        : {
-            kind: "gradient" as const,
-            gradientType: "radial" as const,
-            stops: fill.stops,
-            centerX: fill.centerX,
-            centerY: fill.centerY,
-          };
-    this.currentSource = setSlideBackground(
-      this.source,
-      this.target,
-      background,
-    );
-    return true;
-  }
-
-  setSlideBackgroundSolid(color: string): void {
-    this.currentSource = setSlideBackground(this.source, this.target, {
-      kind: "solid",
-      color: toColorInput(color)!,
-    });
-  }
-
-  setSlideBackgroundImage(bytes: Uint8Array): void {
-    this.currentSource = setSlideBackground(this.source, this.target, {
-      kind: "image",
-      bytes,
-    });
-  }
+export function toSlideBackgroundGradient(
+  backgroundGradient: string,
+  opacity?: number,
+) {
+  const fill = toGradientFill(backgroundGradient, opacity);
+  if (!fill || fill.kind !== "gradient") return undefined;
+  return fill.gradientType === "linear"
+    ? {
+        kind: "gradient" as const,
+        gradientType: "linear" as const,
+        stops: fill.stops,
+        angle: fill.angle ?? asOoxmlAngle(0),
+      }
+    : {
+        kind: "gradient" as const,
+        gradientType: "radial" as const,
+        stops: fill.stops,
+        centerX: fill.centerX,
+        centerY: fill.centerY,
+      };
 }

--- a/packages/pom/src/renderPptx/nodes/chart.ts
+++ b/packages/pom/src/renderPptx/nodes/chart.ts
@@ -3,7 +3,7 @@ import type { RenderContext } from "../types.ts";
 import { asEmu, asOoxmlPercent, asPt } from "@pptx-glimpse/document";
 import { pxToEmu } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
-import { toColorInput } from "../pptxAuthoring.ts";
+import { toColorInput } from "../glimpseAdapter.ts";
 
 type ChartPositionedNode = Extract<PositionedNode, { type: "chart" }>;
 
@@ -77,7 +77,7 @@ export function renderChartNode(
           (_value, index) => chartColors[index % chartColors.length],
         )
       : undefined;
-  ctx.buildContext.pptxAuthoring.registerChart({
+  ctx.authoring.addChart({
     chartType: node.chartType,
     series: series.map((item, index) => ({
       name: item.name,

--- a/packages/pom/src/renderPptx/nodes/icon.ts
+++ b/packages/pom/src/renderPptx/nodes/icon.ts
@@ -1,7 +1,7 @@
 import { asEmu } from "@pptx-glimpse/document";
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
-import { toColorInput } from "../pptxAuthoring.ts";
+import { toColorInput } from "../glimpseAdapter.ts";
 import { pxToEmu } from "../units.ts";
 import {
   addGlimpsePicture,

--- a/packages/pom/src/renderPptx/nodes/list.ts
+++ b/packages/pom/src/renderPptx/nodes/list.ts
@@ -57,12 +57,8 @@ function toRunStyle(
 function buildListParagraphs(
   items: LiNode[],
   parent: UlPositionedNode | OlPositionedNode,
-): {
-  paragraphs: AddTextBoxParagraphInput[];
-  hyperlinks: (string | undefined)[];
-} {
+): AddTextBoxParagraphInput[] {
   const paragraphs: AddTextBoxParagraphInput[] = [];
-  const hyperlinks: (string | undefined)[] = [];
   for (let i = 0; i < items.length; i++) {
     const li = items[i];
     const style = resolveStyle(li, parent);
@@ -84,22 +80,21 @@ function buildListParagraphs(
             superscript: runSubSup.superscript,
             highlight: run.highlight ?? style.highlight,
           }),
+          hyperlink: run.text ? run.href : undefined,
         });
-        hyperlinks.push(run.text ? run.href : undefined);
       }
     } else {
       runs.push({
         text: li.text,
         properties: createGlimpseRunProperties(toRunStyle(style)),
       });
-      hyperlinks.push(undefined);
     }
     paragraphs.push({
       properties: paragraphProperties(parent),
       runs,
     });
   }
-  return { paragraphs, hyperlinks };
+  return paragraphs;
 }
 
 export function renderUlNode(node: UlPositionedNode, ctx: RenderContext): void {
@@ -107,7 +102,7 @@ export function renderUlNode(node: UlPositionedNode, ctx: RenderContext): void {
   const fontFamily = node.fontFamily ?? "Noto Sans JP";
   const content = getContentArea(node);
 
-  const { paragraphs, hyperlinks } = buildListParagraphs(node.items, node);
+  const paragraphs = buildListParagraphs(node.items, node);
   addGlimpseTextBox(ctx, content, {
     fontSize: fontSizePx,
     fontFace: fontFamily,
@@ -123,7 +118,6 @@ export function renderUlNode(node: UlPositionedNode, ctx: RenderContext): void {
     superscript: node.superscript,
     highlight: node.highlight,
     paragraphs,
-    hyperlinks,
     lineHeight: node.lineHeight,
     bullet: {
       kind: "bullet",
@@ -136,7 +130,7 @@ export function renderOlNode(node: OlPositionedNode, ctx: RenderContext): void {
   const fontFamily = node.fontFamily ?? "Noto Sans JP";
   const content = getContentArea(node);
 
-  const { paragraphs, hyperlinks } = buildListParagraphs(node.items, node);
+  const paragraphs = buildListParagraphs(node.items, node);
   addGlimpseTextBox(ctx, content, {
     fontSize: fontSizePx,
     fontFace: fontFamily,
@@ -152,7 +146,6 @@ export function renderOlNode(node: OlPositionedNode, ctx: RenderContext): void {
     superscript: node.superscript,
     highlight: node.highlight,
     paragraphs,
-    hyperlinks,
     lineHeight: node.lineHeight,
     bullet: {
       kind: "number",

--- a/packages/pom/src/renderPptx/nodes/shape.ts
+++ b/packages/pom/src/renderPptx/nodes/shape.ts
@@ -1,16 +1,18 @@
 import {
   asEmu,
   asHundredthPt,
-  asPt,
   type AddShapeParagraphInput,
   type AddShapeRunPropertiesInput,
 } from "@pptx-glimpse/document";
-import type { BorderStyle, PositionedNode, Underline } from "../../types.ts";
+import type { BorderStyle, PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToPt } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
 import { pxToEmu } from "../units.ts";
-import { toColorInput } from "../pptxAuthoring.ts";
+import {
+  createGlimpseShapeRunProperties,
+  toColorInput,
+} from "../glimpseAdapter.ts";
 import {
   addGlimpseShape,
   createShapeBoundsInput,
@@ -45,33 +47,21 @@ function resolveShapeLine(
   };
 }
 
-function toUnderlineInput(underline: Underline | undefined) {
-  if (underline === undefined || underline === false) return undefined;
-  if (underline === true) return true;
-  return {
-    style: underline.style,
-    color: toColorInput(underline.color),
-  };
-}
-
 function buildShapeTextProperties(
   node: ShapePositionedNode,
 ): AddShapeRunPropertiesInput {
-  return {
-    fontFace: node.fontFamily ?? "Noto Sans JP",
-    fontSize: asPt(pxToPt(node.fontSize ?? 24)),
-    color: toColorInput(node.color),
+  return createGlimpseShapeRunProperties({
+    fontFace: node.fontFamily,
+    fontSize: node.fontSize,
+    color: node.color,
     bold: node.bold,
     italic: node.italic,
-    underline: toUnderlineInput(node.underline),
+    underline: node.underline,
     strike: node.strike,
-    baseline: node.subscript
-      ? "subscript"
-      : node.superscript
-        ? "superscript"
-        : undefined,
-    highlight: toColorInput(node.highlight),
-  };
+    subscript: node.subscript,
+    superscript: node.superscript,
+    highlight: node.highlight,
+  });
 }
 
 function buildShapeParagraphs(

--- a/packages/pom/src/renderPptx/nodes/table.ts
+++ b/packages/pom/src/renderPptx/nodes/table.ts
@@ -6,16 +6,17 @@ import {
 } from "../../shared/tableUtils.ts";
 import {
   asEmu,
-  asOoxmlPercent,
-  asPt,
   type AddTableCellInput,
   type AddTableRowInput,
   type AddTableRunInput,
   type SourceDashStyle,
 } from "@pptx-glimpse/document";
-import { pxToEmu, pxToPt } from "../units.ts";
+import { pxToEmu } from "../units.ts";
 import { getContentArea } from "../utils/contentArea.ts";
-import { cleanHex, toColorInput } from "../pptxAuthoring.ts";
+import {
+  cleanHex,
+  createGlimpseTableRunProperties,
+} from "../glimpseAdapter.ts";
 import { resolveSubSup } from "../textOptions.ts";
 
 type TablePositionedNode = Extract<PositionedNode, { type: "table" }>;
@@ -33,7 +34,7 @@ export function renderTableNode(
         dash: toTableDash(node.cellBorder.dashType),
       }
     : undefined;
-  ctx.buildContext.pptxAuthoring.registerTable({
+  ctx.authoring.addTable({
     offsetX: asEmu(Math.round(pxToEmu(content.x))),
     offsetY: asEmu(Math.round(pxToEmu(content.y))),
     width: asEmu(Math.round(pxToEmu(Math.max(content.w, 1)))),
@@ -112,29 +113,19 @@ function buildTableRuns(
 ): AddTableRunInput[] {
   const runs = cell.runs?.length ? cell.runs : [{ text: cell.text }];
   return runs.flatMap((run) => {
-    const underline = run.underline ?? cell.underline;
     const subSup = resolveSubSup(run, cell);
-    const properties = {
-      fontSize: asPt(pxToPt(run.fontSize ?? cell.fontSize ?? 18)),
+    const properties = createGlimpseTableRunProperties({
+      fontSize: run.fontSize ?? cell.fontSize ?? 18,
       fontFace: run.fontFamily ?? cell.fontFamily,
-      color: cleanHex(run.color ?? cell.color),
+      color: run.color ?? cell.color,
       bold: run.bold ?? cell.bold,
       italic: run.italic ?? cell.italic,
-      underline:
-        typeof underline === "object"
-          ? {
-              style: underline.style,
-              color: toColorInput(underline.color),
-            }
-          : Boolean(underline),
+      underline: run.underline ?? cell.underline,
       strike: run.strike ?? cell.strike,
-      baseline: subSup.subscript
-        ? { type: "percent" as const, value: asOoxmlPercent(-40000) }
-        : subSup.superscript
-          ? { type: "percent" as const, value: asOoxmlPercent(30000) }
-          : undefined,
-      highlight: toColorInput(run.highlight ?? cell.highlight),
-    };
+      subscript: subSup.subscript,
+      superscript: subSup.superscript,
+      highlight: run.highlight ?? cell.highlight,
+    });
     const lines = run.text.replace(/\r*\n/g, "\n").split("\n");
     return lines.map((line, index) => ({
       text: index === 0 ? line : `\n${line}`,

--- a/packages/pom/src/renderPptx/nodes/text.ts
+++ b/packages/pom/src/renderPptx/nodes/text.ts
@@ -1,5 +1,6 @@
 import type { PositionedNode } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
+import { createTextNodeInput } from "../glimpseAdapter.ts";
 
 type TextPositionedNode = Extract<PositionedNode, { type: "text" }>;
 
@@ -7,5 +8,7 @@ export function renderTextNode(
   node: TextPositionedNode,
   ctx: RenderContext,
 ): void {
-  ctx.buildContext.pptxAuthoring.register(node);
+  ctx.authoring.addTextBox(
+    createTextNodeInput(node, ctx.authoring.useLayoutTextMargins),
+  );
 }

--- a/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.renderers.test.ts
@@ -433,6 +433,35 @@ describe("renderUlNode", () => {
     );
     expect(slideXml).not.toContain("pom-text:");
   });
+
+  it("inline run の hyperlink を glimpse run input から出力する", async () => {
+    const zip = await renderPagePptxZip(
+      vstackPage([
+        {
+          type: "ul",
+          x: 0,
+          y: 0,
+          w: 384,
+          h: 192,
+          items: [
+            {
+              text: "",
+              runs: [{ text: "Docs", href: "https://example.com/docs" }],
+            },
+          ],
+        },
+      ]),
+    );
+    const slideXml = await zip.file("ppt/slides/slide1.xml")!.async("text");
+    const relsXml = await zip
+      .file("ppt/slides/_rels/slide1.xml.rels")!
+      .async("text");
+
+    expect(textRunXml(slideXml, "Docs")).toMatch(
+      /<a:hlinkClick r:id="rId\d+"\/>/,
+    );
+    expect(relsXml).toContain('Target="https://example.com/docs"');
+  });
 });
 
 describe("renderOlNode", () => {

--- a/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
+++ b/packages/pom/src/renderPptx/renderPptx.textOptions.test.ts
@@ -6,14 +6,23 @@ import {
   convertOutline,
 } from "./textOptions.ts";
 import { renderTextNode } from "./nodes/text.ts";
-import { PptxAuthoringRegistry } from "./pptxAuthoring.ts";
+import { createPptx, type PptxSourceModel } from "@pptx-glimpse/document";
+import { PptxAuthoringContext } from "./authoringContext.ts";
 import type { RenderContext } from "./types.ts";
 import { pxToIn, pxToPt } from "./units.ts";
 
-function firstShapeXml(registry: PptxAuthoringRegistry): string {
-  const entry = registry.entries[0];
-  expect(entry?.kind).toBe("shape");
-  return entry && entry.kind === "shape" ? entry.xml : "";
+function firstShapeXml(source: PptxSourceModel): string {
+  const edit = source.edits?.find(
+    (candidate) => candidate.kind === "addTextBox" && "xml" in candidate,
+  );
+  expect(edit?.kind).toBe("addTextBox");
+  return edit && "xml" in edit ? edit.xml : "";
+}
+
+function createTextRenderContext(): RenderContext {
+  return {
+    authoring: new PptxAuthoringContext(createPptx()),
+  } as RenderContext;
 }
 
 describe("createTextOptions", () => {
@@ -153,10 +162,7 @@ describe("calcGlyphCenteringShiftPx", () => {
 
 describe("renderTextNode (runs 分岐)", () => {
   it("run に fontSize 指定があれば run 単位で適用され、未指定なら親 Text の fontSize を継承する", () => {
-    const registry = new PptxAuthoringRegistry();
-    const ctx = {
-      buildContext: { pptxAuthoring: registry },
-    } as unknown as RenderContext;
+    const ctx = createTextRenderContext();
 
     renderTextNode(
       {
@@ -172,16 +178,13 @@ describe("renderTextNode (runs 分岐)", () => {
       ctx,
     );
 
-    const xml = firstShapeXml(registry);
+    const xml = firstShapeXml(ctx.authoring.source);
     expect(xml).toContain('<a:rPr sz="3900">');
     expect(xml).toContain('<a:rPr sz="1350">');
   });
 
   it("runs ありの Text でノード単位の glow / outline が各 run に適用される", () => {
-    const registry = new PptxAuthoringRegistry();
-    const ctx = {
-      buildContext: { pptxAuthoring: registry },
-    } as unknown as RenderContext;
+    const ctx = createTextRenderContext();
 
     renderTextNode(
       {
@@ -198,7 +201,7 @@ describe("renderTextNode (runs 分岐)", () => {
       ctx,
     );
 
-    const xml = firstShapeXml(registry);
+    const xml = firstShapeXml(ctx.authoring.source);
     expect(xml.match(/<a:glow rad="76200">/g)).toHaveLength(2);
     expect(xml.match(/<a:alpha val="50000"\/>/g)).toHaveLength(2);
     expect(xml.match(/<a:ln w="19050">/g)).toHaveLength(2);
@@ -206,10 +209,7 @@ describe("renderTextNode (runs 分岐)", () => {
   });
 
   it("href を持つ run は underline 未指定時に旧 addText と同じ既定 underline を出力する", () => {
-    const registry = new PptxAuthoringRegistry();
-    const ctx = {
-      buildContext: { pptxAuthoring: registry },
-    } as unknown as RenderContext;
+    const ctx = createTextRenderContext();
 
     renderTextNode(
       {
@@ -227,16 +227,13 @@ describe("renderTextNode (runs 分岐)", () => {
       ctx,
     );
 
-    const xml = firstShapeXml(registry);
+    const xml = firstShapeXml(ctx.authoring.source);
     expect(xml).toContain('<a:rPr u="sng"');
     expect(xml.match(/<a:rPr/g)).toHaveLength(2);
   });
 
   it("Text glow の opacity 未指定時は既定値 0.75 を XML に反映する", () => {
-    const registry = new PptxAuthoringRegistry();
-    const ctx = {
-      buildContext: { pptxAuthoring: registry },
-    } as unknown as RenderContext;
+    const ctx = createTextRenderContext();
 
     renderTextNode(
       {
@@ -251,7 +248,7 @@ describe("renderTextNode (runs 分岐)", () => {
       ctx,
     );
 
-    const xml = firstShapeXml(registry);
+    const xml = firstShapeXml(ctx.authoring.source);
     expect(xml).toContain('<a:alpha val="75000"/>');
   });
 });

--- a/packages/pom/src/renderPptx/renderPptx.ts
+++ b/packages/pom/src/renderPptx/renderPptx.ts
@@ -18,7 +18,13 @@ import {
   renderBorderOnly,
 } from "./utils/backgroundBorder.ts";
 import { getNodeDef } from "../registry/index.ts";
-import { toColorInput } from "./pptxAuthoring.ts";
+import {
+  enrichPictureInput,
+  enrichShapeInput,
+  toColorInput,
+  toSlideBackgroundGradient,
+} from "./glimpseAdapter.ts";
+import { PptxAuthoringContext } from "./authoringContext.ts";
 import { createGlimpseRunProperties } from "./utils/glimpseTextBox.ts";
 import {
   createShapeBoundsInput,
@@ -120,16 +126,17 @@ function masterTextRunProperties(
 
 function addMasterContent(
   buildContext: BuildContext,
+  authoring: PptxAuthoringContext,
   master: SlideMasterOptions,
 ): void {
-  const target = buildContext.pptxAuthoring.source.slideMasters[0]?.handle;
+  const target = authoring.source.slideMasters[0]?.handle;
   if (!target)
     throw new Error("createPptx did not create a slide master handle");
-  buildContext.pptxAuthoring.selectSlide(target);
+  authoring.selectTarget(target);
   for (const obj of master.objects ?? []) {
     switch (obj.type) {
       case "text":
-        buildContext.pptxAuthoring.registerTextBox({
+        authoring.addTextBox({
           ...masterBounds(obj),
           body: {
             anchor: "middle",
@@ -157,35 +164,42 @@ function addMasterContent(
         });
         break;
       case "image":
-        buildContext.pptxAuthoring.registerPicture({
-          ...masterBounds(obj),
-          bytes: imageBytesFromSource(
-            obj.src,
-            getImageData(obj.src, buildContext.imageDataCache),
+        authoring.addPicture(
+          enrichPictureInput(
+            {
+              ...masterBounds(obj),
+              bytes: imageBytesFromSource(
+                obj.src,
+                getImageData(obj.src, buildContext.imageDataCache),
+              ),
+            },
+            undefined,
           ),
-        });
+        );
         break;
       case "rect":
-        buildContext.pptxAuthoring.registerShape(
-          {
-            ...masterBounds(obj),
-            geometry: { kind: "preset", preset: "rect" },
-            fill: obj.fill
-              ? solidShapeFill(obj.fill.color ?? "FFFFFF")
-              : noneShapeFill(),
-            outline: obj.border ? shapeOutline(obj.border) : undefined,
-          },
-          {
-            fillColor: obj.fill?.color,
-            fillOpacity:
-              obj.fill?.transparency === undefined
-                ? undefined
-                : 1 - obj.fill.transparency / 100,
-          },
+        authoring.addShape(
+          enrichShapeInput(
+            {
+              ...masterBounds(obj),
+              geometry: { kind: "preset", preset: "rect" },
+              fill: obj.fill
+                ? solidShapeFill(obj.fill.color ?? "FFFFFF")
+                : noneShapeFill(),
+              outline: obj.border ? shapeOutline(obj.border) : undefined,
+            },
+            {
+              fillColor: obj.fill?.color,
+              fillOpacity:
+                obj.fill?.transparency === undefined
+                  ? undefined
+                  : 1 - obj.fill.transparency / 100,
+            },
+          ),
         );
         break;
       case "line":
-        buildContext.pptxAuthoring.registerShape({
+        authoring.addShape({
           ...masterBounds(obj),
           geometry: { kind: "preset", preset: "line" },
           fill: noneShapeFill(),
@@ -196,8 +210,8 @@ function addMasterContent(
   }
   if (master.slideNumber) {
     const value = master.slideNumber;
-    buildContext.pptxAuthoring.replaceSource(
-      addSlideNumber(buildContext.pptxAuthoring.source, target, {
+    authoring.replaceSource(
+      addSlideNumber(authoring.source, target, {
         offsetX: asEmu(Math.round(pxToEmu(value.x))),
         offsetY: asEmu(Math.round(pxToEmu(value.y))),
         width:
@@ -254,27 +268,25 @@ export function renderPptx(
         : undefined,
     },
   });
-  buildContext.pptxAuthoring.initialize(source, margin !== undefined);
-  if (master) addMasterContent(buildContext, master);
+  const authoring = new PptxAuthoringContext(source, margin !== undefined);
+  if (master) addMasterContent(buildContext, authoring, master);
 
   for (const [pageIndex, data] of pages.entries()) {
     if (pageIndex > 0) {
-      const layoutPartPath =
-        buildContext.pptxAuthoring.source.slideLayouts[0]?.partPath;
+      const layoutPartPath = authoring.source.slideLayouts[0]?.partPath;
       if (!layoutPartPath)
         throw new Error("createPptx did not create a slide layout");
-      source = addEmptySlideFromLayout(buildContext.pptxAuthoring.source, {
+      source = addEmptySlideFromLayout(authoring.source, {
         layoutPartPath,
       });
-      buildContext.pptxAuthoring.replaceSource(source);
+      authoring.replaceSource(source);
     }
-    const slideHandle =
-      buildContext.pptxAuthoring.source.slides[pageIndex]?.handle;
+    const slideHandle = authoring.source.slides[pageIndex]?.handle;
     if (!slideHandle)
       throw new Error(`slide handle was not found: ${pageIndex + 1}`);
-    buildContext.pptxAuthoring.selectSlide(slideHandle);
+    authoring.selectTarget(slideHandle);
     const idPositionMap = buildIdPositionMap(data, buildContext.diagnostics);
-    const ctx: RenderContext = { buildContext, idPositionMap };
+    const ctx: RenderContext = { buildContext, authoring, idPositionMap };
 
     // ルートノードの backgroundColor はスライドの background プロパティとして適用
     // これにより、マスタースライドのオブジェクトを覆い隠さない
@@ -288,19 +300,22 @@ export function renderPptx(
       : undefined;
     const rootHasOpacity =
       !isLinelike && "opacity" in data && data.opacity !== undefined;
-    const rootGradientApplied =
+    const rootGradient =
       rootBackgroundGradient && !rootHasOpacity
-        ? buildContext.pptxAuthoring.setSlideBackgroundGradient(
-            rootBackgroundGradient,
-          )
-        : false;
+        ? toSlideBackgroundGradient(rootBackgroundGradient)
+        : undefined;
+    const rootGradientApplied = rootGradient !== undefined;
+    if (rootGradient) authoring.setSlideBackground(rootGradient);
     if (
       !rootGradientApplied &&
       rootBackgroundColor &&
       !rootBackgroundGradient &&
       !rootHasOpacity
     ) {
-      buildContext.pptxAuthoring.setSlideBackgroundSolid(rootBackgroundColor);
+      authoring.setSlideBackground({
+        kind: "solid",
+        color: toColorInput(rootBackgroundColor)!,
+      });
     }
 
     // ルートノードの backgroundImage はスライドの background プロパティとして適用
@@ -311,9 +326,10 @@ export function renderPptx(
         rootBackgroundImage.src,
         buildContext.imageDataCache,
       );
-      buildContext.pptxAuthoring.setSlideBackgroundImage(
-        imageBytesFromSource(rootBackgroundImage.src, cachedData),
-      );
+      authoring.setSlideBackground({
+        kind: "image",
+        bytes: imageBytesFromSource(rootBackgroundImage.src, cachedData),
+      });
     }
 
     /**
@@ -367,5 +383,5 @@ export function renderPptx(
     renderNode(data, true); // ルートノードとして処理
   }
 
-  return createWritablePptx(() => buildContext.pptxAuthoring.source);
+  return createWritablePptx(() => authoring.source);
 }

--- a/packages/pom/src/renderPptx/renderPptx.ts
+++ b/packages/pom/src/renderPptx/renderPptx.ts
@@ -210,25 +210,24 @@ function addMasterContent(
   }
   if (master.slideNumber) {
     const value = master.slideNumber;
-    authoring.replaceSource(
-      addSlideNumber(authoring.source, target, {
-        offsetX: asEmu(Math.round(pxToEmu(value.x))),
-        offsetY: asEmu(Math.round(pxToEmu(value.y))),
-        width:
-          value.w === undefined
-            ? asEmu(800000)
-            : asEmu(Math.round(pxToEmu(value.w))),
-        height:
-          value.h === undefined
-            ? asEmu(300000)
-            : asEmu(Math.round(pxToEmu(value.h))),
-        properties: {
-          fontFace: value.fontFamily,
-          fontSize: value.fontSize ? asPt(pxToPt(value.fontSize)) : undefined,
-          color: toColorInput(value.color),
-        },
-      }),
-    );
+    const source = addSlideNumber(authoring.source, target, {
+      offsetX: asEmu(Math.round(pxToEmu(value.x))),
+      offsetY: asEmu(Math.round(pxToEmu(value.y))),
+      width:
+        value.w === undefined
+          ? asEmu(800000)
+          : asEmu(Math.round(pxToEmu(value.w))),
+      height:
+        value.h === undefined
+          ? asEmu(300000)
+          : asEmu(Math.round(pxToEmu(value.h))),
+      properties: {
+        fontFace: value.fontFamily,
+        fontSize: value.fontSize ? asPt(pxToPt(value.fontSize)) : undefined,
+        color: toColorInput(value.color),
+      },
+    });
+    authoring.replaceSource(source, target);
   }
 }
 
@@ -247,7 +246,7 @@ export function renderPptx(
 ) {
   const margin =
     master?.margin === undefined ? undefined : resolveBoxSpacing(master.margin);
-  let source = createPptx({
+  const source = createPptx({
     slideSize: {
       width: asEmu(Math.round(pxToEmu(slidePx.w))),
       height: asEmu(Math.round(pxToEmu(slidePx.h))),
@@ -276,15 +275,19 @@ export function renderPptx(
       const layoutPartPath = authoring.source.slideLayouts[0]?.partPath;
       if (!layoutPartPath)
         throw new Error("createPptx did not create a slide layout");
-      source = addEmptySlideFromLayout(authoring.source, {
+      const nextSource = addEmptySlideFromLayout(authoring.source, {
         layoutPartPath,
       });
-      authoring.replaceSource(source);
+      const slideHandle = nextSource.slides[pageIndex]?.handle;
+      if (!slideHandle)
+        throw new Error(`slide handle was not found: ${pageIndex + 1}`);
+      authoring.replaceSource(nextSource, slideHandle);
+    } else {
+      const slideHandle = authoring.source.slides[pageIndex]?.handle;
+      if (!slideHandle)
+        throw new Error(`slide handle was not found: ${pageIndex + 1}`);
+      authoring.selectTarget(slideHandle);
     }
-    const slideHandle = authoring.source.slides[pageIndex]?.handle;
-    if (!slideHandle)
-      throw new Error(`slide handle was not found: ${pageIndex + 1}`);
-    authoring.selectTarget(slideHandle);
     const idPositionMap = buildIdPositionMap(data, buildContext.diagnostics);
     const ctx: RenderContext = { buildContext, authoring, idPositionMap };
 

--- a/packages/pom/src/renderPptx/types.ts
+++ b/packages/pom/src/renderPptx/types.ts
@@ -1,4 +1,5 @@
 import type { BuildContext } from "../buildContext.ts";
+import type { PptxAuthoringContext } from "./authoringContext.ts";
 
 export type NodeBounds = { x: number; y: number; w: number; h: number };
 
@@ -15,17 +16,19 @@ export type NodeBounds = { x: number; y: number; w: number; h: number };
  *   (getContentArea / getContentAreaIn / withContentBounds)
  * - scaleToFit 系 diagram の前処理 (コンテンツ領域 + スケール係数):
  *   utils/scaleToFit.ts (resolveScaledContentArea)
- * - 見た目属性の純粋変換: utils/visualStyle.ts
+ * - POM style / geometry → glimpse input の純粋変換: glimpseAdapter.ts
+ * - renderer 内部の見た目属性解決: utils/visualStyle.ts
  *   (fill / border / shadow / borderRadius / stripHash)
  * - 背景色・背景画像・ボーダーの描画順序: utils/backgroundBorder.ts
  *   (renderer の手前で renderPptx 本体から呼ばれる)
  * - 2 点間直線の描画 (Line / Arrow): utils/straightLine.ts (addStraightLine)
- * - テキスト系属性の変換: textOptions.ts
- *   (createTextOptions / convertUnderline / convertStrike)
+ * - テキスト配置の解決: textOptions.ts (createTextOptions)
  */
 export type RenderContext = {
   /** diagnostics や画像・グラデーションのキャッシュなど build 全体の状態 */
   buildContext: BuildContext;
+  /** PPTX source、current target、要素名採番を render 内に閉じ込める状態 */
+  authoring: PptxAuthoringContext;
   /** Arrow の from/to 参照解決に使う id → 絶対座標マップ */
   idPositionMap: Map<string, NodeBounds>;
 };

--- a/packages/pom/src/renderPptx/utils/glimpsePicture.ts
+++ b/packages/pom/src/renderPptx/utils/glimpsePicture.ts
@@ -9,6 +9,7 @@ import {
 import type { ShadowStyle } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToEmu } from "../units.ts";
+import { enrichPictureInput } from "../glimpseAdapter.ts";
 
 type PictureBoundsPx = { x: number; y: number; w: number; h: number };
 type ImageSizing = {
@@ -150,8 +151,8 @@ export function addGlimpsePicture(
     rotation: createPictureRotationInput(options?.rotate),
     crop: sizingResult.crop,
   };
-  ctx.buildContext.pptxAuthoring.registerPicture(input, {
-    name: options?.name,
-    shadow: options?.shadow,
-  });
+  ctx.authoring.addPicture(
+    enrichPictureInput(input, options?.shadow),
+    options?.name,
+  );
 }

--- a/packages/pom/src/renderPptx/utils/glimpseShape.test.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseShape.test.ts
@@ -5,7 +5,7 @@ import {
   shapeOutline,
   solidShapeFill,
 } from "./glimpseShape.ts";
-import { toColorInput } from "../pptxAuthoring.ts";
+import { toColorInput } from "../glimpseAdapter.ts";
 
 describe("glimpse shape helpers", () => {
   it("3桁色を6桁RGBへ展開する", () => {

--- a/packages/pom/src/renderPptx/utils/glimpseShape.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseShape.ts
@@ -9,7 +9,11 @@ import {
 } from "@pptx-glimpse/document";
 import type { BorderStyle, ShadowStyle, TextGlow } from "../../types.ts";
 import { parseGradient } from "../../shared/gradient.ts";
-import { toColorInput, type CustomGeometryXmlInput } from "../pptxAuthoring.ts";
+import {
+  enrichShapeInput,
+  toColorInput,
+  type CustomGeometryXmlInput,
+} from "../glimpseAdapter.ts";
 import { pxToEmu } from "../units.ts";
 import type { RenderContext } from "../types.ts";
 
@@ -125,9 +129,12 @@ export function addGlimpseShape(
   bounds: ShapeBoundsPx,
   options?: GlimpseShapeStyleOptions & { name?: string },
 ): void {
-  ctx.buildContext.pptxAuthoring.registerShape(input, {
-    ...options,
-    zeroWidth: bounds.w === 0,
-    zeroHeight: bounds.h === 0,
-  });
+  ctx.authoring.addShape(
+    enrichShapeInput(input, {
+      ...options,
+      zeroWidth: bounds.w === 0,
+      zeroHeight: bounds.h === 0,
+    }),
+    options?.name,
+  );
 }

--- a/packages/pom/src/renderPptx/utils/glimpseTextBox.ts
+++ b/packages/pom/src/renderPptx/utils/glimpseTextBox.ts
@@ -3,33 +3,22 @@ import {
   asHundredthPt,
   asOoxmlAngle,
   asOoxmlPercent,
-  asPt,
   type AddTextBoxInput,
   type AddTextBoxParagraphInput,
-  type AddTextBoxRunPropertiesInput,
   type SourceAutoNumScheme,
 } from "@pptx-glimpse/document";
-import type { Underline } from "../../types.ts";
 import type { RenderContext } from "../types.ts";
 import { pxToEmu, pxToPt } from "../units.ts";
-import { toColorInput } from "../pptxAuthoring.ts";
+import {
+  createGlimpseRunProperties,
+  type GlimpseTextRunStyle,
+} from "../glimpseAdapter.ts";
 
 type TextBoundsPx = { x: number; y: number; w: number; h: number };
 
 type TextBoxVerticalAlign = "top" | "middle" | "bottom";
 
-export type GlimpseTextRunStyle = {
-  fontSize?: number;
-  fontFace?: string;
-  color?: string;
-  bold?: boolean;
-  italic?: boolean;
-  underline?: Underline;
-  strike?: boolean;
-  subscript?: boolean;
-  superscript?: boolean;
-  highlight?: string;
-};
+export type { GlimpseTextRunStyle } from "../glimpseAdapter.ts";
 
 export type GlimpseTextBoxOptions = GlimpseTextRunStyle & {
   text?: string;
@@ -50,34 +39,7 @@ export type ListBulletOptions =
       startAt?: number;
     };
 
-function toUnderlineInput(underline: Underline | undefined) {
-  if (underline === undefined || underline === false) return undefined;
-  if (underline === true) return true;
-  return {
-    style: underline.style,
-    color: toColorInput(underline.color),
-  };
-}
-
-export function createGlimpseRunProperties(
-  style: GlimpseTextRunStyle,
-): AddTextBoxRunPropertiesInput {
-  return {
-    fontFace: style.fontFace ?? "Noto Sans JP",
-    fontSize: asPt(pxToPt(style.fontSize ?? 24)),
-    color: toColorInput(style.color),
-    bold: style.bold,
-    italic: style.italic,
-    underline: toUnderlineInput(style.underline),
-    strike: style.strike,
-    baseline: style.subscript
-      ? { type: "percent", value: asOoxmlPercent(-40000) }
-      : style.superscript
-        ? { type: "percent", value: asOoxmlPercent(30000) }
-        : undefined,
-    highlight: toColorInput(style.highlight),
-  };
-}
+export { createGlimpseRunProperties } from "../glimpseAdapter.ts";
 
 function createGlimpseParagraph(
   text: string,
@@ -181,7 +143,6 @@ export function addGlimpseTextBox(
   bounds: TextBoundsPx,
   options: GlimpseTextBoxOptions & {
     paragraphs?: readonly AddTextBoxParagraphInput[];
-    hyperlinks?: readonly (string | undefined)[];
   } = {},
 ): void {
   const paragraphs = withListProperties(
@@ -192,12 +153,7 @@ export function addGlimpseTextBox(
       }),
     options,
   );
-  ctx.buildContext.pptxAuthoring.registerTextBox(
-    textBoxInput(bounds, options, paragraphs),
-    {
-      hyperlinks: options.hyperlinks,
-    },
-  );
+  ctx.authoring.addTextBox(textBoxInput(bounds, options, paragraphs));
 }
 
 function isSupportedAutoNumScheme(


### PR DESCRIPTION
close #962

## 概要

- `BuildContext` から PPTX authoring state を除去し、`renderPptx/authoringContext.ts` の render 固有 context へ移しました
- POM の text / color / gradient / shadow / geometry を glimpse input に変換する純粋 adapter を `glimpseAdapter.ts` に分離しました
- Text / List / Shape / Table の run style 変換を共通 helper に集約しました
- hyperlink を glimpse run input に直接設定し、run と別の対応配列を廃止しました
- テスト専用 XML accessor を削除し、source model または書き出した PPTX を通じた検証へ変更しました

## 影響範囲

- `packages/pom/src/buildContext.ts`
- `packages/pom/src/renderPptx/**`
- `@hirokisakabe/pom` の公開 API と PPTX の意図した出力には変更ありません

## ローカル検証

- `pnpm --filter @hirokisakabe/pom run build`
- `pnpm --filter @hirokisakabe/pom run typecheck`
- `pnpm --filter @hirokisakabe/pom run lint`
- `pnpm --filter @hirokisakabe/pom run lint:deps`
- `pnpm --filter @hirokisakabe/pom run fmt:check`
- `pnpm --filter @hirokisakabe/pom run knip`
- `pnpm --filter @hirokisakabe/pom run test:run`（662 passed / 3 skipped）
- `pnpm --filter @hirokisakabe/pom run vrt:docker`（55 pages、visual difference なし）
