### PR TITLE
docs: pom kit を primary user journey として可視化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">pom</h1>
 <p align="center">
-  AI-friendly PowerPoint generation with a Flexbox layout engine.
+  Prompt-to-PowerPoint with agent skills, an XML source, and a live-preview CLI.
 </p>
 
 <p align="center">
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <b>pom (PowerPoint Object Model)</b> is a TypeScript library that converts XML into editable PowerPoint files (.pptx).
+  <b>pom kit</b> turns a prompt into editable PowerPoint files while keeping pom XML as the source of truth.
 </p>
 
 <p align="center">
@@ -24,51 +24,55 @@
 
 ---
 
-## Features
-
-- **AI Friendly** — Simple XML structure designed for LLM code generation.
-- **Declarative** — Describe slides as XML. No imperative API calls needed.
-- **Flexible Layout** — Flexbox-style layout with VStack / HStack, powered by yoga-layout.
-- **Rich Nodes** — 20 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
-- **Schema-validated** — XML input is validated with Zod schemas at runtime with clear error messages.
-- **PowerPoint Native** — Full access to native PowerPoint shape features (roundRect, ellipse, arrows, etc.).
-
-## Quick Start
+## Quick Start — pom kit
 
 > Requires Node.js 22+
 
 ```bash
-npm install @hirokisakabe/pom
+npx skills add hirokisakabe/pom --all   # install pom-slide and pom-theme
+npm install -g @hirokisakabe/pom-cli    # install preview / build CLI
 ```
 
-```typescript
-import { buildPptx } from "@hirokisakabe/pom";
+Then ask your coding agent to create a deck:
 
-const xml = `
-<Slide>
-  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
-    <Text fontSize="48" bold="true">Presentation Title</Text>
-    <Text fontSize="24" color="666666">Subtitle</Text>
-  </VStack>
-</Slide>
-`;
+```text
+/pom-slide Create a three-slide quarterly sales report
+```
 
-const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
-await pptx.writeFile({ fileName: "presentation.pptx" });
+The skill writes `slides.pom.xml`, reviews the rendered slides, and starts live preview when `pom-cli` is available. Build the final deck with:
+
+```bash
+pom build slides.pom.xml -o slides.pptx
 ```
 
 ## Packages
 
 This repository is a pnpm monorepo containing the following packages:
 
-| Package                                       | Description                                                  | npm                                                                                        |
-| --------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| [packages/pom](./packages/pom/)               | Core library — XML to PPTX conversion                        | [`@hirokisakabe/pom`](https://www.npmjs.com/package/@hirokisakabe/pom)                     |
-| [packages/pom-md](./packages/pom-md/)         | Markdown to pom XML converter                                | [`@hirokisakabe/pom-md`](https://www.npmjs.com/package/@hirokisakabe/pom-md)               |
-| [packages/pom-vscode](./packages/pom-vscode/) | VS Code extension for live preview                           | [Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode) |
-| [apps/website](./apps/website/)               | Documentation website ([pom.pptx.app](https://pom.pptx.app)) | —                                                                                          |
+| Package                                       | Role                                                                        | Distribution                                                                               |
+| --------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [packages/pom-cli](./packages/pom-cli/)       | Primary CLI — preview, build, and render pom XML                            | [`@hirokisakabe/pom-cli`](https://www.npmjs.com/package/@hirokisakabe/pom-cli)             |
+| [packages/pom](./packages/pom/)               | Core library — parse, layout, and render pom XML to PPTX                    | [`@hirokisakabe/pom`](https://www.npmjs.com/package/@hirokisakabe/pom)                     |
+| [packages/pom-md](./packages/pom-md/)         | Markdown authoring surface that converts to pom XML                         | [`@hirokisakabe/pom-md`](https://www.npmjs.com/package/@hirokisakabe/pom-md)               |
+| [packages/pom-jsx](./packages/pom-jsx/)       | Typed JSX/TSX authoring surface that serializes to pom XML                  | [`@hirokisakabe/pom-jsx`](https://www.npmjs.com/package/@hirokisakabe/pom-jsx)             |
+| [packages/pom-editor](./packages/pom-editor/) | Visual AST editor component with pom XML input and output                   | [`@hirokisakabe/pom-editor`](https://www.npmjs.com/package/@hirokisakabe/pom-editor)       |
+| [packages/pom-vscode](./packages/pom-vscode/) | VS Code extension for pom XML / Markdown live preview                       | [Marketplace](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.pom-vscode) |
+| [apps/website](./apps/website/)               | Documentation website and playground ([pom.pptx.app](https://pom.pptx.app)) | —                                                                                          |
 
-## pom kit — Agent Skills
+## How the authoring surfaces fit together
+
+**pom XML is the canonical, editable source passed to the layout and rendering pipeline.** Choose the authoring surface that fits your workflow:
+
+- **Agent skills (recommended)** — `pom-slide` generates and revises pom XML from prompts; `pom-theme` supplies reusable brand tokens and master settings. The generated XML, not the prompt, is the deck source of truth.
+- **XML** — Author the canonical format directly for maximum control, then preview or build it with `pom-cli`.
+- **Markdown** — `pom-md` converts approachable `.pom.md` content (plus optional `pomxml` fences) into pom XML before rendering.
+- **JSX/TSX** — `pom-jsx` serializes typed components and reusable layouts into pom XML before rendering.
+- **Visual editor** — `pom-editor` reads pom XML and emits updated pom XML after drag-and-drop structure edits.
+- **Library API** — `@hirokisakabe/pom` accepts pom XML via `buildPptx()` for advanced or programmatic integrations.
+
+Markdown, JSX, and the visual editor are alternative authoring surfaces, not deprecated paths or separate rendering models. They all converge on the same pom XML representation.
+
+## pom kit workflow
 
 The **pom kit** bundles two agent skills (`pom-theme`, `pom-slide`) and the `pom-cli` preview server. Installed into a coding agent such as [Claude Code](https://claude.ai/code), it gives you a prompt-to-PPTX workflow: onboard your brand, generate slides from natural language, and iterate in a live preview.
 
@@ -100,6 +104,39 @@ npm install -g @hirokisakabe/pom-cli    # live preview / build CLI
    The agent generates a `slides.pom.xml` file in the current directory, applying the theme if present, and self-reviews the rendered result.
 
 3. **Preview**: if `pom-cli` is installed, a live preview server starts automatically at `http://localhost:3000`. Edit the XML (yourself or via follow-up prompts) and the preview updates live. When you're happy, export the deck with `pom build slides.pom.xml -o slides.pptx`.
+
+## Programmatic library use
+
+Install the core library when you want to integrate pom into a TypeScript pipeline:
+
+```bash
+npm install @hirokisakabe/pom
+```
+
+```typescript
+import { buildPptx } from "@hirokisakabe/pom";
+
+const xml = `
+<Slide>
+  <VStack w="100%" h="max" padding="48" gap="24" alignItems="start">
+    <Text fontSize="48" bold="true">Presentation Title</Text>
+    <Text fontSize="24" color="666666">Subtitle</Text>
+  </VStack>
+</Slide>
+`;
+
+const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
+await pptx.writeFile({ fileName: "presentation.pptx" });
+```
+
+## Features
+
+- **AI Friendly** — Simple XML structure designed for LLM code generation.
+- **Declarative** — Describe slides as XML. No imperative API calls needed.
+- **Flexible Layout** — Flexbox-style layout with VStack / HStack, powered by yoga-layout.
+- **Rich Nodes** — 20 built-in node types: charts, flowcharts, tables, timelines, org trees, and more.
+- **Schema-validated** — XML input is validated with Zod schemas at runtime with clear error messages.
+- **PowerPoint Native** — Full access to native PowerPoint shape features (roundRect, ellipse, arrows, etc.).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ npm install -g @hirokisakabe/pom-cli    # install preview / build CLI
 Then ask your coding agent to create a deck:
 
 ```text
-/pom-slide Create a three-slide quarterly sales report
+Use the pom-slide skill to create a three-slide quarterly sales report.
 ```
 
-The skill writes `slides.pom.xml`, reviews the rendered slides, and starts live preview when `pom-cli` is available. Build the final deck with:
+In Claude Code, you can also invoke it as `/pom-slide`; in Codex and other agents, use the natural-language request above. The skill writes `slides.pom.xml`, reviews the rendered slides, and starts live preview when `pom-cli` is available. If preview does not start automatically, run `pom preview slides.pom.xml`. Build the final deck with:
 
 ```bash
 pom build slides.pom.xml -o slides.pptx
@@ -86,6 +86,8 @@ npm install -g @hirokisakabe/pom-cli    # live preview / build CLI
 [`skills`](https://github.com/vercel-labs/skills) auto-detects your installed agents (Claude Code, Codex, Cursor, and more) and places the skills for each. Note that `--all` installs every skill for every detected agent, scoped to the current project; pass `-g` for a user-level (global) install, or `--agent` / `--skill` to narrow the targets. To update the skills later, run `npx skills update`.
 
 **Usage — theme → design → preview:**
+
+The slash-command examples below apply to Claude Code. In Codex and other agents, make the same request in natural language and name the `pom-theme` or `pom-slide` skill.
 
 1. **Theme** (optional): onboard your brand assets with `/pom-theme`:
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ npm install -g @hirokisakabe/pom-cli    # install preview / build CLI
 Then ask your coding agent to create a deck:
 
 ```text
-Use the pom-slide skill to create a three-slide quarterly sales report.
+Create a three-slide quarterly sales report with a title, chart, and summary.
 ```
 
-In Claude Code, you can also invoke it as `/pom-slide`; in Codex and other agents, use the natural-language request above. The skill writes `slides.pom.xml`, reviews the rendered slides, and starts live preview when `pom-cli` is available. If preview does not start automatically, run `pom preview slides.pom.xml`. Build the final deck with:
+This request matches the `pom-slide` description, so the agent can select it automatically. The skill writes `slides.pom.xml`, reviews the rendered slides, and starts live preview when `pom-cli` is available. If preview does not start automatically, run `pom preview slides.pom.xml`. Build the final deck with:
 
 ```bash
 pom build slides.pom.xml -o slides.pptx
@@ -79,11 +79,11 @@ The **pom kit** bundles two agent skills (`pom-theme`, `pom-slide`) and the `pom
 ```mermaid
 flowchart TD
     Prompt["Deck prompt"] --> Agent["Coding agent"]
-    Agent --> Slide["pom-slide skill"]
-
-    Brand["Brand assets / theme prompt"] --> Theme["pom-theme skill"]
-    Theme --> Config["pom-theme.json"]
-    Config --> Slide
+    Brand["Brand assets / theme prompt"] --> Agent
+    Agent -->|"matches slide request"| Slide["pom-slide skill"]
+    Agent -->|"matches theme request"| Theme["pom-theme skill"]
+    Theme --> Config["pom-theme.json<br/>(optional defaults)"]
+    Config -.-> Slide
 
     Slide --> XML["slides.pom.xml<br/>(source of truth)"]
     XML --> Preview["pom preview"]
@@ -92,7 +92,7 @@ flowchart TD
     Build --> PPTX["Editable PPTX"]
 ```
 
-The skills create and revise the XML; `pom-cli` consumes that same source for both the live preview and the final PowerPoint build.
+The agent can choose a skill by matching the request against each skill's description. `pom-theme` creates optional brand defaults; `pom-slide` creates and revises the XML. `pom-cli` consumes that same XML source for both the live preview and the final PowerPoint build.
 
 **Install (2 commands):**
 
@@ -101,29 +101,31 @@ npx skills add hirokisakabe/pom --all   # install all skills (pom-slide, pom-the
 npm install -g @hirokisakabe/pom-cli    # live preview / build CLI
 ```
 
-[`skills`](https://github.com/vercel-labs/skills) auto-detects your installed agents (Claude Code, Codex, Cursor, and more) and places the skills for each. Note that `--all` installs every skill for every detected agent, scoped to the current project; pass `-g` for a user-level (global) install, or `--agent` / `--skill` to narrow the targets. To update the skills later, run `npx skills update`.
+[`skills`](https://github.com/vercel-labs/skills) supports Claude Code, Codex, Cursor, and many other coding agents. The `--all` flag installs every skill for every agent target without prompts, scoped to the current project; pass `-g` for a user-level (global) install, or omit `--all` to choose skills and agents interactively. To update the skills later, run `npx skills update`.
 
 **Usage — theme → design → preview:**
 
-The slash-command examples below apply to Claude Code. In Codex and other agents, make the same request in natural language and name the `pom-theme` or `pom-slide` skill.
+The examples below rely on the agent selecting the relevant skill automatically. You do not need to name a skill in the request.
 
-1. **Theme** (optional): onboard your brand assets with `/pom-theme`:
-
-   ```
-   /pom-theme ブランドカラーは #0052CC。コーポレート向けのライトテーマで
-   ```
-
-   This saves a `pom-theme.json` (color palette + typography + SlideMaster settings) in the current directory. Subsequent `/pom-slide` runs automatically apply its colors, fonts, and background. The SlideMaster settings can also be passed directly to `buildPptx()` as the `master` option.
-
-2. **Design**: generate slides with `/pom-slide`:
+1. **Theme** (optional): ask the agent to onboard your brand assets:
 
    ```
-   /pom-slide 四半期の売上レポート。3 枚構成で、タイトル・グラフ・まとめを含む
+   ブランドカラーは #0052CC。pom 用のコーポレート向けライトテーマを作ってください。
    ```
 
-   The agent generates a `slides.pom.xml` file in the current directory, applying the theme if present, and self-reviews the rendered result.
+   `pom-theme` saves a `pom-theme.json` (color palette + typography + SlideMaster settings) in the current directory. Subsequent slide requests automatically apply its colors, fonts, and background. The SlideMaster settings can also be passed directly to `buildPptx()` as the `master` option.
+
+2. **Design**: describe the deck you want:
+
+   ```
+   四半期の売上レポートを 3 枚で作ってください。タイトル・グラフ・まとめを含めてください。
+   ```
+
+   `pom-slide` generates a `slides.pom.xml` file in the current directory, applies the theme if present, and self-reviews the rendered result.
 
 3. **Preview**: if `pom-cli` is installed, a live preview server starts automatically at `http://localhost:3000`. Edit the XML (yourself or via follow-up prompts) and the preview updates live. When you're happy, export the deck with `pom build slides.pom.xml -o slides.pptx`.
+
+Direct invocation is optional and agent-specific. Claude Code supports `/pom-theme` and `/pom-slide`; Codex CLI and the IDE extension let you mention a skill with `$` or choose one from `/skills`.
 
 ## Programmatic library use
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ Markdown, JSX, and the visual editor are alternative authoring surfaces, not dep
 
 The **pom kit** bundles two agent skills (`pom-theme`, `pom-slide`) and the `pom-cli` preview server. Installed into a coding agent such as [Claude Code](https://claude.ai/code), it gives you a prompt-to-PPTX workflow: onboard your brand, generate slides from natural language, and iterate in a live preview.
 
+```mermaid
+flowchart TD
+    Prompt["Deck prompt"] --> Agent["Coding agent"]
+    Agent --> Slide["pom-slide skill"]
+
+    Brand["Brand assets / theme prompt"] --> Theme["pom-theme skill"]
+    Theme --> Config["pom-theme.json"]
+    Config --> Slide
+
+    Slide --> XML["slides.pom.xml<br/>(source of truth)"]
+    XML --> Preview["pom preview"]
+    Preview --> Live["Live preview"]
+    XML --> Build["pom build"]
+    Build --> PPTX["Editable PPTX"]
+```
+
+The skills create and revise the XML; `pom-cli` consumes that same source for both the live preview and the final PowerPoint build.
+
 **Install (2 commands):**
 
 ```bash

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -111,16 +111,16 @@ const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
 await pptx.writeFile({ fileName: "presentation.pptx" });`;
 
 export default async function LandingPage() {
-  const [highlightedCode, highlightedInstall, highlightedGenerate] =
+  const [highlightedCode, highlightedKitInstall, highlightedPreview] =
     await Promise.all([
       codeToHtml(codeExample, { lang: "typescript", theme: "github-dark" }),
-      codeToHtml("npm install @hirokisakabe/pom", {
-        lang: "bash",
-        theme: "github-dark",
-      }),
       codeToHtml(
-        `const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });\nawait pptx.writeFile({ fileName: "presentation.pptx" });`,
-        { lang: "typescript", theme: "github-dark" },
+        `npx skills add hirokisakabe/pom --all\nnpm install -g @hirokisakabe/pom-cli`,
+        { lang: "bash", theme: "github-dark" },
+      ),
+      codeToHtml(
+        `/pom-slide Create a three-slide quarterly sales report\n\npom preview slides.pom.xml\npom build slides.pom.xml -o slides.pptx`,
+        { lang: "bash", theme: "github-dark" },
       ),
     ]);
 
@@ -156,28 +156,28 @@ export default async function LandingPage() {
       </header>
 
       {/* Hero */}
-      <section className="flex flex-col items-center px-6 pt-24 pb-20 text-center">
-        <div className="mb-4 inline-flex items-center rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-sm text-gray-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
-          npm install @hirokisakabe/pom
+      <section className="flex flex-col items-center px-6 pt-20 pb-16 text-center sm:pt-24 sm:pb-20">
+        <div className="mb-4 inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-300">
+          pom kit · skills + CLI + XML
         </div>
         <h1 className="mb-6 max-w-3xl text-5xl leading-tight font-bold tracking-tight sm:text-6xl">
-          Declarative PowerPoint
+          Go from a prompt
           <br />
           <span className="bg-gradient-to-r from-blue-600 to-violet-600 bg-clip-text text-transparent dark:from-blue-400 dark:to-violet-400">
-            from XML
+            to editable PowerPoint
           </span>
         </h1>
         <p className="mb-10 max-w-2xl text-lg text-gray-600 dark:text-gray-400">
-          Write XML. Get editable PPTX. pom turns declarative markup into native
-          PowerPoint slides with Flexbox layout, 20 built-in node types, and
-          first-class AI support.
+          Tell your coding agent what to present. pom skills generate the pom
+          XML source, and pom CLI previews and builds native, editable PPTX
+          files.
         </p>
-        <div className="flex gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row">
           <Link
-            href="/nodes"
+            href="#quick-start"
             className="rounded-lg bg-gray-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
           >
-            Get Started
+            Install pom kit
           </Link>
           <Link
             href="/playground"
@@ -185,6 +185,70 @@ export default async function LandingPage() {
           >
             Try Playground
           </Link>
+        </div>
+        <div className="mt-14 grid w-full max-w-5xl grid-cols-1 overflow-hidden rounded-xl border border-gray-200 bg-gray-50 text-left sm:grid-cols-5 dark:border-gray-800 dark:bg-gray-900">
+          {[
+            ["Prompt", "Describe the deck"],
+            ["Agent skills", "Design and review"],
+            ["pom XML", "Editable source of truth"],
+            ["pom CLI", "Preview and build"],
+            ["PPTX", "Native PowerPoint"],
+          ].map(([label, detail], index) => (
+            <div
+              key={label}
+              className="relative border-b border-gray-200 px-5 py-4 last:border-b-0 sm:border-r sm:border-b-0 sm:last:border-r-0 dark:border-gray-800"
+            >
+              <p className="mb-1 font-[family-name:var(--font-geist-mono)] text-xs font-semibold tracking-wide text-blue-600 uppercase dark:text-blue-400">
+                {String(index + 1).padStart(2, "0")} · {label}
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {detail}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Quick Start */}
+      <section
+        id="quick-start"
+        className="mx-auto max-w-3xl scroll-mt-6 px-6 py-20"
+      >
+        <p className="mb-3 text-center font-[family-name:var(--font-geist-mono)] text-xs font-semibold tracking-widest text-blue-600 uppercase dark:text-blue-400">
+          Prompt → preview → PowerPoint
+        </p>
+        <h2 className="mb-4 text-center text-3xl font-bold">
+          Quick Start with pom kit
+        </h2>
+        <p className="mx-auto mb-10 max-w-2xl text-center text-gray-600 dark:text-gray-400">
+          Install the two agent skills and pom CLI, then ask your agent for a
+          deck. The generated <code>slides.pom.xml</code> stays under your
+          control as the editable source.
+        </p>
+        <div className="space-y-6">
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-500">
+              1. Install skills and CLI
+            </p>
+            <div
+              className="overflow-x-auto rounded-lg font-[family-name:var(--font-geist-mono)] text-sm [&_pre]:px-5 [&_pre]:py-4"
+              dangerouslySetInnerHTML={{ __html: highlightedKitInstall }}
+            />
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-500">
+              2. Prompt, preview, and build
+            </p>
+            <div
+              className="overflow-x-auto rounded-lg font-[family-name:var(--font-geist-mono)] text-sm leading-relaxed [&_pre]:px-5 [&_pre]:py-4"
+              dangerouslySetInnerHTML={{ __html: highlightedPreview }}
+            />
+          </div>
+          <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+            Use <code>/pom-theme</code> first when you want to onboard brand
+            colors and typography. Continue editing the XML directly or with
+            follow-up prompts; the CLI refreshes the preview as it changes.
+          </p>
         </div>
       </section>
 
@@ -207,14 +271,14 @@ export default async function LandingPage() {
         </div>
       </section>
 
-      {/* Code Example */}
+      {/* Programmatic use */}
       <section className="mx-auto max-w-4xl px-6 py-20">
         <h2 className="mb-4 text-center text-3xl font-bold">
-          XML in, PPTX out
+          Programmatic library use
         </h2>
         <p className="mb-10 text-center text-gray-600 dark:text-gray-400">
-          Describe your slides in XML and generate native PowerPoint files with
-          a single function call.
+          Building a custom pipeline? Pass pom XML to <code>buildPptx</code>
+          directly for full TypeScript control.
         </p>
         <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-800">
           <div className="flex items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-800 dark:bg-gray-900">
@@ -247,45 +311,6 @@ export default async function LandingPage() {
           >
             View all nodes in detail →
           </Link>
-        </div>
-      </section>
-
-      {/* Quick Start */}
-      <section className="mx-auto max-w-3xl px-6 py-20">
-        <h2 className="mb-10 text-center text-3xl font-bold">Quick Start</h2>
-        <div className="space-y-6">
-          <div>
-            <p className="mb-2 text-sm font-medium text-gray-500">1. Install</p>
-            <div
-              className="rounded-lg font-[family-name:var(--font-geist-mono)] text-sm [&_pre]:px-5 [&_pre]:py-4"
-              dangerouslySetInnerHTML={{ __html: highlightedInstall }}
-            />
-          </div>
-          <div>
-            <p className="mb-2 text-sm font-medium text-gray-500">
-              2. Generate
-            </p>
-            <div
-              className="overflow-x-auto rounded-lg font-[family-name:var(--font-geist-mono)] text-sm leading-relaxed [&_pre]:px-5 [&_pre]:py-4"
-              dangerouslySetInnerHTML={{ __html: highlightedGenerate }}
-            />
-          </div>
-          <div>
-            <p className="mb-2 text-sm font-medium text-gray-500">
-              3. For AI agents
-            </p>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Include{" "}
-              <a
-                href="/llm.txt"
-                className="font-medium text-blue-600 underline dark:text-blue-400"
-              >
-                llm.txt
-              </a>{" "}
-              in your system prompt for a compact XML reference designed for
-              LLMs.
-            </p>
-          </div>
         </div>
       </section>
 

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -37,7 +37,7 @@ const features = [
   {
     title: "AI Friendly",
     description:
-      "Simple XML structure designed for LLM code generation. Include llm.txt in your system prompt for XML reference.",
+      "Describe the deck you want in natural language. The agent can select the installed skill when the request matches its description.",
     icon: "🤖",
   },
   {
@@ -123,7 +123,7 @@ export default async function LandingPage() {
       { lang: "bash", theme: "github-dark" },
     ),
     codeToHtml(
-      `Use the pom-slide skill to create a three-slide quarterly sales report.`,
+      `Create a three-slide quarterly sales report with a title, chart, and summary.`,
       { lang: "text", theme: "github-dark" },
     ),
     codeToHtml(`pom build slides.pom.xml -o slides.pptx`, {
@@ -176,9 +176,9 @@ export default async function LandingPage() {
           </span>
         </h1>
         <p className="mb-10 max-w-2xl text-lg text-gray-600 dark:text-gray-400">
-          Tell your coding agent what to present. pom skills generate the pom
-          XML source, and pom CLI previews and builds native, editable PPTX
-          files.
+          Tell your coding agent what to present. The pom-slide skill turns the
+          request into pom XML, and pom CLI previews and builds native, editable
+          PPTX files.
         </p>
         <div className="flex flex-col gap-4 sm:flex-row">
           <Link
@@ -197,7 +197,7 @@ export default async function LandingPage() {
         <div className="mt-14 grid w-full max-w-5xl grid-cols-1 overflow-hidden rounded-xl border border-gray-200 bg-gray-50 text-left sm:grid-cols-5 dark:border-gray-800 dark:bg-gray-900">
           {[
             ["Prompt", "Describe the deck"],
-            ["Agent skills", "Design and review"],
+            ["Agent skills", "Match, design, review"],
             ["pom XML", "Editable source of truth"],
             ["pom CLI", "Preview and build"],
             ["PPTX", "Native PowerPoint"],
@@ -262,11 +262,13 @@ export default async function LandingPage() {
             />
           </div>
           <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">
-            Requires Node.js 22+. In Claude Code, you can invoke the skill as
-            <code> /pom-slide</code>; in Codex and other agents, use the natural
-            language request above. Use the <code>pom-theme</code> skill first
-            to onboard brand colors and typography. If preview does not start
-            automatically, run <code>pom preview slides.pom.xml</code>.
+            Requires Node.js 22+. Agents can select installed skills
+            automatically when your request matches their descriptions, so you
+            do not need to name one. To onboard brand colors first, ask your
+            agent to create a pom theme from your brand assets. If needed, use
+            your agent&apos;s skill picker for direct invocation. If preview
+            does not start automatically, run{" "}
+            <code>pom preview slides.pom.xml</code>.
           </p>
         </div>
       </section>

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -111,18 +111,26 @@ const { pptx } = await buildPptx(xml, { w: 1280, h: 720 });
 await pptx.writeFile({ fileName: "presentation.pptx" });`;
 
 export default async function LandingPage() {
-  const [highlightedCode, highlightedKitInstall, highlightedPreview] =
-    await Promise.all([
-      codeToHtml(codeExample, { lang: "typescript", theme: "github-dark" }),
-      codeToHtml(
-        `npx skills add hirokisakabe/pom --all\nnpm install -g @hirokisakabe/pom-cli`,
-        { lang: "bash", theme: "github-dark" },
-      ),
-      codeToHtml(
-        `/pom-slide Create a three-slide quarterly sales report\n\npom preview slides.pom.xml\npom build slides.pom.xml -o slides.pptx`,
-        { lang: "bash", theme: "github-dark" },
-      ),
-    ]);
+  const [
+    highlightedCode,
+    highlightedKitInstall,
+    highlightedPrompt,
+    highlightedBuild,
+  ] = await Promise.all([
+    codeToHtml(codeExample, { lang: "typescript", theme: "github-dark" }),
+    codeToHtml(
+      `npx skills add hirokisakabe/pom --all\nnpm install -g @hirokisakabe/pom-cli`,
+      { lang: "bash", theme: "github-dark" },
+    ),
+    codeToHtml(
+      `Use the pom-slide skill to create a three-slide quarterly sales report.`,
+      { lang: "text", theme: "github-dark" },
+    ),
+    codeToHtml(`pom build slides.pom.xml -o slides.pptx`, {
+      lang: "bash",
+      theme: "github-dark",
+    }),
+  ]);
 
   return (
     <div
@@ -237,17 +245,28 @@ export default async function LandingPage() {
           </div>
           <div>
             <p className="mb-2 text-sm font-medium text-gray-500">
-              2. Prompt, preview, and build
+              2. Ask your agent
             </p>
             <div
               className="overflow-x-auto rounded-lg font-[family-name:var(--font-geist-mono)] text-sm leading-relaxed [&_pre]:px-5 [&_pre]:py-4"
-              dangerouslySetInnerHTML={{ __html: highlightedPreview }}
+              dangerouslySetInnerHTML={{ __html: highlightedPrompt }}
+            />
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-500">
+              3. Build with pom CLI
+            </p>
+            <div
+              className="overflow-x-auto rounded-lg font-[family-name:var(--font-geist-mono)] text-sm leading-relaxed [&_pre]:px-5 [&_pre]:py-4"
+              dangerouslySetInnerHTML={{ __html: highlightedBuild }}
             />
           </div>
           <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">
-            Use <code>/pom-theme</code> first when you want to onboard brand
-            colors and typography. Continue editing the XML directly or with
-            follow-up prompts; the CLI refreshes the preview as it changes.
+            Requires Node.js 22+. In Claude Code, you can invoke the skill as
+            <code> /pom-slide</code>; in Codex and other agents, use the natural
+            language request above. Use the <code>pom-theme</code> skill first
+            to onboard brand colors and typography. If preview does not start
+            automatically, run <code>pom preview slides.pom.xml</code>.
           </p>
         </div>
       </section>


### PR DESCRIPTION
close #871

## 目的

landing page と root README の第一導線を library-first から pom kit（agent skills → pom CLI → pom XML → PPTX）中心へ整理します。

## 変更内容

- landing page の hero と第一 CTA に prompt-to-PPTX workflow を表示
- landing page の最初の Quick Start を skills / pom-cli の install と agent-neutral な usage に変更
- `buildPptx` の例を advanced / programmatic library use として維持
- root README の Packages table に pom-cli / pom-jsx / pom-editor を追加
- skills、XML、Markdown、JSX、visual editor が pom XML に収束する authoring surface の関係を明記
- cross-review の指摘に沿い、agent prompt と shell command を分離し、Claude Code / Codex の起動方法の違いと Node.js 要件を補足

## 影響範囲

- `README.md`
- `apps/website/app/page.tsx`

コード生成 pipeline や各 package API への変更はありません。

## ローカル検証

- `pnpm --filter pom-docs run fmt:check`
- `pnpm --filter pom-docs run lint`
- `pnpm --filter pom-docs run knip`
- `pnpm --filter pom-docs run typecheck`
- `pnpm --filter pom-docs run test:run`（73 tests）
- `pnpm --filter pom-docs run build`
- landing page の desktop / mobile screenshot 目視確認
- 第一 CTA が `#quick-start` へ遷移することをブラウザで確認
