### PR TITLE
pom-cli preview に PomEditor の編集 UI を組み込む

### DIFF
--- a/.changeset/modern-beans-edit.md
+++ b/.changeset/modern-beans-edit.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-cli": minor
+---
+
+Add the shared PomEditor to `pom preview`, including unsaved XML/AST previews, explicit atomic saves, and external-change conflict detection.

--- a/.github/workflows/ci-pom-cli.yml
+++ b/.github/workflows/ci-pom-cli.yml
@@ -7,9 +7,11 @@ on:
       - "packages/pom-cli/**"
       - "packages/pom/src/**"
       - "packages/pom-md/**"
+      - "packages/pom-editor/src/**"
       - "package.json"
       - "eslint.config.shared.mjs"
       - "packages/pom/package.json"
+      - "packages/pom-editor/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".node-version"
@@ -20,9 +22,11 @@ on:
       - "packages/pom-cli/**"
       - "packages/pom/src/**"
       - "packages/pom-md/**"
+      - "packages/pom-editor/src/**"
       - "package.json"
       - "eslint.config.shared.mjs"
       - "packages/pom/package.json"
+      - "packages/pom-editor/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".node-version"
@@ -48,6 +52,8 @@ jobs:
       - run: pnpm --filter @hirokisakabe/pom run build
         working-directory: .
       - run: pnpm --filter @hirokisakabe/pom-md run build
+        working-directory: .
+      - run: pnpm --filter @hirokisakabe/pom-editor run build
         working-directory: .
       - run: pnpm run fmt:check
       - run: pnpm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       - run: pnpm --filter @hirokisakabe/pom-md run lint
       - run: pnpm --filter @hirokisakabe/pom-md run typecheck
       - run: pnpm --filter @hirokisakabe/pom-md run test:run
+      - run: pnpm --filter @hirokisakabe/pom-editor run build
       - run: pnpm --filter @hirokisakabe/pom-cli run build
       - run: pnpm --filter @hirokisakabe/pom-cli run fmt:check
       - run: pnpm --filter @hirokisakabe/pom-cli run lint
@@ -48,7 +49,6 @@ jobs:
       - run: pnpm --filter @hirokisakabe/pom-jsx run lint
       - run: pnpm --filter @hirokisakabe/pom-jsx run typecheck
       - run: pnpm --filter @hirokisakabe/pom-jsx run test:run
-      - run: pnpm --filter @hirokisakabe/pom-editor run build
       - run: pnpm --filter @hirokisakabe/pom-editor run fmt:check
       - run: pnpm --filter @hirokisakabe/pom-editor run lint
       - run: pnpm --filter @hirokisakabe/pom-editor run typecheck

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -12,7 +12,7 @@
 
 ## Features
 
-- **Live Preview Server** — `pom preview` opens a browser, watches the source file, and rebuilds + reloads on every save (handles editor atomic writes like Vim).
+- **Browser Editor + Live Preview** — `pom preview` opens the shared `PomEditor`, with XML / AST editing, unsaved previews, and explicit conflict-safe saves for `.pom.xml` files.
 - **PPTX Build** — `pom build` converts `.pom.xml` / `.pom.md` to a `.pptx` file, with optional `--watch` mode for incremental rebuilds.
 - **PNG / SVG Render** — `pom render` rasterizes each slide to PNG (default) or SVG without LibreOffice, useful for slide-image previews in docs.
 - **Theme Extraction** — `pom theme extract` reads an existing `.pptx` and prints its theme colors as pom `ThemeTokens` JSON, for onboarding brand assets.
@@ -36,20 +36,22 @@ One command is all it takes — no global install required:
 npx @hirokisakabe/pom-cli preview slides.pom.xml
 ```
 
-This starts a local preview server, opens your browser automatically, and live-reloads the preview every time the file is saved. This also works well when invoked from agent skills or scripts.
+This starts a local editor and preview server and opens your browser automatically. The editor client is bundled with `pom-cli`, so it does not need a CDN or an internet connection. This also works well when invoked from agent skills or scripts.
 
 ## Usage
 
 ### Preview
 
-Starts a local preview server with live reload on file changes.
+Starts the browser editor and live preview server.
 
 ```bash
 pom preview slides.pom.xml
 pom preview slides.pom.md
 ```
 
-The browser opens http://localhost:3000 automatically. The page updates whenever the file is saved — including atomic saves performed by editors like Vim.
+The browser opens http://localhost:3000 automatically. For `.pom.xml` files, XML and AST edits are kept in the browser and immediately reflected in the preview. Use **Save** to write the current XML back to the input file. If another editor changed the file after it was loaded, Save is rejected instead of overwriting that change. Successful saves replace the file atomically.
+
+External file changes continue to update the browser when there are no unsaved browser edits. When unsaved edits exist, they are preserved and the toolbar reports the external change. `.pom.md` input remains preview-only because writing generated XML back to Markdown is outside the editor's scope.
 
 To suppress the automatic browser open (e.g. in CI or headless environments):
 
@@ -62,8 +64,6 @@ To use a different port (e.g. when 3000 is already in use):
 ```bash
 pom preview slides.pom.xml --port 3001
 ```
-
-Use the zoom buttons in the toolbar or press `+` / `-` to zoom in and out. The current zoom level is saved across sessions.
 
 To print per-step timing on stderr when each rebuild completes:
 

--- a/packages/pom-cli/client/App.test.tsx
+++ b/packages/pom-cli/client/App.test.tsx
@@ -219,4 +219,33 @@ describe("CLI preview App", () => {
 
     expect(await screen.findByText("Saved")).toBeTruthy();
   });
+
+  it("Save後に再編集してもSave内容の通知をexternal change扱いしない", async () => {
+    arrangeDocument();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    let resolveSave: ((revision: string) => void) | undefined;
+    api.saveDocument.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    render(<App />);
+    const editor = await screen.findByRole("textbox", { name: "XML editor" });
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+    fireEvent.change(editor, { target: { value: "<Text>saving</Text>" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.change(editor, { target: { value: "<Text>new edit</Text>" } });
+
+    FakeEventSource.instances[0]?.emit({
+      xml: "<Text>saving</Text>",
+      revision: "revision-2",
+      filename: "slides.pom.xml",
+      editable: true,
+    });
+    resolveSave?.("revision-2");
+
+    await waitFor(() =>
+      expect(screen.getByRole("status").textContent).toBe("Unsaved changes"),
+    );
+  });
 });

--- a/packages/pom-cli/client/App.test.tsx
+++ b/packages/pom-cli/client/App.test.tsx
@@ -201,4 +201,22 @@ describe("CLI preview App", () => {
       ),
     ).toBeTruthy();
   });
+
+  it("Save内容と一致するdocument通知を保存成功として反映する", async () => {
+    arrangeDocument();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    render(<App />);
+    const editor = await screen.findByRole("textbox", { name: "XML editor" });
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+    fireEvent.change(editor, { target: { value: "<Text>browser</Text>" } });
+
+    FakeEventSource.instances[0]?.emit({
+      xml: "<Text>browser</Text>",
+      revision: "revision-2",
+      filename: "slides.pom.xml",
+      editable: true,
+    });
+
+    expect(await screen.findByText("Saved")).toBeTruthy();
+  });
 });

--- a/packages/pom-cli/client/App.test.tsx
+++ b/packages/pom-cli/client/App.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PomEditorProps } from "@hirokisakabe/pom-editor";
+
+const api = vi.hoisted(() => ({
+  generatePreview: vi.fn(),
+  loadDocument: vi.fn(),
+  saveDocument: vi.fn(),
+}));
+
+vi.mock("./api.ts", () => api);
+vi.mock("@hirokisakabe/pom-editor", () => ({
+  PomEditor: (props: PomEditorProps) => {
+    const [error, setError] = useState<string | null>(null);
+    return (
+      <div data-testid="shared-pom-editor">
+        <textarea
+          aria-label="XML editor"
+          value={props.xml}
+          onChange={(event) => props.onChange(event.target.value)}
+        />
+        <button
+          type="button"
+          onClick={() => props.onChange("<Text>AST DnD result</Text>")}
+        >
+          Simulate AST DnD
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            void props.onPreview(props.xml, {
+              signal: new AbortController().signal,
+            })
+          }
+        >
+          Preview
+        </button>
+        {props.onSave && (
+          <button
+            type="button"
+            onClick={() =>
+              void Promise.resolve(props.onSave?.(props.xml)).catch((reason) =>
+                setError(
+                  reason instanceof Error ? reason.message : String(reason),
+                ),
+              )
+            }
+          >
+            Save
+          </button>
+        )}
+        {props.toolbarStart}
+        {props.toolbarEnd}
+        {error && <div role="alert">{error}</div>}
+      </div>
+    );
+  },
+}));
+
+import { App } from "./App.tsx";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function arrangeDocument() {
+  api.loadDocument.mockResolvedValue({
+    xml: "<Text>initial</Text>",
+    revision: "revision-1",
+    filename: "slides.pom.xml",
+    editable: true,
+  });
+  api.generatePreview.mockResolvedValue({ svgs: [] });
+  api.saveDocument.mockResolvedValue("revision-2");
+}
+
+describe("CLI preview App", () => {
+  it("共通PomEditorのXML変更とAST DnD結果を未保存previewへ渡す", async () => {
+    arrangeDocument();
+    render(<App />);
+    expect(await screen.findByTestId("shared-pom-editor")).toBeTruthy();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "XML editor" }), {
+      target: { value: "<Text>XML edit</Text>" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    expect(api.generatePreview).toHaveBeenLastCalledWith(
+      "<Text>XML edit</Text>",
+      expect.any(AbortSignal),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Simulate AST DnD" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    expect(api.generatePreview).toHaveBeenLastCalledWith(
+      "<Text>AST DnD result</Text>",
+      expect.any(AbortSignal),
+    );
+    expect(screen.getByRole("status").textContent).toBe("Unsaved changes");
+  });
+
+  it("Saveへ編集中XMLと読込時revisionを渡し、成功後にSaved表示へ戻す", async () => {
+    arrangeDocument();
+    render(<App />);
+    const editor = await screen.findByRole("textbox", { name: "XML editor" });
+    fireEvent.change(editor, { target: { value: "<Text>saved</Text>" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(api.saveDocument).toHaveBeenCalledWith(
+        "<Text>saved</Text>",
+        "revision-1",
+      ),
+    );
+    expect(await screen.findByText("Saved")).toBeTruthy();
+  });
+
+  it("external change conflictをPomEditor内のerrorとして表示する", async () => {
+    arrangeDocument();
+    api.saveDocument.mockRejectedValue(
+      new Error("The file changed outside pom preview. Reload before saving."),
+    );
+    render(<App />);
+    const editor = await screen.findByRole("textbox", { name: "XML editor" });
+    fireEvent.change(editor, { target: { value: "<Text>conflict</Text>" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "The file changed outside pom preview",
+    );
+  });
+});

--- a/packages/pom-cli/client/App.test.tsx
+++ b/packages/pom-cli/client/App.test.tsx
@@ -67,9 +67,43 @@ vi.mock("@hirokisakabe/pom-editor", () => ({
 
 import { App } from "./App.tsx";
 
+type DocumentEvent = {
+  xml: string;
+  revision: string;
+  filename: string;
+  editable: boolean;
+};
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  private documentListener: ((event: MessageEvent<string>) => void) | null =
+    null;
+
+  constructor(_url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent<string>) => void,
+  ) {
+    if (type === "document") this.documentListener = listener;
+  }
+
+  emit(document: DocumentEvent) {
+    this.documentListener?.(
+      new MessageEvent("document", { data: JSON.stringify(document) }),
+    );
+  }
+
+  close() {}
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  FakeEventSource.instances.length = 0;
 });
 
 function arrangeDocument() {
@@ -136,5 +170,35 @@ describe("CLI preview App", () => {
     expect((await screen.findByRole("alert")).textContent).toContain(
       "The file changed outside pom preview",
     );
+  });
+
+  it("Save処理中に届いたexternal change通知をsuccess responseで消さない", async () => {
+    arrangeDocument();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    let resolveSave: ((revision: string) => void) | undefined;
+    api.saveDocument.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    render(<App />);
+    const editor = await screen.findByRole("textbox", { name: "XML editor" });
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+    fireEvent.change(editor, { target: { value: "<Text>browser</Text>" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    FakeEventSource.instances[0]?.emit({
+      xml: "<Text>external</Text>",
+      revision: "external-revision",
+      filename: "slides.pom.xml",
+      editable: true,
+    });
+    resolveSave?.("revision-2");
+
+    expect(
+      await screen.findByText(
+        "External changes detected — Save will be blocked",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/packages/pom-cli/client/App.tsx
+++ b/packages/pom-cli/client/App.tsx
@@ -61,6 +61,13 @@ export function App() {
         setExternalChange(true);
         return;
       }
+      if (updated.xml === xmlRef.current) {
+        savedXmlRef.current = updated.xml;
+        setSavedXml(updated.xml);
+        setDocument(updated);
+        setExternalChange(false);
+        return;
+      }
       if (xmlRef.current !== savedXmlRef.current) {
         setExternalChange(true);
         return;

--- a/packages/pom-cli/client/App.tsx
+++ b/packages/pom-cli/client/App.tsx
@@ -24,6 +24,7 @@ export function App() {
   const [externalChange, setExternalChange] = useState(false);
   const xmlRef = useRef("");
   const savedXmlRef = useRef("");
+  const pendingSaveXmlRef = useRef<string | null>(null);
   const eventGenerationRef = useRef(0);
 
   useEffect(() => {
@@ -68,6 +69,16 @@ export function App() {
         setExternalChange(false);
         return;
       }
+      if (
+        updated.xml === pendingSaveXmlRef.current ||
+        updated.xml === savedXmlRef.current
+      ) {
+        savedXmlRef.current = updated.xml;
+        setSavedXml(updated.xml);
+        setDocument(updated);
+        setExternalChange(false);
+        return;
+      }
       if (xmlRef.current !== savedXmlRef.current) {
         setExternalChange(true);
         return;
@@ -102,14 +113,21 @@ export function App() {
         document.editable
           ? async (value) => {
               const eventGeneration = eventGenerationRef.current;
-              const revision = await saveDocument(value, document.revision);
-              savedXmlRef.current = value;
-              setSavedXml(value);
-              setDocument((current) =>
-                current ? { ...current, revision } : current,
-              );
-              if (eventGenerationRef.current === eventGeneration) {
-                setExternalChange(false);
+              pendingSaveXmlRef.current = value;
+              try {
+                const revision = await saveDocument(value, document.revision);
+                savedXmlRef.current = value;
+                setSavedXml(value);
+                setDocument((current) =>
+                  current ? { ...current, revision } : current,
+                );
+                if (eventGenerationRef.current === eventGeneration) {
+                  setExternalChange(false);
+                }
+              } finally {
+                if (pendingSaveXmlRef.current === value) {
+                  pendingSaveXmlRef.current = null;
+                }
               }
             }
           : undefined

--- a/packages/pom-cli/client/App.tsx
+++ b/packages/pom-cli/client/App.tsx
@@ -22,7 +22,9 @@ export function App() {
   const [savedXml, setSavedXml] = useState("");
   const [loadError, setLoadError] = useState<string | null>(null);
   const [externalChange, setExternalChange] = useState(false);
+  const xmlRef = useRef("");
   const savedXmlRef = useRef("");
+  const eventGenerationRef = useRef(0);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -31,6 +33,7 @@ export function App() {
         setDocument(loaded);
         setXml(loaded.xml);
         setSavedXml(loaded.xml);
+        xmlRef.current = loaded.xml;
         savedXmlRef.current = loaded.xml;
       })
       .catch((error: unknown) => {
@@ -45,23 +48,23 @@ export function App() {
     if (!document || typeof EventSource === "undefined") return;
     const source = new EventSource("/_events");
     source.addEventListener("document", (event) => {
+      eventGenerationRef.current += 1;
       const updated = JSON.parse((event as MessageEvent<string>).data) as
         PreviewDocument | { error: string };
       if ("error" in updated) {
         setExternalChange(true);
         return;
       }
-      setXml((currentXml) => {
-        if (currentXml !== savedXmlRef.current) {
-          setExternalChange(true);
-          return currentXml;
-        }
-        savedXmlRef.current = updated.xml;
-        setSavedXml(updated.xml);
-        setDocument(updated);
-        setExternalChange(false);
-        return updated.xml;
-      });
+      if (xmlRef.current !== savedXmlRef.current) {
+        setExternalChange(true);
+        return;
+      }
+      xmlRef.current = updated.xml;
+      savedXmlRef.current = updated.xml;
+      setXml(updated.xml);
+      setSavedXml(updated.xml);
+      setDocument(updated);
+      setExternalChange(false);
     });
     return () => source.close();
   }, [document?.filename]);
@@ -77,18 +80,24 @@ export function App() {
   return (
     <PomEditor
       xml={xml}
-      onChange={setXml}
+      onChange={(value) => {
+        xmlRef.current = value;
+        setXml(value);
+      }}
       onPreview={(value, { signal }) => generatePreview(value, signal)}
       onSave={
         document.editable
           ? async (value) => {
+              const eventGeneration = eventGenerationRef.current;
               const revision = await saveDocument(value, document.revision);
               savedXmlRef.current = value;
               setSavedXml(value);
               setDocument((current) =>
                 current ? { ...current, revision } : current,
               );
-              setExternalChange(false);
+              if (eventGenerationRef.current === eventGeneration) {
+                setExternalChange(false);
+              }
             }
           : undefined
       }

--- a/packages/pom-cli/client/App.tsx
+++ b/packages/pom-cli/client/App.tsx
@@ -49,8 +49,14 @@ export function App() {
     const source = new EventSource("/_events");
     source.addEventListener("document", (event) => {
       eventGenerationRef.current += 1;
-      const updated = JSON.parse((event as MessageEvent<string>).data) as
-        PreviewDocument | { error: string };
+      let updated: PreviewDocument | { error: string };
+      try {
+        updated = JSON.parse((event as MessageEvent<string>).data) as
+          PreviewDocument | { error: string };
+      } catch {
+        setExternalChange(true);
+        return;
+      }
       if ("error" in updated) {
         setExternalChange(true);
         return;

--- a/packages/pom-cli/client/App.tsx
+++ b/packages/pom-cli/client/App.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { PomEditor } from "@hirokisakabe/pom-editor";
+import {
+  generatePreview,
+  loadDocument,
+  saveDocument,
+  type PreviewDocument,
+} from "./api.ts";
+
+const filenameStyle = {
+  overflow: "hidden",
+  color: "#4b5563",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: 12,
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+} as const;
+
+export function App() {
+  const [document, setDocument] = useState<PreviewDocument | null>(null);
+  const [xml, setXml] = useState("");
+  const [savedXml, setSavedXml] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [externalChange, setExternalChange] = useState(false);
+  const savedXmlRef = useRef("");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    loadDocument(controller.signal)
+      .then((loaded) => {
+        setDocument(loaded);
+        setXml(loaded.xml);
+        setSavedXml(loaded.xml);
+        savedXmlRef.current = loaded.xml;
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          setLoadError(error instanceof Error ? error.message : String(error));
+        }
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!document || typeof EventSource === "undefined") return;
+    const source = new EventSource("/_events");
+    source.addEventListener("document", (event) => {
+      const updated = JSON.parse((event as MessageEvent<string>).data) as
+        PreviewDocument | { error: string };
+      if ("error" in updated) {
+        setExternalChange(true);
+        return;
+      }
+      setXml((currentXml) => {
+        if (currentXml !== savedXmlRef.current) {
+          setExternalChange(true);
+          return currentXml;
+        }
+        savedXmlRef.current = updated.xml;
+        setSavedXml(updated.xml);
+        setDocument(updated);
+        setExternalChange(false);
+        return updated.xml;
+      });
+    });
+    return () => source.close();
+  }, [document?.filename]);
+
+  if (loadError) {
+    return <div role="alert">{loadError}</div>;
+  }
+  if (!document) {
+    return <div>Loading editor...</div>;
+  }
+
+  const isDirty = xml !== savedXml;
+  return (
+    <PomEditor
+      xml={xml}
+      onChange={setXml}
+      onPreview={(value, { signal }) => generatePreview(value, signal)}
+      onSave={
+        document.editable
+          ? async (value) => {
+              const revision = await saveDocument(value, document.revision);
+              savedXmlRef.current = value;
+              setSavedXml(value);
+              setDocument((current) =>
+                current ? { ...current, revision } : current,
+              );
+              setExternalChange(false);
+            }
+          : undefined
+      }
+      toolbarStart={
+        <span style={filenameStyle} title={document.filename}>
+          {document.filename}
+        </span>
+      }
+      toolbarEnd={
+        <span
+          role="status"
+          style={{
+            color: externalChange ? "#b45309" : isDirty ? "#2563eb" : "#6b7280",
+            fontSize: 12,
+          }}
+        >
+          {externalChange
+            ? "External changes detected — Save will be blocked"
+            : isDirty
+              ? "Unsaved changes"
+              : document.editable
+                ? "Saved"
+                : "Preview only (.pom.md)"}
+        </span>
+      }
+      style={{ height: "100vh", background: "#fff" }}
+    />
+  );
+}

--- a/packages/pom-cli/client/api.test.ts
+++ b/packages/pom-cli/client/api.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generatePreview, loadDocument, saveDocument } from "./api.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockResponse(status: number, body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("preview client API", () => {
+  it("document responseの必須fieldを検証する", async () => {
+    mockResponse(200, {
+      xml: "<Text />",
+      revision: "revision-1",
+      filename: "slides.pom.xml",
+      editable: true,
+    });
+    await expect(loadDocument()).resolves.toMatchObject({
+      xml: "<Text />",
+      revision: "revision-1",
+    });
+
+    mockResponse(200, { xml: "<Text />" });
+    await expect(loadDocument()).rejects.toThrow("Invalid document response");
+  });
+
+  it("previewへXMLとAbortSignalを渡し、SVG responseを検証する", async () => {
+    const fetchMock = mockResponse(200, { svgs: ["<svg />"] });
+    const signal = new AbortController().signal;
+    await expect(generatePreview("<Text />", signal)).resolves.toEqual({
+      svgs: ["<svg />"],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/_api/preview",
+      expect.objectContaining({
+        body: JSON.stringify({ xml: "<Text />" }),
+        signal,
+      }),
+    );
+
+    mockResponse(200, {});
+    await expect(generatePreview("<Text />", signal)).rejects.toThrow(
+      "Invalid preview response",
+    );
+  });
+
+  it("422 diagnosticsをPomEditorへ返す", async () => {
+    mockResponse(422, {
+      errors: [{ type: "xml_syntax", message: "Invalid XML" }],
+    });
+    await expect(
+      generatePreview("<Text>", new AbortController().signal),
+    ).resolves.toEqual({
+      errors: [{ type: "xml_syntax", message: "Invalid XML" }],
+    });
+  });
+
+  it("Save successのrevisionと409 conflict messageを扱う", async () => {
+    mockResponse(200, { revision: "revision-2" });
+    await expect(saveDocument("<Text />", "revision-1")).resolves.toBe(
+      "revision-2",
+    );
+
+    mockResponse(409, { message: "External change conflict" });
+    await expect(saveDocument("<Text />", "revision-1")).rejects.toThrow(
+      "External change conflict",
+    );
+  });
+});

--- a/packages/pom-cli/client/api.ts
+++ b/packages/pom-cli/client/api.ts
@@ -1,0 +1,59 @@
+import type {
+  PomEditorDiagnostic,
+  PomEditorPreviewResult,
+} from "@hirokisakabe/pom-editor";
+
+export interface PreviewDocument {
+  xml: string;
+  revision: string;
+  filename: string;
+  editable: boolean;
+}
+
+interface ErrorResponse {
+  message?: string;
+  errors?: PomEditorDiagnostic[];
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+export async function loadDocument(signal?: AbortSignal) {
+  const response = await fetch("/_api/document", { signal });
+  if (!response.ok) throw new Error("Failed to load the preview document");
+  return readJson<PreviewDocument>(response);
+}
+
+export async function generatePreview(
+  xml: string,
+  signal: AbortSignal,
+): Promise<PomEditorPreviewResult> {
+  const response = await fetch("/_api/preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ xml }),
+    signal,
+  });
+  const result = await readJson<PomEditorPreviewResult & ErrorResponse>(
+    response,
+  );
+  if (result.errors) return { errors: result.errors };
+  if (!response.ok) throw new Error(result.message ?? "Preview failed");
+  return { svgs: result.svgs ?? [] };
+}
+
+export async function saveDocument(xml: string, revision: string) {
+  const response = await fetch("/_api/document", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ xml, revision }),
+  });
+  const result = await readJson<{ revision?: string; message?: string }>(
+    response,
+  );
+  if (!response.ok || !result.revision) {
+    throw new Error(result.message ?? "Save failed");
+  }
+  return result.revision;
+}

--- a/packages/pom-cli/client/api.ts
+++ b/packages/pom-cli/client/api.ts
@@ -10,19 +10,42 @@ export interface PreviewDocument {
   editable: boolean;
 }
 
-interface ErrorResponse {
-  message?: string;
-  errors?: PomEditorDiagnostic[];
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
-async function readJson<T>(response: Response): Promise<T> {
-  return (await response.json()) as T;
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new Error("Invalid response from the preview server");
+  }
+}
+
+function errorMessage(value: unknown, fallback: string): string {
+  return isRecord(value) && typeof value.message === "string"
+    ? value.message
+    : fallback;
 }
 
 export async function loadDocument(signal?: AbortSignal) {
   const response = await fetch("/_api/document", { signal });
-  if (!response.ok) throw new Error("Failed to load the preview document");
-  return readJson<PreviewDocument>(response);
+  const result = await readJson(response);
+  if (!response.ok) {
+    throw new Error(
+      errorMessage(result, "Failed to load the preview document"),
+    );
+  }
+  if (
+    !isRecord(result) ||
+    typeof result.xml !== "string" ||
+    typeof result.revision !== "string" ||
+    typeof result.filename !== "string" ||
+    typeof result.editable !== "boolean"
+  ) {
+    throw new Error("Invalid document response from the preview server");
+  }
+  return result as unknown as PreviewDocument;
 }
 
 export async function generatePreview(
@@ -35,12 +58,19 @@ export async function generatePreview(
     body: JSON.stringify({ xml }),
     signal,
   });
-  const result = await readJson<PomEditorPreviewResult & ErrorResponse>(
-    response,
-  );
-  if (result.errors) return { errors: result.errors };
-  if (!response.ok) throw new Error(result.message ?? "Preview failed");
-  return { svgs: result.svgs ?? [] };
+  const result = await readJson(response);
+  if (isRecord(result) && Array.isArray(result.errors)) {
+    return { errors: result.errors as PomEditorDiagnostic[] };
+  }
+  if (!response.ok) throw new Error(errorMessage(result, "Preview failed"));
+  if (
+    !isRecord(result) ||
+    !Array.isArray(result.svgs) ||
+    !result.svgs.every((svg) => typeof svg === "string")
+  ) {
+    throw new Error("Invalid preview response from the preview server");
+  }
+  return { svgs: result.svgs } satisfies PomEditorPreviewResult;
 }
 
 export async function saveDocument(xml: string, revision: string) {
@@ -49,11 +79,13 @@ export async function saveDocument(xml: string, revision: string) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ xml, revision }),
   });
-  const result = await readJson<{ revision?: string; message?: string }>(
-    response,
-  );
-  if (!response.ok || !result.revision) {
-    throw new Error(result.message ?? "Save failed");
+  const result = await readJson(response);
+  if (
+    !response.ok ||
+    !isRecord(result) ||
+    typeof result.revision !== "string"
+  ) {
+    throw new Error(errorMessage(result, "Save failed"));
   }
   return result.revision;
 }

--- a/packages/pom-cli/client/main.tsx
+++ b/packages/pom-cli/client/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Preview root element was not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/pom-cli/client/react-shim.ts
+++ b/packages/pom-cli/client/react-shim.ts
@@ -1,0 +1,3 @@
+import * as React from "react";
+
+export { React };

--- a/packages/pom-cli/eslint.config.mts
+++ b/packages/pom-cli/eslint.config.mts
@@ -3,6 +3,6 @@ import { defineSharedConfig } from "../../eslint.config.shared.mjs";
 export default defineSharedConfig({
   tsconfigRootDir: import.meta.dirname,
   environment: "node",
-  files: ["**/*.{ts,mts,cts}"],
+  files: ["**/*.{ts,tsx,mts,cts}"],
   ignores: ["**/*.test.ts", "eslint.config.mts", "vitest.config.ts"],
 });

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -30,11 +30,12 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('dist/cli.js', '755')\"",
+    "build": "tsc -p tsconfig.build.json && pnpm run build:client && node -e \"require('fs').chmodSync('dist/cli.js', '755')\"",
+    "build:client": "esbuild client/main.tsx --bundle --format=iife --platform=browser --target=es2022 --inject:client/react-shim.ts --minify --outfile=dist/assets/preview.js",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "knip": "knip",
     "test": "vitest",
     "test:run": "vitest run"
@@ -46,6 +47,14 @@
     "pptx-glimpse": "^3.2.3"
   },
   "devDependencies": {
-    "@types/node": "^26.1.0"
+    "@hirokisakabe/pom-editor": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^26.1.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "esbuild": "^0.28.1",
+    "jsdom": "^29.1.1",
+    "react": "^19",
+    "react-dom": "^19"
   }
 }

--- a/packages/pom-cli/src/input.ts
+++ b/packages/pom-cli/src/input.ts
@@ -14,6 +14,14 @@ export function loadInput(
   log: (msg: string) => void = () => {},
 ): LoadedInput {
   const content = fs.readFileSync(absInput, "utf-8");
+  return loadInputContent(absInput, content, log);
+}
+
+export function loadInputContent(
+  absInput: string,
+  content: string,
+  log: (msg: string) => void = () => {},
+): LoadedInput {
   const ext = path.extname(absInput);
 
   let xml: string;

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  atomicWriteFile,
+  createPreviewServer,
+  readPreviewDocument,
+  savePreviewDocument,
+} from "./preview.ts";
+
+const INITIAL_XML = "<VStack><Text>initial</Text></VStack>";
+let tempDir: string;
+let inputFile: string;
+let server: http.Server | null;
+let baseUrl: string;
+
+beforeEach(async () => {
+  tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pom-preview-"));
+  inputFile = path.join(tempDir, "slides.pom.xml");
+  await fs.promises.writeFile(inputFile, INITIAL_XML);
+  server = null;
+});
+
+afterEach(async () => {
+  if (server?.listening) {
+    await new Promise<void>((resolve, reject) =>
+      server?.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+  await fs.promises.rm(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function startServer(
+  generatePreview = vi.fn().mockResolvedValue({ svgs: [] }),
+) {
+  server = createPreviewServer(inputFile, {
+    clientScript: "globalThis.__POM_PREVIEW_CLIENT__ = true;",
+    generatePreview,
+  });
+  await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("No server address");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+  return generatePreview;
+}
+
+describe("preview document save", () => {
+  it("同一directoryの一時fileをrenameしてatomicに更新する", async () => {
+    const rename = vi.spyOn(fs.promises, "rename");
+    await atomicWriteFile(inputFile, "<Text>atomic</Text>");
+
+    expect(await fs.promises.readFile(inputFile, "utf8")).toBe(
+      "<Text>atomic</Text>",
+    );
+    expect(rename).toHaveBeenCalledTimes(1);
+    const [temporaryPath, targetPath] = rename.mock.calls[0] ?? [];
+    expect(path.dirname(String(temporaryPath))).toBe(tempDir);
+    expect(targetPath).toBe(inputFile);
+  });
+
+  it("外部変更後のSaveを拒否し、対象fileを上書きしない", async () => {
+    const revision = readPreviewDocument(inputFile).revision;
+    await fs.promises.writeFile(inputFile, "<Text>external</Text>");
+
+    await expect(
+      savePreviewDocument(inputFile, "<Text>browser</Text>", revision),
+    ).rejects.toThrow("changed outside pom preview");
+    expect(await fs.promises.readFile(inputFile, "utf8")).toBe(
+      "<Text>external</Text>",
+    );
+  });
+});
+
+describe("preview server", () => {
+  it("PomEditor client assetをlocal endpointから配信する", async () => {
+    await startServer();
+    const html = await fetch(baseUrl).then((response) => response.text());
+    const asset = await fetch(`${baseUrl}/_assets/preview.js`).then(
+      (response) => response.text(),
+    );
+
+    expect(html).toContain('<script src="/_assets/preview.js"');
+    expect(html).not.toMatch(/https?:\/\/.*(?:jsdelivr|unpkg|cdnjs)/);
+    expect(asset).toContain("__POM_PREVIEW_CLIENT__");
+  });
+
+  it("編集中の未保存XMLをpreview APIへ渡す", async () => {
+    const generatePreview = await startServer();
+    const xml = "<Text>unsaved</Text>";
+    const response = await fetch(`${baseUrl}/_api/preview`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(generatePreview).toHaveBeenCalledWith(xml);
+  });
+
+  it("Save APIで対象fileを更新し、自身のwatchからpreview生成を重複実行しない", async () => {
+    const generatePreview = await startServer();
+    const document = await fetch(`${baseUrl}/_api/document`).then(
+      (response) => response.json() as Promise<{ revision: string }>,
+    );
+    const xml = "<Text>saved from browser</Text>";
+    const response = await fetch(`${baseUrl}/_api/document`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml, revision: document.revision }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await fs.promises.readFile(inputFile, "utf8")).toBe(xml);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(generatePreview).not.toHaveBeenCalled();
+  });
+
+  it("外部変更後のSave APIは409 conflictを返す", async () => {
+    await startServer();
+    const document = await fetch(`${baseUrl}/_api/document`).then(
+      (response) => response.json() as Promise<{ revision: string }>,
+    );
+    await fs.promises.writeFile(inputFile, "<Text>external</Text>");
+    const response = await fetch(`${baseUrl}/_api/document`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        xml: "<Text>browser</Text>",
+        revision: document.revision,
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ code: "conflict" });
+    expect(await fs.promises.readFile(inputFile, "utf8")).toBe(
+      "<Text>external</Text>",
+    );
+  });
+});

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -88,6 +88,25 @@ describe("preview document save", () => {
       "<Text>external</Text>",
     );
   });
+
+  it("一時file作成中の外部変更もrename前の再検査で拒否する", async () => {
+    const revision = readPreviewDocument(inputFile).revision;
+    const originalReadFile = fs.promises.readFile.bind(fs.promises);
+    let targetReads = 0;
+    vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args) => {
+      if (String(args[0]) === inputFile && ++targetReads === 2) {
+        await fs.promises.writeFile(inputFile, "<Text>external late</Text>");
+      }
+      return originalReadFile(...args);
+    });
+
+    await expect(
+      savePreviewDocument(inputFile, "<Text>browser</Text>", revision),
+    ).rejects.toThrow("changed outside pom preview");
+    expect(await originalReadFile(inputFile, "utf8")).toBe(
+      "<Text>external late</Text>",
+    );
+  });
 });
 
 describe("preview server", () => {
@@ -101,6 +120,29 @@ describe("preview server", () => {
     expect(html).toContain('<script src="/_assets/preview.js"');
     expect(html).not.toMatch(/https?:\/\/.*(?:jsdelivr|unpkg|cdnjs)/);
     expect(asset).toContain("__POM_PREVIEW_CLIENT__");
+  });
+
+  it("localhost以外のHostとcross-origin requestを拒否する", async () => {
+    await startServer();
+    const invalidHostStatus = await new Promise<number | undefined>(
+      (resolve, reject) => {
+        const request = http.get(
+          `${baseUrl}/_api/document`,
+          { headers: { Host: "example.com" } },
+          (response) => {
+            response.resume();
+            response.on("end", () => resolve(response.statusCode));
+          },
+        );
+        request.on("error", reject);
+      },
+    );
+    const invalidOrigin = await fetch(`${baseUrl}/_api/document`, {
+      headers: { Origin: "https://example.com" },
+    });
+
+    expect(invalidHostStatus).toBe(403);
+    expect(invalidOrigin.status).toBe(403);
   });
 
   it("編集中の未保存XMLをpreview APIへ渡す", async () => {

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -158,6 +158,17 @@ describe("preview server", () => {
     expect(generatePreview).toHaveBeenCalledWith(xml);
   });
 
+  it("request body上限超過を413で返す", async () => {
+    await startServer();
+    const response = await fetch(`${baseUrl}/_api/preview`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml: "x".repeat(10 * 1024 * 1024) }),
+    });
+
+    expect(response.status).toBe(413);
+  });
+
   it("Save後のwatch通知を抑止し、後続のexternal changeだけを配信する", async () => {
     const onDocumentEvent = vi.fn();
     const generatePreview = await startServer(undefined, onDocumentEvent);

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -3,6 +3,18 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const watchState = vi.hoisted(() => ({
+  callback: null as (() => void) | null,
+}));
+
+vi.mock("./watch.ts", () => ({
+  watchInputFile: (_absPath: string, onChange: () => void) => {
+    watchState.callback = onChange;
+    return { close: vi.fn() };
+  },
+}));
+
 import {
   atomicWriteFile,
   createPreviewServer,
@@ -21,6 +33,7 @@ beforeEach(async () => {
   inputFile = path.join(tempDir, "slides.pom.xml");
   await fs.promises.writeFile(inputFile, INITIAL_XML);
   server = null;
+  watchState.callback = null;
 });
 
 afterEach(async () => {
@@ -35,10 +48,12 @@ afterEach(async () => {
 
 async function startServer(
   generatePreview = vi.fn().mockResolvedValue({ svgs: [] }),
+  onDocumentEvent?: ReturnType<typeof vi.fn>,
 ) {
   server = createPreviewServer(inputFile, {
     clientScript: "globalThis.__POM_PREVIEW_CLIENT__ = true;",
     generatePreview,
+    onDocumentEvent,
   });
   await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
   const address = server.address();
@@ -101,8 +116,9 @@ describe("preview server", () => {
     expect(generatePreview).toHaveBeenCalledWith(xml);
   });
 
-  it("Save APIで対象fileを更新し、自身のwatchからpreview生成を重複実行しない", async () => {
-    const generatePreview = await startServer();
+  it("Save後のwatch通知を抑止し、後続のexternal changeだけを配信する", async () => {
+    const onDocumentEvent = vi.fn();
+    const generatePreview = await startServer(undefined, onDocumentEvent);
     const document = await fetch(`${baseUrl}/_api/document`).then(
       (response) => response.json() as Promise<{ revision: string }>,
     );
@@ -115,7 +131,13 @@ describe("preview server", () => {
 
     expect(response.status).toBe(200);
     expect(await fs.promises.readFile(inputFile, "utf8")).toBe(xml);
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    watchState.callback?.();
+    await fs.promises.writeFile(inputFile, "<Text>external after save</Text>");
+    watchState.callback?.();
+    expect(onDocumentEvent).toHaveBeenCalledTimes(1);
+    expect(onDocumentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ xml: "<Text>external after save</Text>" }),
+    );
     expect(generatePreview).not.toHaveBeenCalled();
   });
 

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -176,8 +176,13 @@ describe("preview server", () => {
     watchState.callback?.();
     await fs.promises.writeFile(inputFile, "<Text>external after save</Text>");
     watchState.callback?.();
-    expect(onDocumentEvent).toHaveBeenCalledTimes(1);
-    expect(onDocumentEvent).toHaveBeenCalledWith(
+    expect(onDocumentEvent).toHaveBeenCalledTimes(2);
+    expect(onDocumentEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ xml }),
+    );
+    expect(onDocumentEvent).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({ xml: "<Text>external after save</Text>" }),
     );
     expect(generatePreview).not.toHaveBeenCalled();
@@ -202,6 +207,31 @@ describe("preview server", () => {
     await expect(response.json()).resolves.toMatchObject({ code: "conflict" });
     expect(await fs.promises.readFile(inputFile, "utf8")).toBe(
       "<Text>external</Text>",
+    );
+  });
+
+  it("同じrevisionからの同時Saveは一方だけを受け付ける", async () => {
+    await startServer();
+    const document = await fetch(`${baseUrl}/_api/document`).then(
+      (response) => response.json() as Promise<{ revision: string }>,
+    );
+    const save = (xml: string) =>
+      fetch(`${baseUrl}/_api/document`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ xml, revision: document.revision }),
+      });
+
+    const responses = await Promise.all([
+      save("<Text>first</Text>"),
+      save("<Text>second</Text>"),
+    ]);
+
+    expect(responses.map((response) => response.status).sort()).toEqual([
+      200, 409,
+    ]);
+    expect(["<Text>first</Text>", "<Text>second</Text>"]).toContain(
+      await fs.promises.readFile(inputFile, "utf8"),
     );
   });
 });

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { buildPptx, DiagnosticsError } from "@hirokisakabe/pom";
 import { convertPptxToSvg } from "pptx-glimpse";
 import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
-import { loadInput, type LoadedInput } from "./input.ts";
+import { loadInput, loadInputContent, type LoadedInput } from "./input.ts";
 import { watchInputFile } from "./watch.ts";
 
 const DEFAULT_PORT = 3000;
@@ -42,6 +42,8 @@ class SaveConflictError extends Error {
   }
 }
 
+class RequestTooLargeError extends Error {}
+
 function makeLog(verbose: boolean) {
   if (!verbose) return (_msg: string) => {};
   return (msg: string) => process.stderr.write(`[pom] ${msg}\n`);
@@ -73,7 +75,7 @@ function revisionOf(content: string): string {
 
 export function readPreviewDocument(absInput: string): PreviewDocument {
   const content = fs.readFileSync(absInput, "utf8");
-  const loaded = loadInput(absInput);
+  const loaded = loadInputContent(absInput, content);
   return {
     xml: loaded.xml,
     revision: revisionOf(content),
@@ -206,17 +208,21 @@ async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let body = "";
     let bytes = 0;
+    let tooLarge = false;
     req.setEncoding("utf8");
     req.on("data", (chunk: string) => {
+      if (tooLarge) return;
       bytes += Buffer.byteLength(chunk);
       if (bytes > MAX_REQUEST_BYTES) {
-        reject(new Error("Request body is too large"));
-        req.destroy();
+        tooLarge = true;
+        body = "";
+        reject(new RequestTooLargeError("Request body is too large"));
         return;
       }
       body += chunk;
     });
     req.on("end", () => {
+      if (tooLarge) return;
       try {
         resolve(JSON.parse(body) as unknown);
       } catch (error) {
@@ -410,7 +416,7 @@ export function createPreviewServer(
       }
       sendJson(res, 404, { message: "Not found" });
     } catch (error) {
-      sendJson(res, 400, {
+      sendJson(res, error instanceof RequestTooLargeError ? 413 : 400, {
         message: error instanceof Error ? error.message : String(error),
       });
     }

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -1,14 +1,46 @@
-import { spawn } from "child_process";
-import fs from "fs";
-import http from "http";
-import path from "path";
-import { buildPptx } from "@hirokisakabe/pom";
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildPptx, DiagnosticsError } from "@hirokisakabe/pom";
 import { convertPptxToSvg } from "pptx-glimpse";
 import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
-import { loadInput } from "./input.ts";
+import { loadInput, type LoadedInput } from "./input.ts";
 import { watchInputFile } from "./watch.ts";
 
 const DEFAULT_PORT = 3000;
+const MAX_REQUEST_BYTES = 10 * 1024 * 1024;
+
+interface PreviewDocument {
+  xml: string;
+  revision: string;
+  filename: string;
+  editable: boolean;
+}
+
+interface PreviewSuccess {
+  svgs: string[];
+}
+
+interface PreviewFailure {
+  errors: Array<{
+    type: string;
+    message: string;
+    line?: number;
+    column?: number;
+  }>;
+}
+
+type PreviewResult = PreviewSuccess | PreviewFailure;
+
+class SaveConflictError extends Error {
+  constructor() {
+    super("The file changed outside pom preview. Reload before saving.");
+    this.name = "SaveConflictError";
+  }
+}
 
 function makeLog(verbose: boolean) {
   if (!verbose) return (_msg: string) => {};
@@ -22,7 +54,6 @@ function openBrowser(url: string): void {
     cmd = "open";
     args = [url];
   } else if (process.platform === "win32") {
-    // 空文字はウィンドウタイトル。省略すると URL がタイトル扱いされる
     cmd = "cmd";
     args = ["/c", "start", "", url];
   } else {
@@ -36,330 +67,310 @@ function openBrowser(url: string): void {
   child.unref();
 }
 
-type SvgResult =
-  | { type: "success"; svgs: string[]; slideWidth: number }
-  | { type: "error"; message: string }
-  | { type: "empty" };
+function revisionOf(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function readPreviewDocument(absInput: string): PreviewDocument {
+  const content = fs.readFileSync(absInput, "utf8");
+  const loaded = loadInput(absInput);
+  return {
+    xml: loaded.xml,
+    revision: revisionOf(content),
+    filename: path.basename(absInput),
+    editable: absInput.endsWith(".pom.xml"),
+  };
+}
+
+export async function atomicWriteFile(
+  target: string,
+  content: string,
+): Promise<void> {
+  const temp = path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const mode = (await fs.promises.stat(target)).mode;
+  try {
+    const handle = await fs.promises.open(temp, "wx", mode);
+    try {
+      await handle.writeFile(content, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await fs.promises.rename(temp, target);
+  } catch (error) {
+    await fs.promises.unlink(temp).catch(() => {});
+    throw error;
+  }
+}
+
+export async function savePreviewDocument(
+  absInput: string,
+  xml: string,
+  expectedRevision: string,
+): Promise<string> {
+  if (!absInput.endsWith(".pom.xml")) {
+    throw new Error(
+      "Only .pom.xml files can be saved from the preview editor.",
+    );
+  }
+  const current = await fs.promises.readFile(absInput, "utf8");
+  if (revisionOf(current) !== expectedRevision) throw new SaveConflictError();
+  await atomicWriteFile(absInput, xml);
+  return revisionOf(xml);
+}
 
 async function generateSvgs(
-  inputFile: string,
+  xml: string,
+  context: Pick<LoadedInput, "slideWidth" | "slideHeight" | "masterPptxData">,
   verbose = false,
-): Promise<SvgResult> {
+): Promise<PreviewSuccess> {
+  if (!xml.trim()) return { svgs: [] };
   const log = makeLog(verbose);
-  const { xml, slideWidth, slideHeight, masterPptxData } = loadInput(
-    inputFile,
-    log,
-  );
-
-  if (!xml.trim()) {
-    return { type: "empty" };
-  }
-
   const t1 = Date.now();
   const { pptx } = await buildPptx(
     xml,
-    { w: slideWidth, h: slideHeight },
+    { w: context.slideWidth, h: context.slideHeight },
     {
       textMeasurement: "fallback",
-      ...(masterPptxData ? { masterPptx: masterPptxData } : {}),
+      ...(context.masterPptxData ? { masterPptx: context.masterPptxData } : {}),
     },
   );
   log(`Building PPTX... done (${Date.now() - t1}ms)`);
-
   const buffer = await pptx.write({ outputType: "uint8array" });
   if (!(buffer instanceof Uint8Array)) {
     throw new Error("Unexpected output type from pptx.write");
   }
-
-  const fontDirs = [resolveBundledFontsDir()];
-
   const t2 = Date.now();
-  // インライン SVG なのでネイティブ <text> + サブセットフォント埋め込みが使える。
-  // ブラウザのテキスト描画 (ヒンティング等) が効き、テキスト選択も可能になる
   const { slides } = await convertPptxToSvg(buffer, {
-    width: slideWidth,
-    fontDirs,
+    width: context.slideWidth,
+    fontDirs: [resolveBundledFontsDir()],
     fontMapping: EXTRA_FONT_MAPPING,
     skipSystemFonts: true,
     textOutput: "text",
   });
   log(`Converting to SVG... done (${Date.now() - t2}ms)`);
-
-  const svgs = slides.map((s) => s.svg);
-
-  return { type: "success", svgs, slideWidth };
+  return { svgs: slides.map((slide) => slide.svg) };
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+function previewFailure(error: unknown): PreviewFailure {
+  if (error instanceof DiagnosticsError) {
+    return {
+      errors: error.diagnostics.map((diagnostic) => ({
+        type: diagnostic.code,
+        message: diagnostic.message,
+      })),
+    };
+  }
+  return {
+    errors: [
+      {
+        type: "unknown",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    ],
+  };
 }
 
 function buildPreviewHtml(filename: string): string {
-  const safeFilename = escapeHtml(filename);
-  return `<!DOCTYPE html>
-<html>
+  const title = `pom — ${filename}`
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+  return `<!doctype html>
+<html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>pom — ${safeFilename}</title>
-<style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    background: #0f0f13;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: #e2e2e8;
-    min-height: 100vh;
-  }
-  .toolbar {
-    position: sticky; top: 0; z-index: 100;
-    display: flex; align-items: center; gap: 12px;
-    padding: 0 20px; height: 48px;
-    background: #1a1a2e;
-    border-bottom: 1px solid #2d2d4e;
-  }
-  .app-name {
-    font-size: 13px; font-weight: 700;
-    color: #a78bfa; letter-spacing: 0.06em;
-    flex-shrink: 0;
-  }
-  .filename {
-    font-size: 12px; color: #94a3b8;
-    font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-    background: #0f172a; border: 1px solid #2d2d4e;
-    padding: 2px 8px; border-radius: 4px;
-    flex-shrink: 1; min-width: 0; overflow: hidden;
-    text-overflow: ellipsis; white-space: nowrap;
-  }
-  .zoom-controls { display: flex; gap: 4px; flex-shrink: 0; }
-  .zoom-btn {
-    padding: 4px 10px; font-size: 11px;
-    border: 1px solid #3d3d5e; border-radius: 4px;
-    background: #2d2d4e; color: #c4c4d4; cursor: pointer;
-    transition: background 0.15s, color 0.15s;
-  }
-  .zoom-btn:hover { background: #3d3d6e; color: #e2e2f2; }
-  .zoom-btn.active { background: #7c3aed; color: #fff; border-color: #7c3aed; }
-  .zoom-hint { font-size: 11px; color: #3d3d5e; flex-shrink: 0; }
-  .status-group {
-    margin-left: auto; display: flex; align-items: center;
-    gap: 6px; flex-shrink: 0;
-  }
-  .status-dot {
-    width: 8px; height: 8px; border-radius: 50%;
-    background: #f59e0b;
-    transition: background 0.3s, box-shadow 0.3s;
-  }
-  .status-dot.connected { background: #22c55e; box-shadow: 0 0 6px #22c55e88; }
-  .status-dot.warning   { background: #f59e0b; box-shadow: 0 0 6px #f59e0b88; }
-  .status-dot.error     { background: #ef4444; box-shadow: 0 0 6px #ef444488; }
-  .status-text { font-size: 12px; color: #94a3b8; }
-  .slides-container {
-    padding: 32px 20px;
-    display: flex; flex-direction: column;
-    align-items: center; gap: 32px;
-  }
-  .slide-wrapper { width: 100%; display: flex; justify-content: center; }
-  .slide-frame {
-    position: relative;
-    border-radius: 8px; overflow: hidden; background: #fff;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.4);
-  }
-  .slide-frame svg { display: block; }
-  .slide-number {
-    position: absolute; bottom: 10px; right: 12px;
-    font-size: 11px; font-weight: 500;
-    color: rgba(255,255,255,0.8);
-    background: rgba(0,0,0,0.5);
-    padding: 2px 8px; border-radius: 3px;
-    font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-    pointer-events: none; user-select: none;
-  }
-  .loading-screen {
-    display: flex; flex-direction: column;
-    align-items: center; justify-content: center;
-    height: calc(100vh - 48px); gap: 16px;
-  }
-  .spinner {
-    width: 32px; height: 32px;
-    border: 3px solid #2d2d4e;
-    border-top-color: #7c3aed;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-  }
-  @keyframes spin { to { transform: rotate(360deg); } }
-  .loading-text { font-size: 13px; color: #555578; }
-  .empty-screen {
-    display: flex; align-items: center; justify-content: center;
-    height: calc(100vh - 48px);
-    font-size: 13px; color: #555578;
-  }
-  .error-screen { padding: 32px; display: flex; justify-content: center; }
-  .error-block {
-    max-width: 720px; width: 100%;
-    background: #1a0a0a; border: 1px solid #5c1a1a;
-    border-radius: 8px; overflow: hidden;
-  }
-  .error-header {
-    padding: 10px 16px; background: #2a0a0a;
-    border-bottom: 1px solid #5c1a1a;
-    font-size: 12px; font-weight: 600; color: #f87171;
-  }
-  .error-body {
-    padding: 14px 16px;
-    font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
-    font-size: 12px; color: #fca5a5; line-height: 1.6;
-    white-space: pre-wrap; word-break: break-all;
-  }
-</style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+  <style>*{box-sizing:border-box}html,body,#root{height:100%;margin:0}body{font-family:Inter,ui-sans-serif,system-ui,sans-serif}body>div[role=alert]{padding:24px;color:#b91c1c}</style>
 </head>
 <body>
-<div class="toolbar">
-  <span class="app-name">pom</span>
-  <span class="filename">${safeFilename}</span>
-  <div class="zoom-controls">
-    <button class="zoom-btn" data-zoom="fit">Fit</button>
-    <button class="zoom-btn" data-zoom="50">50%</button>
-    <button class="zoom-btn" data-zoom="75">75%</button>
-    <button class="zoom-btn" data-zoom="100">100%</button>
-    <button class="zoom-btn" data-zoom="150">150%</button>
-  </div>
-  <span class="zoom-hint">+ / −</span>
-  <div class="status-group">
-    <span class="status-dot warning" id="statusDot"></span>
-    <span class="status-text" id="statusText">Connecting...</span>
-  </div>
-</div>
-<div id="content">
-  <div class="loading-screen">
-    <div class="spinner"></div>
-    <span class="loading-text">Building preview...</span>
-  </div>
-</div>
-
-<script>
-(function() {
-  var ZOOM_STEPS = ['fit', '50', '75', '100', '150'];
-  var currentZoom = localStorage.getItem('pom-zoom') || 'fit';
-  var currentSlideWidth = 1280;
-
-  if (ZOOM_STEPS.indexOf(currentZoom) === -1) currentZoom = 'fit';
-  applyZoom(currentZoom);
-
-  document.querySelectorAll('.zoom-btn').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      setZoom(this.getAttribute('data-zoom'));
-    });
-  });
-
-  document.addEventListener('keydown', function(e) {
-    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-    if (e.key === '+' || e.key === '=') {
-      var idx = ZOOM_STEPS.indexOf(currentZoom);
-      if (idx < ZOOM_STEPS.length - 1) setZoom(ZOOM_STEPS[idx + 1]);
-    } else if (e.key === '-') {
-      var idx = ZOOM_STEPS.indexOf(currentZoom);
-      if (idx > 0) setZoom(ZOOM_STEPS[idx - 1]);
-    }
-  });
-
-  function setZoom(zoom) {
-    localStorage.setItem('pom-zoom', zoom);
-    applyZoom(zoom);
-  }
-
-  function applyZoom(zoom) {
-    if (ZOOM_STEPS.indexOf(zoom) === -1) zoom = 'fit';
-    currentZoom = zoom;
-    document.querySelectorAll('.zoom-btn').forEach(function(b) {
-      b.classList.toggle('active', b.getAttribute('data-zoom') === zoom);
-    });
-    document.querySelectorAll('.slide-frame svg').forEach(function(svg) {
-      applySvgZoom(svg, zoom, currentSlideWidth);
-    });
-  }
-
-  function applySvgZoom(svg, zoom, slideWidth) {
-    var frame = svg.closest('.slide-frame');
-    if (zoom === 'fit') {
-      frame.style.width = '100%';
-      frame.style.maxWidth = slideWidth + 'px';
-      svg.style.width = '100%';
-      svg.style.height = 'auto';
-    } else {
-      var scale = parseInt(zoom) / 100;
-      frame.style.width = (slideWidth * scale) + 'px';
-      frame.style.maxWidth = '';
-      svg.style.width = (slideWidth * scale) + 'px';
-      svg.style.height = 'auto';
-    }
-  }
-
-  var statusDot = document.getElementById('statusDot');
-  var statusText = document.getElementById('statusText');
-  var content = document.getElementById('content');
-
-  function setStatus(state, text) {
-    statusDot.className = 'status-dot ' + state;
-    statusText.textContent = text;
-  }
-
-  var es = new EventSource('/_sse');
-
-  es.addEventListener('open', function() {
-    setStatus('connected', 'Connected');
-  });
-
-  es.addEventListener('update', function(e) {
-    var data = JSON.parse(e.data);
-    if (data.type === 'success') {
-      currentSlideWidth = data.slideWidth;
-      setStatus('connected', 'Updated ' + new Date().toLocaleTimeString());
-      var total = data.svgs.length;
-      var slideHtml = data.svgs.map(function(svg, i) {
-        return '<div class="slide-wrapper">' +
-          '<div class="slide-frame">' + svg +
-            '<span class="slide-number">' + (i + 1) + ' / ' + total + '</span>' +
-          '</div>' +
-        '</div>';
-      }).join('');
-      content.innerHTML = '<div class="slides-container">' + slideHtml + '</div>';
-      document.querySelectorAll('.slide-frame svg').forEach(function(svgEl) {
-        applySvgZoom(svgEl, currentZoom, currentSlideWidth);
-      });
-    } else if (data.type === 'error') {
-      setStatus('error', 'Error');
-      var escaped = data.message
-        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-      content.innerHTML =
-        '<div class="error-screen">' +
-          '<div class="error-block">' +
-            '<div class="error-header">&#9888; Build Error</div>' +
-            '<pre class="error-body">' + escaped + '</pre>' +
-          '</div>' +
-        '</div>';
-    } else if (data.type === 'empty') {
-      setStatus('connected', 'No slides');
-      content.innerHTML = '<div class="empty-screen">No slides to preview</div>';
-    } else if (data.type === 'building') {
-      setStatus('warning', 'Building...');
-      content.innerHTML =
-        '<div class="loading-screen">' +
-          '<div class="spinner"></div>' +
-          '<span class="loading-text">Building preview...</span>' +
-        '</div>';
-    }
-  });
-
-  es.addEventListener('error', function() {
-    setStatus('error', 'Disconnected — retrying...');
-  });
-})();
-</script>
+  <div id="root">Loading editor...</div>
+  <script src="/_assets/preview.js" defer></script>
 </body>
 </html>`;
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    let bytes = 0;
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      bytes += Buffer.byteLength(chunk);
+      if (bytes > MAX_REQUEST_BYTES) {
+        reject(new Error("Request body is too large"));
+        req.destroy();
+        return;
+      }
+      body += chunk;
+    });
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(body) as unknown);
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function readStringField(value: unknown, field: "xml" | "revision"): string {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    typeof (value as Record<string, unknown>)[field] !== "string"
+  ) {
+    throw new Error(`Expected a string ${field} field`);
+  }
+  return (value as Record<string, string>)[field];
+}
+
+function sendJson(
+  res: http.ServerResponse,
+  status: number,
+  value: unknown,
+): void {
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end(JSON.stringify(value));
+}
+
+export interface PreviewServerOptions {
+  verbose?: boolean;
+  clientScript?: string;
+  generatePreview?: (xml: string) => Promise<PreviewResult>;
+}
+
+export function createPreviewServer(
+  absInput: string,
+  options: PreviewServerOptions = {},
+): http.Server {
+  const verbose = options.verbose ?? false;
+  const eventClients = new Set<http.ServerResponse>();
+  let ignoredWatchRevision: string | null = null;
+  const clientScriptPath = fileURLToPath(
+    new URL("./assets/preview.js", import.meta.url),
+  );
+
+  function sendDocumentEvent(document: PreviewDocument): void {
+    const data = JSON.stringify(document);
+    for (const client of eventClients) {
+      client.write(`event: document\ndata: ${data}\n\n`);
+    }
+  }
+
+  const watcher = watchInputFile(absInput, () => {
+    try {
+      const document = readPreviewDocument(absInput);
+      if (document.revision === ignoredWatchRevision) {
+        ignoredWatchRevision = null;
+        return;
+      }
+      sendDocumentEvent(document);
+    } catch (error) {
+      const data = JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+      });
+      for (const client of eventClients) {
+        client.write(`event: document\ndata: ${data}\n\n`);
+      }
+    }
+  });
+
+  async function handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    try {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      if (req.method === "GET" && url.pathname === "/") {
+        res.writeHead(200, {
+          "Content-Type": "text/html; charset=utf-8",
+          "Content-Security-Policy":
+            "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'",
+        });
+        res.end(buildPreviewHtml(path.basename(absInput)));
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/_assets/preview.js") {
+        const script =
+          options.clientScript ?? fs.readFileSync(clientScriptPath, "utf8");
+        res.writeHead(200, {
+          "Content-Type": "text/javascript; charset=utf-8",
+          "Cache-Control": "no-cache",
+        });
+        res.end(script);
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/_api/document") {
+        sendJson(res, 200, readPreviewDocument(absInput));
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/_api/preview") {
+        const body = await readJsonBody(req);
+        const xml = readStringField(body, "xml");
+        try {
+          const result = options.generatePreview
+            ? await options.generatePreview(xml)
+            : await generateSvgs(xml, loadInput(absInput), verbose);
+          sendJson(res, 200, result);
+        } catch (error) {
+          sendJson(res, 422, previewFailure(error));
+        }
+        return;
+      }
+      if (req.method === "PUT" && url.pathname === "/_api/document") {
+        const body = await readJsonBody(req);
+        const xml = readStringField(body, "xml");
+        const revision = readStringField(body, "revision");
+        try {
+          const nextRevision = await savePreviewDocument(
+            absInput,
+            xml,
+            revision,
+          );
+          ignoredWatchRevision = nextRevision;
+          sendJson(res, 200, { revision: nextRevision });
+        } catch (error) {
+          if (error instanceof SaveConflictError) {
+            sendJson(res, 409, { code: "conflict", message: error.message });
+          } else {
+            throw error;
+          }
+        }
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/_events") {
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+        res.write(": connected\n\n");
+        eventClients.add(res);
+        req.on("close", () => eventClients.delete(res));
+        return;
+      }
+      sendJson(res, 404, { message: "Not found" });
+    } catch (error) {
+      sendJson(res, 400, {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  const server = http.createServer((req, res) => {
+    void handleRequest(req, res);
+  });
+  server.on("close", () => watcher.close());
+  return server;
 }
 
 export function runPreview(
@@ -367,134 +378,26 @@ export function runPreview(
   port: number = DEFAULT_PORT,
   options: { verbose?: boolean; open?: boolean } = {},
 ): void {
-  const verbose = options.verbose ?? false;
-  const log = makeLog(verbose);
   const absInput = path.resolve(inputFile);
-
   if (!fs.existsSync(absInput)) {
     throw new Error(`Input file not found: ${absInput}`);
   }
-
-  const clients: http.ServerResponse[] = [];
-  let currentResult: SvgResult = { type: "empty" };
-  let initialBuildDone = false;
-
-  function broadcast(result: SvgResult): void {
-    currentResult = result;
-    const data = JSON.stringify(result);
-    for (const client of clients) {
-      client.write(`event: update\ndata: ${data}\n\n`);
-    }
-  }
-
-  function broadcastBuilding(): void {
-    const data = JSON.stringify({ type: "building" });
-    for (const client of clients) {
-      client.write(`event: update\ndata: ${data}\n\n`);
-    }
-  }
-
-  let isBuilding = false;
-  let pendingRefresh = false;
-
-  function refresh(): void {
-    if (isBuilding) {
-      pendingRefresh = true;
-      return;
-    }
-    isBuilding = true;
-    pendingRefresh = false;
-    const totalStart = Date.now();
-    log("File changed, rebuilding...");
-    broadcastBuilding();
-    generateSvgs(absInput, verbose)
-      .then((result) => {
-        log(`Done (total: ${Date.now() - totalStart}ms)`);
-        broadcast(result);
-      })
-      .catch((err: unknown) => {
-        broadcast({
-          type: "error",
-          message: err instanceof Error ? err.message : String(err),
-        });
-      })
-      .finally(() => {
-        isBuilding = false;
-        if (pendingRefresh) refresh();
-      });
-  }
-
-  isBuilding = true;
-  const initialStart = Date.now();
-  generateSvgs(absInput, verbose)
-    .then((result) => {
-      currentResult = result;
-      log(`Initial build done (total: ${Date.now() - initialStart}ms)`);
-      broadcast(result);
-    })
-    .catch((err: unknown) => {
-      broadcast({
-        type: "error",
-        message: err instanceof Error ? err.message : String(err),
-      });
-    })
-    .finally(() => {
-      initialBuildDone = true;
-      isBuilding = false;
-      if (pendingRefresh) refresh();
-    });
-
-  watchInputFile(absInput, refresh);
-
-  const html = buildPreviewHtml(path.basename(absInput));
-
-  const server = http.createServer((req, res) => {
-    if (req.url === "/_sse") {
-      res.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Access-Control-Allow-Origin": "*",
-      });
-      res.write(": connected\n\n");
-
-      if (!initialBuildDone) {
-        res.write(
-          `event: update\ndata: ${JSON.stringify({ type: "building" })}\n\n`,
-        );
-      } else {
-        res.write(`event: update\ndata: ${JSON.stringify(currentResult)}\n\n`);
-      }
-
-      clients.push(res);
-      req.on("close", () => {
-        const idx = clients.indexOf(res);
-        if (idx !== -1) clients.splice(idx, 1);
-      });
-    } else {
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(html);
-    }
-  });
-
-  server.on("error", (err: NodeJS.ErrnoException) => {
-    if (err.code === "EADDRINUSE") {
+  const server = createPreviewServer(absInput, { verbose: options.verbose });
+  server.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EADDRINUSE") {
       console.error(
         `Port ${port} is already in use. Is another pom preview running?`,
       );
     } else {
-      console.error(`Server error: ${err.message}`);
+      console.error(`Server error: ${error.message}`);
     }
     process.exit(1);
   });
-
   server.listen(port, () => {
     const url = `http://localhost:${port}`;
     console.log(`Preview server: ${url}`);
     console.log(`Watching: ${absInput}`);
     console.log("Press Ctrl+C to stop");
-    if (options.open ?? true) {
-      openBrowser(url);
-    }
+    if (options.open ?? true) openBrowser(url);
   });
 }

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -85,6 +85,7 @@ export function readPreviewDocument(absInput: string): PreviewDocument {
 export async function atomicWriteFile(
   target: string,
   content: string,
+  expectedRevision?: string,
 ): Promise<void> {
   const temp = path.join(
     path.dirname(target),
@@ -98,6 +99,12 @@ export async function atomicWriteFile(
       await handle.sync();
     } finally {
       await handle.close();
+    }
+    if (expectedRevision !== undefined) {
+      const current = await fs.promises.readFile(target, "utf8");
+      if (revisionOf(current) !== expectedRevision) {
+        throw new SaveConflictError();
+      }
     }
     await fs.promises.rename(temp, target);
   } catch (error) {
@@ -118,7 +125,7 @@ export async function savePreviewDocument(
   }
   const current = await fs.promises.readFile(absInput, "utf8");
   if (revisionOf(current) !== expectedRevision) throw new SaveConflictError();
-  await atomicWriteFile(absInput, xml);
+  await atomicWriteFile(absInput, xml, expectedRevision);
   return revisionOf(xml);
 }
 
@@ -257,6 +264,7 @@ export function createPreviewServer(
   const verbose = options.verbose ?? false;
   const eventClients = new Set<http.ServerResponse>();
   let ignoredWatchRevision: string | null = null;
+  let ignoredWatchTimer: NodeJS.Timeout | null = null;
   const clientScriptPath = fileURLToPath(
     new URL("./assets/preview.js", import.meta.url),
   );
@@ -274,6 +282,8 @@ export function createPreviewServer(
       const document = readPreviewDocument(absInput);
       if (document.revision === ignoredWatchRevision) {
         ignoredWatchRevision = null;
+        if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
+        ignoredWatchTimer = null;
         return;
       }
       sendDocumentEvent(document);
@@ -292,6 +302,20 @@ export function createPreviewServer(
     res: http.ServerResponse,
   ): Promise<void> {
     try {
+      const host = req.headers.host;
+      if (!host) throw new Error("Missing Host header");
+      const hostname = host.startsWith("[")
+        ? host.slice(1, host.indexOf("]"))
+        : host.split(":", 1)[0];
+      if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+        sendJson(res, 403, { message: "Invalid Host header" });
+        return;
+      }
+      const origin = req.headers.origin;
+      if (origin && origin !== `http://${host}`) {
+        sendJson(res, 403, { message: "Invalid Origin header" });
+        return;
+      }
       const url = new URL(req.url ?? "/", "http://localhost");
       if (req.method === "GET" && url.pathname === "/") {
         res.writeHead(200, {
@@ -334,14 +358,19 @@ export function createPreviewServer(
         const xml = readStringField(body, "xml");
         const revision = readStringField(body, "revision");
         try {
-          const nextRevision = await savePreviewDocument(
-            absInput,
-            xml,
-            revision,
-          );
+          const nextRevision = revisionOf(xml);
           ignoredWatchRevision = nextRevision;
+          if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
+          ignoredWatchTimer = setTimeout(() => {
+            ignoredWatchRevision = null;
+            ignoredWatchTimer = null;
+          }, 1000);
+          await savePreviewDocument(absInput, xml, revision);
           sendJson(res, 200, { revision: nextRevision });
         } catch (error) {
+          ignoredWatchRevision = null;
+          if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
+          ignoredWatchTimer = null;
           if (error instanceof SaveConflictError) {
             sendJson(res, 409, { code: "conflict", message: error.message });
           } else {
@@ -371,7 +400,12 @@ export function createPreviewServer(
   const server = http.createServer((req, res) => {
     void handleRequest(req, res);
   });
-  server.on("close", () => watcher.close());
+  server.on("close", () => {
+    watcher.close();
+    if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
+    for (const client of eventClients) client.end();
+    eventClients.clear();
+  });
   return server;
 }
 
@@ -395,7 +429,7 @@ export function runPreview(
     }
     process.exit(1);
   });
-  server.listen(port, () => {
+  server.listen(port, "127.0.0.1", () => {
     const url = `http://localhost:${port}`;
     console.log(`Preview server: ${url}`);
     console.log(`Watching: ${absInput}`);

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -263,8 +263,8 @@ export function createPreviewServer(
 ): http.Server {
   const verbose = options.verbose ?? false;
   const eventClients = new Set<http.ServerResponse>();
-  let ignoredWatchRevision: string | null = null;
-  let ignoredWatchTimer: NodeJS.Timeout | null = null;
+  const ignoredWatchRevisions = new Map<string, NodeJS.Timeout>();
+  let saveQueue = Promise.resolve();
   const clientScriptPath = fileURLToPath(
     new URL("./assets/preview.js", import.meta.url),
   );
@@ -277,13 +277,35 @@ export function createPreviewServer(
     }
   }
 
+  function ignoreNextWatch(revision: string): void {
+    const existing = ignoredWatchRevisions.get(revision);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      ignoredWatchRevisions.delete(revision);
+    }, 1000);
+    ignoredWatchRevisions.set(revision, timer);
+  }
+
+  function stopIgnoringWatch(revision: string): void {
+    const timer = ignoredWatchRevisions.get(revision);
+    if (timer) clearTimeout(timer);
+    ignoredWatchRevisions.delete(revision);
+  }
+
+  function serializeSave<T>(save: () => Promise<T>): Promise<T> {
+    const result = saveQueue.then(save, save);
+    saveQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
   const watcher = watchInputFile(absInput, () => {
     try {
       const document = readPreviewDocument(absInput);
-      if (document.revision === ignoredWatchRevision) {
-        ignoredWatchRevision = null;
-        if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
-        ignoredWatchTimer = null;
+      if (ignoredWatchRevisions.has(document.revision)) {
+        stopIgnoringWatch(document.revision);
         return;
       }
       sendDocumentEvent(document);
@@ -359,18 +381,14 @@ export function createPreviewServer(
         const revision = readStringField(body, "revision");
         try {
           const nextRevision = revisionOf(xml);
-          ignoredWatchRevision = nextRevision;
-          if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
-          ignoredWatchTimer = setTimeout(() => {
-            ignoredWatchRevision = null;
-            ignoredWatchTimer = null;
-          }, 1000);
-          await savePreviewDocument(absInput, xml, revision);
+          ignoreNextWatch(nextRevision);
+          await serializeSave(() =>
+            savePreviewDocument(absInput, xml, revision),
+          );
           sendJson(res, 200, { revision: nextRevision });
+          sendDocumentEvent(readPreviewDocument(absInput));
         } catch (error) {
-          ignoredWatchRevision = null;
-          if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
-          ignoredWatchTimer = null;
+          stopIgnoringWatch(revisionOf(xml));
           if (error instanceof SaveConflictError) {
             sendJson(res, 409, { code: "conflict", message: error.message });
           } else {
@@ -402,7 +420,8 @@ export function createPreviewServer(
   });
   server.on("close", () => {
     watcher.close();
-    if (ignoredWatchTimer) clearTimeout(ignoredWatchTimer);
+    for (const timer of ignoredWatchRevisions.values()) clearTimeout(timer);
+    ignoredWatchRevisions.clear();
     for (const client of eventClients) client.end();
     eventClients.clear();
   });

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -247,6 +247,7 @@ export interface PreviewServerOptions {
   verbose?: boolean;
   clientScript?: string;
   generatePreview?: (xml: string) => Promise<PreviewResult>;
+  onDocumentEvent?: (document: PreviewDocument) => void;
 }
 
 export function createPreviewServer(
@@ -261,6 +262,7 @@ export function createPreviewServer(
   );
 
   function sendDocumentEvent(document: PreviewDocument): void {
+    options.onDocumentEvent?.(document);
     const data = JSON.stringify(document);
     for (const client of eventClients) {
       client.write(`event: document\ndata: ${data}\n\n`);

--- a/packages/pom-cli/tsconfig.build.json
+++ b/packages/pom-cli/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/pom-cli/tsconfig.json
+++ b/packages/pom-cli/tsconfig.json
@@ -6,13 +6,10 @@
     "target": "es2022",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
     "rewriteRelativeImportExtensions": true,
-    "types": ["node"]
+    "jsx": "react-jsx",
+    "types": ["node", "react", "react-dom"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "include": ["src/**/*", "client/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         version: 8.64.0(@typescript/typescript6@6.0.2)(eslint@10.7.0(jiti@2.7.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/website:
     dependencies:
@@ -253,9 +253,33 @@ importers:
         specifier: ^3.2.3
         version: 3.2.3
     devDependencies:
+      "@hirokisakabe/pom-editor":
+        specifier: workspace:*
+        version: link:../pom-editor
+      "@testing-library/react":
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@types/node":
         specifier: ^26.1.0
         version: 26.1.0
+      "@types/react":
+        specifier: ^19
+        version: 19.2.17
+      "@types/react-dom":
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.17)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@1.8.0)
+      react:
+        specifier: ^19
+        version: 19.2.7
+      react-dom:
+        specifier: ^19
+        version: 19.2.7(react@19.2.7)
 
   packages/pom-editor:
     dependencies:
@@ -15904,9 +15928,9 @@ snapshots:
   "@rolldown/binding-openharmony-arm64@1.2.0":
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.11(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)":
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.11(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
@@ -16694,13 +16718,13 @@ snapshots:
       "@rolldown/pluginutils": 1.0.1
       vite: 8.0.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  "@vitest/browser-playwright@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(playwright@1.61.1)(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)":
+  "@vitest/browser-playwright@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(playwright@1.61.1)(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)":
     dependencies:
-      "@vitest/browser": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-      "@vitest/mocker": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      "@vitest/browser": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      "@vitest/mocker": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -16735,16 +16759,16 @@ snapshots:
       - vite
     optional: true
 
-  "@vitest/browser@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)":
+  "@vitest/browser@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)":
     dependencies:
       "@blazediff/core": 1.9.1
-      "@vitest/mocker": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      "@vitest/mocker": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       "@vitest/utils": 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -16813,14 +16837,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))":
+  "@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))":
     dependencies:
       "@vitest/spy": 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2)
-      vite: 8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   "@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))":
     dependencies:
@@ -20885,7 +20909,7 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.11(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0):
+  rolldown@1.0.0-rc.11(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       "@oxc-project/types": 0.122.0
       "@rolldown/pluginutils": 1.0.0-rc.11
@@ -20902,7 +20926,7 @@ snapshots:
       "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.11
       "@rolldown/binding-linux-x64-musl": 1.0.0-rc.11
       "@rolldown/binding-openharmony-arm64": 1.0.0-rc.11
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.11(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.11(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.11
       "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.11
     transitivePeerDependencies:
@@ -21865,12 +21889,12 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
       postcss: 8.5.19
-      rolldown: 1.0.0-rc.11(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      rolldown: 1.0.0-rc.11(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       tinyglobby: 0.2.17
     optionalDependencies:
       "@types/node": 26.1.0
@@ -21901,10 +21925,10 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  vitest@4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       "@vitest/expect": 4.1.10
-      "@vitest/mocker": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      "@vitest/mocker": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       "@vitest/pretty-format": 4.1.10
       "@vitest/runner": 4.1.10
       "@vitest/snapshot": 4.1.10
@@ -21921,11 +21945,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 26.1.0
-      "@vitest/browser-playwright": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(playwright@1.61.1)(vite@8.0.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      "@vitest/browser-playwright": 4.1.10(msw@2.14.6(@types/node@26.1.0)(@typescript/typescript6@6.0.2))(playwright@1.61.1)(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       "@vitest/coverage-v8": 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       "@vitest/ui": 4.1.10(vitest@4.1.10)
       happy-dom: 20.11.0


### PR DESCRIPTION
close #971

## 概要

`pom preview <file>` のブラウザ画面を、#972 で共通化された `PomEditor` を利用する編集 UI に置き換えます。ブラウザ内で XML / AST 編集、未保存内容の preview、明示 Save まで完結できるようにし、CLI host 固有のファイル操作と競合検出を追加しました。

## 変更内容

- `@hirokisakabe/pom-editor` の `PomEditor` を browser client から直接利用
- 未保存 XML から SVG preview を生成する local API を追加
- SHA-256 revision による外部変更検出と 409 conflict 表示を追加
- 同一 directory の一時ファイルを fsync 後に rename する atomic Save を実装
- 同時 Save の直列化、保存イベントの全 client 配信、watch の自己更新重複抑止を実装
- preview server を loopback に限定し、Host / Origin を検証
- browser asset を esbuild で CLI package 内へ bundle（外部 CDN 不要）
- `.pom.xml` は編集・保存対応、`.pom.md` は従来どおり preview only
- CLI browser 編集フローを README に追記
- `@hirokisakabe/pom-cli` の minor changeset を追加

## 影響範囲

- **pom-editor**: 共通 `PomEditor` を CLI client bundle から再利用。pom-editor 本体の source 変更はありません。
- **pom-cli**: host adapter、preview/save API、競合検出、atomic file update、SSE、bundled client asset を追加する主変更箇所です。
- **website playground**: 引き続き同じ `PomEditor` を利用し、実装変更はありません。targeted regression test が通ることを確認しました。

CLI 側には XML editor、AST editor、slide preview component を複製していません。

## 配布サイズ

`pnpm --filter @hirokisakabe/pom-cli pack` の tarball 実測値:

- 変更前: 20,140,894 bytes
- 変更後: 20,558,168 bytes
- 増分: 417,274 bytes（約 407.5 KiB、2.07%）
- bundled `dist/assets/preview.js`: 1,549,383 bytes（raw）

pack 内容に `dist/assets/preview.js` が含まれ、HTML / asset に外部 CDN 参照がないことを確認しています。

## 動作確認

- `pnpm --filter @hirokisakabe/pom-cli run fmt:check`
- `pnpm --filter @hirokisakabe/pom-cli run lint`
- `pnpm --filter @hirokisakabe/pom-cli run typecheck`
- `pnpm --filter @hirokisakabe/pom-cli run knip`
- `pnpm --filter @hirokisakabe/pom-cli run build`
- `pnpm --filter @hirokisakabe/pom-cli run test:run`（8 files / 50 tests）
- `pnpm --filter @hirokisakabe/pom-editor run test:run`（4 files / 23 tests）
- `pnpm --filter pom-docs exec vitest run playground/client/components/AppLayout.test.tsx`（1 file / 4 tests）
- 実 browser で XML 編集 → preview、AST mode / DnD handle、Save、console error なしを確認

## レビュー

- 受け入れ条件: 12/12 ✓
- 独立 Codex cross-review を実施し、指摘された Save/watch race、同時 Save、複数 client 同期、API validation、安全性を追加コミットで反映済み
