### PR TITLE
pom-editor: AST モードの diagnostic UX を改善する

### DIFF
--- a/.changeset/fuzzy-bags-navigate.md
+++ b/.changeset/fuzzy-bags-navigate.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-editor": minor
+---
+
+AST モードの diagnostic から XML の該当行へ移動できるようにし、行情報がない error と parse 不能状態にも案内を追加しました。

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -105,10 +105,11 @@ function App() {
 
 ### `<PomAstEditor xml onChange />`
 
-| Prop       | Type                    | Description                                              |
-| ---------- | ----------------------- | -------------------------------------------------------- |
-| `xml`      | `string`                | pom XML string (one or more `<Slide>` elements)          |
-| `onChange` | `(xml: string) => void` | Called with updated XML after each drag-and-drop reorder |
+| Prop               | Type                    | Description                                                        |
+| ------------------ | ----------------------- | ------------------------------------------------------------------ |
+| `xml`              | `string`                | pom XML string (one or more `<Slide>` elements)                    |
+| `onChange`         | `(xml: string) => void` | Called with updated XML after each drag-and-drop reorder           |
+| `onRequestXmlMode` | `() => void`            | Optional callback shown after parse errors to return to XML source |
 
 Renders a tree of nodes from the parsed XML. Each row supports two drop targets:
 

--- a/packages/pom-editor/src/PomAstEditor.test.tsx
+++ b/packages/pom-editor/src/PomAstEditor.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PomAstEditor } from "./PomAstEditor.tsx";
+
+afterEach(cleanup);
+
+describe("PomAstEditor", () => {
+  it("parse不能時にerrorとXML modeへ戻る導線を表示する", () => {
+    const onRequestXmlMode = vi.fn();
+    render(
+      <PomAstEditor
+        xml="<Slide><"
+        onChange={vi.fn()}
+        onRequestXmlMode={onRequestXmlMode}
+      />,
+    );
+
+    expect(screen.getByText(/XML validation failed/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open XML editor" }));
+
+    expect(onRequestXmlMode).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/pom-editor/src/PomAstEditor.tsx
+++ b/packages/pom-editor/src/PomAstEditor.tsx
@@ -10,9 +10,14 @@ import type { AstNode } from "./ast.ts";
 export interface PomAstEditorProps {
   xml: string;
   onChange: (xml: string) => void;
+  onRequestXmlMode?: () => void;
 }
 
-export function PomAstEditor({ xml, onChange }: PomAstEditorProps) {
+export function PomAstEditor({
+  xml,
+  onChange,
+  onRequestXmlMode,
+}: PomAstEditorProps) {
   const [ast, setAst] = useState<AstNode[]>([]);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,7 +51,25 @@ export function PomAstEditor({ xml, onChange }: PomAstEditorProps) {
           wordBreak: "break-word",
         }}
       >
-        {error}
+        <div>{error}</div>
+        {onRequestXmlMode && (
+          <button
+            type="button"
+            onClick={onRequestXmlMode}
+            style={{
+              marginTop: 12,
+              border: "1px solid #dc2626",
+              borderRadius: 6,
+              padding: "6px 8px",
+              background: "#fff",
+              color: "#b91c1c",
+              cursor: "pointer",
+              fontFamily: "sans-serif",
+            }}
+          >
+            Open XML editor
+          </button>
+        )}
       </div>
     );
   }

--- a/packages/pom-editor/src/PomEditor.test.tsx
+++ b/packages/pom-editor/src/PomEditor.test.tsx
@@ -7,34 +7,55 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const editorViewMock = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  focus: vi.fn(),
+  state: {
+    doc: {
+      lines: 3,
+      line: vi.fn(() => ({ from: 10, to: 20 })),
+    },
+  },
+}));
+
 vi.mock("./XmlEditor.tsx", () => ({
   XmlEditor: ({
     value,
     onChange,
+    onViewReady,
   }: {
     value: string;
     onChange: (xml: string) => void;
-  }) => (
-    <textarea
-      data-testid="pom-xml-editor"
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-    />
-  ),
+    onViewReady: (view: never) => void;
+  }) => {
+    onViewReady(editorViewMock as never);
+    return (
+      <textarea
+        data-testid="pom-xml-editor"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  },
 }));
 
 vi.mock("./PomAstEditor.tsx", () => ({
   PomAstEditor: ({
     xml,
     onChange,
+    onRequestXmlMode,
   }: {
     xml: string;
     onChange: (xml: string) => void;
+    onRequestXmlMode?: () => void;
   }) => (
     <div>
       <span>{xml}</span>
       <button type="button" onClick={() => onChange("<Text>from AST</Text>")}>
         Change AST
+      </button>
+      <button type="button" onClick={onRequestXmlMode}>
+        Open XML editor
       </button>
     </div>
   ),
@@ -45,6 +66,7 @@ import { PomEditor } from "./PomEditor.tsx";
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.clearAllMocks();
 });
 
 describe("PomEditor", () => {
@@ -127,5 +149,105 @@ describe("PomEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledWith("<Text />"));
+  });
+
+  it("AST modeの行付きdiagnosticからXML modeへ切り替えて該当位置へ移動する", async () => {
+    render(
+      <PomEditor
+        xml={"<Slide>\n<Text />\n</Slide>"}
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          errors: [
+            {
+              type: "schema",
+              message: "Invalid attribute",
+              line: 2,
+              column: 3,
+            },
+          ],
+        })}
+        debounceMs={0}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "ast" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Invalid attribute/ }),
+    );
+
+    expect(screen.getByTestId("pom-xml-editor")).toBeTruthy();
+    expect(
+      screen.getByRole("radio", { name: "xml" }).getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(editorViewMock.state.doc.line).toHaveBeenCalledWith(2);
+    expect(editorViewMock.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ selection: { anchor: 12 } }),
+    );
+    expect(editorViewMock.focus).toHaveBeenCalled();
+  });
+
+  it("XML modeの既存diagnostic line jumpを維持する", async () => {
+    render(
+      <PomEditor
+        xml={"<Slide>\n<Text />\n</Slide>"}
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          errors: [
+            { type: "xml_syntax", message: "Tag is not closed", line: 2 },
+          ],
+        })}
+        debounceMs={0}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Tag is not closed/ }),
+    );
+
+    expect(editorViewMock.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ selection: { anchor: 10 } }),
+    );
+    expect(editorViewMock.focus).toHaveBeenCalled();
+  });
+
+  it("AST modeの行なしdiagnosticを選択すると案内を表示する", async () => {
+    render(
+      <PomEditor
+        xml="<Text />"
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          errors: [{ type: "structure", message: "Slide is required" }],
+        })}
+        debounceMs={0}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "ast" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Slide is required/ }),
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "does not include a source line",
+    );
+    expect(screen.getByTestId("pom-ast-editor")).toBeTruthy();
+  });
+
+  it("AST treeを構築できない場合もXML modeへ戻れる", () => {
+    render(
+      <PomEditor
+        xml="<Text>"
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({ svgs: [] })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "ast" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open XML editor" }));
+
+    expect(screen.getByTestId("pom-xml-editor")).toBeTruthy();
+    expect(
+      screen.getByRole("radio", { name: "xml" }).getAttribute("aria-checked"),
+    ).toBe("true");
   });
 });

--- a/packages/pom-editor/src/PomEditor.test.tsx
+++ b/packages/pom-editor/src/PomEditor.test.tsx
@@ -233,6 +233,30 @@ describe("PomEditor", () => {
     expect(screen.getByTestId("pom-ast-editor")).toBeTruthy();
   });
 
+  it("XML modeの行なしdiagnosticには現在のmodeに合う案内を表示する", async () => {
+    render(
+      <PomEditor
+        xml="<Text />"
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          errors: [{ type: "structure", message: "Slide is required" }],
+        })}
+        debounceMs={0}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Slide is required/ }),
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "inspect the XML source manually",
+    );
+    expect(screen.getByRole("status").textContent).not.toContain(
+      "switch to XML mode",
+    );
+  });
+
   it("AST treeを構築できない場合もXML modeへ戻れる", () => {
     render(
       <PomEditor

--- a/packages/pom-editor/src/PomEditor.tsx
+++ b/packages/pom-editor/src/PomEditor.tsx
@@ -189,7 +189,9 @@ export function PomEditor({
     if (!diagnostic) return;
     if (!diagnostic.line) {
       setDiagnosticNotice(
-        "This error does not include a source line. Review its message and switch to XML mode to inspect the source.",
+        mode === "ast"
+          ? "This error does not include a source line. Review its message and switch to XML mode to inspect the source."
+          : "This error does not include a source line. Review its message and inspect the XML source manually.",
       );
       return;
     }

--- a/packages/pom-editor/src/PomEditor.tsx
+++ b/packages/pom-editor/src/PomEditor.tsx
@@ -72,7 +72,9 @@ export function PomEditor({
   const [diagnostics, setDiagnostics] = useState<PomEditorDiagnostic[] | null>(
     null,
   );
+  const [diagnosticNotice, setDiagnosticNotice] = useState<string | null>(null);
   const editorViewRef = useRef<EditorView | null>(null);
+  const pendingDiagnosticRef = useRef<PomEditorDiagnostic | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const onPreviewRef = useRef(onPreview);
@@ -87,6 +89,7 @@ export function PomEditor({
     abortControllerRef.current = controller;
     setIsLoading(true);
     setDiagnostics(null);
+    setDiagnosticNotice(null);
 
     try {
       const result = await onPreviewRef.current(xml, {
@@ -147,6 +150,7 @@ export function PomEditor({
     if (runningAction !== null) return;
     setRunningAction(action);
     setDiagnostics(null);
+    setDiagnosticNotice(null);
     try {
       await callback(xml);
     } catch (error) {
@@ -161,10 +165,8 @@ export function PomEditor({
     }
   }
 
-  function handleDiagnosticClick(index: number) {
-    const view = editorViewRef.current;
-    const diagnostic = diagnostics?.[index];
-    if (!view || !diagnostic?.line) return;
+  function focusDiagnostic(view: EditorView, diagnostic: PomEditorDiagnostic) {
+    if (!diagnostic.line) return;
     const requestedLine = Number.isFinite(diagnostic.line)
       ? Math.trunc(diagnostic.line)
       : 1;
@@ -180,6 +182,35 @@ export function PomEditor({
       effects: EditorView.scrollIntoView(anchor, { y: "center" }),
     });
     view.focus();
+  }
+
+  function handleDiagnosticClick(index: number) {
+    const diagnostic = diagnostics?.[index];
+    if (!diagnostic) return;
+    if (!diagnostic.line) {
+      setDiagnosticNotice(
+        "This error does not include a source line. Review its message and switch to XML mode to inspect the source.",
+      );
+      return;
+    }
+
+    setDiagnosticNotice(null);
+    if (mode === "ast") {
+      pendingDiagnosticRef.current = diagnostic;
+      setMode("xml");
+      return;
+    }
+
+    const view = editorViewRef.current;
+    if (view) focusDiagnostic(view, diagnostic);
+  }
+
+  function handleXmlViewReady(view: EditorView) {
+    editorViewRef.current = view;
+    const pendingDiagnostic = pendingDiagnosticRef.current;
+    if (!pendingDiagnostic) return;
+    pendingDiagnosticRef.current = null;
+    focusDiagnostic(view, pendingDiagnostic);
   }
 
   return (
@@ -296,9 +327,7 @@ export function PomEditor({
               value={xml}
               onChange={onChange}
               diagnostics={diagnostics}
-              onViewReady={(view) => {
-                editorViewRef.current = view;
-              }}
+              onViewReady={handleXmlViewReady}
             />
           ) : (
             <div
@@ -312,7 +341,11 @@ export function PomEditor({
                 background: "#fff",
               }}
             >
-              <PomAstEditor xml={xml} onChange={onChange} />
+              <PomAstEditor
+                xml={xml}
+                onChange={onChange}
+                onRequestXmlMode={() => setMode("xml")}
+              />
             </div>
           )}
         </div>
@@ -320,9 +353,10 @@ export function PomEditor({
           svgs={svgs}
           isLoading={isLoading}
           diagnostics={diagnostics}
+          diagnosticNotice={diagnosticNotice}
           currentPage={currentPage}
           onPageChange={setCurrentPage}
-          onDiagnosticClick={mode === "xml" ? handleDiagnosticClick : undefined}
+          onDiagnosticClick={handleDiagnosticClick}
           onCopyPreview={onCopyPreview}
         />
       </div>

--- a/packages/pom-editor/src/SlidePreview.test.tsx
+++ b/packages/pom-editor/src/SlidePreview.test.tsx
@@ -25,7 +25,7 @@ describe("SlidePreview", () => {
     expect(screen.getByText("Edit XML to see a preview")).toBeTruthy();
   });
 
-  it("diagnosticsを表示し、行情報がある項目をbuttonで通知する", () => {
+  it("行情報の有無にかかわらずdiagnosticの選択を通知する", () => {
     const diagnostics: PomEditorDiagnostic[] = [
       { type: "xml_syntax", message: "Tag is not closed", line: 3 },
       { type: "schema", message: "Invalid attribute" },
@@ -41,11 +41,8 @@ describe("SlidePreview", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Tag is not closed/ }));
     expect(onDiagnosticClick).toHaveBeenCalledWith(0);
-    expect(
-      screen
-        .getByRole("button", { name: /Invalid attribute/ })
-        .hasAttribute("disabled"),
-    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: /Invalid attribute/ }));
+    expect(onDiagnosticClick).toHaveBeenCalledWith(1);
   });
 
   it("SVGをsanitizeして表示とcopy callbackへ渡す", () => {

--- a/packages/pom-editor/src/SlidePreview.tsx
+++ b/packages/pom-editor/src/SlidePreview.tsx
@@ -24,6 +24,7 @@ interface SlidePreviewProps {
   svgs: string[];
   isLoading: boolean;
   diagnostics: PomEditorDiagnostic[] | null;
+  diagnosticNotice?: string | null;
   currentPage: number;
   onPageChange: (page: number) => void;
   onDiagnosticClick?: (diagnosticIndex: number) => void;
@@ -42,6 +43,7 @@ export function SlidePreview({
   svgs,
   isLoading,
   diagnostics,
+  diagnosticNotice,
   currentPage,
   onPageChange,
   onDiagnosticClick,
@@ -113,6 +115,20 @@ export function SlidePreview({
   if (diagnostics && diagnostics.length > 0) {
     return (
       <div style={frameStyle}>
+        {diagnosticNotice && (
+          <div
+            role="status"
+            style={{
+              padding: "10px 16px",
+              borderBottom: "1px solid #fde68a",
+              background: "#fffbeb",
+              color: "#92400e",
+              fontSize: 13,
+            }}
+          >
+            {diagnosticNotice}
+          </div>
+        )}
         <ul
           style={{
             overflow: "auto",
@@ -133,7 +149,7 @@ export function SlidePreview({
             >
               <button
                 type="button"
-                disabled={!diagnostic.line || !onDiagnosticClick}
+                disabled={!onDiagnosticClick}
                 onClick={() => onDiagnosticClick?.(index)}
                 style={{
                   display: "flex",
@@ -144,10 +160,7 @@ export function SlidePreview({
                   background: "transparent",
                   color: "inherit",
                   textAlign: "left",
-                  cursor:
-                    diagnostic.line && onDiagnosticClick
-                      ? "pointer"
-                      : "default",
+                  cursor: onDiagnosticClick ? "pointer" : "default",
                 }}
               >
                 <span aria-hidden="true" style={{ color: "#dc2626" }}>


### PR DESCRIPTION
close #864

## 概要

AST モードでも diagnostic を操作できるようにし、行情報がある error から XML エディタの該当位置へ移動できるようにしました。行情報がない error には明示的な案内を表示し、AST を構築できない場合にも XML モードへ戻る導線を追加しています。

## 変更内容

- AST モードで diagnostic を選択した際、行情報があれば XML モードへ切り替えて該当 line / column を選択・scroll
- 行情報がない diagnostic の選択時に、現在の mode に応じた案内を表示
- `PomAstEditor` の parse / validation error 表示に `Open XML editor` callback を追加
- mode 切替、line jump、行なし error、parse 不能状態、既存 XML jump の component test を追加
- `@hirokisakabe/pom-editor` の minor changeset と公開 prop の README 記載を追加

## 影響範囲

- `packages/pom-editor/`
- website playground と pom-cli preview は共通 `PomEditor` を利用しているため、host 固有の実装変更なしで同じ interaction が反映されます
- pom core の Diagnostic model、pom-vscode には変更ありません

## 検証

- `pnpm --filter @hirokisakabe/pom-editor run test:run`
- `pnpm --filter @hirokisakabe/pom-editor run lint`
- `pnpm --filter @hirokisakabe/pom-editor run typecheck`
- `pnpm --filter @hirokisakabe/pom-editor run build`
- `pnpm --filter @hirokisakabe/pom-editor run knip`
- `pnpm --filter @hirokisakabe/pom-editor run fmt:check`
- `pnpm --filter pom-docs run test:run`
- `pnpm --filter @hirokisakabe/pom-cli run test:run`
