### PR TITLE
pom-editor: AST ツリーの DnD 操作性を改善する

### DIFF
--- a/.changeset/tidy-trees-drag.md
+++ b/.changeset/tidy-trees-drag.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-editor": patch
+---
+
+AST ツリーの drop hit area、挿入先 feedback、drag overlay、auto-scroll を改善する。

--- a/packages/pom-editor/src/AstTree.test.tsx
+++ b/packages/pom-editor/src/AstTree.test.tsx
@@ -17,6 +17,7 @@ let capturedHandlers: {
   onDragEnd?: (event: DragEvent) => void;
   onDragCancel?: () => void;
 } = {};
+let capturedAutoScroll: boolean | undefined;
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({
@@ -25,16 +26,20 @@ vi.mock("@dnd-kit/core", () => ({
     onDragOver,
     onDragEnd,
     onDragCancel,
+    autoScroll,
   }: {
     children: React.ReactNode;
+    autoScroll?: boolean;
     onDragStart?: typeof capturedHandlers.onDragStart;
     onDragOver?: typeof capturedHandlers.onDragOver;
     onDragEnd?: typeof capturedHandlers.onDragEnd;
     onDragCancel?: typeof capturedHandlers.onDragCancel;
   }) => {
     capturedHandlers = { onDragStart, onDragOver, onDragEnd, onDragCancel };
+    capturedAutoScroll = autoScroll;
     return <>{children}</>;
   },
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   PointerSensor: class {},
   useSensor: () => ({}),
   useSensors: () => [],
@@ -60,6 +65,7 @@ import type { AstNode } from "./ast.ts";
 afterEach(() => {
   cleanup();
   capturedHandlers = {};
+  capturedAutoScroll = undefined;
 });
 
 // Two slides, each is a VStack with text children.
@@ -254,6 +260,18 @@ describe("AstTree DnD — inside drops (container nesting)", () => {
 });
 
 describe("AstTree DnD — visual feedback distinguishes inside vs between", () => {
+  it("before / after gap の見た目を広げずに 16px の drop hit area を提供する", () => {
+    render(<AstTree ast={makeAst()} onChange={vi.fn()} />);
+
+    for (const id of ["gap:0:0", "gap:0:2"]) {
+      const gap = screen.getByTestId(id);
+      expect(gap.style.height).toBe("16px");
+      expect(gap.style.marginTop).toBe("-7px");
+      expect(gap.style.marginBottom).toBe("-7px");
+      expect(gap.dataset.dropPlacement).toBe("between");
+    }
+  });
+
   it("inside drop ターゲットに対して container 本体が青ハイライトされる", () => {
     const onChange = vi.fn();
     render(<AstTree ast={makeAst()} onChange={onChange} />);
@@ -271,18 +289,21 @@ describe("AstTree DnD — visual feedback distinguishes inside vs between", () =
     expect(insideHighlighted!.style.outline).toBe("1px solid #2563eb");
   });
 
-  it("gap drop ターゲットに対して挿入インジケータが青で表示される", () => {
-    const onChange = vi.fn();
-    render(<AstTree ast={makeAst()} onChange={onChange} />);
+  it.each(["gap:0:0", "gap:0:2"])(
+    "%s drop ターゲットに対して挿入インジケータが青で表示される",
+    (gapId) => {
+      const onChange = vi.fn();
+      render(<AstTree ast={makeAst()} onChange={onChange} />);
 
-    act(() => {
-      capturedHandlers.onDragOver?.(dragTo("1", "gap:0:2"));
-    });
+      act(() => {
+        capturedHandlers.onDragOver?.(dragTo("1", gapId));
+      });
 
-    const gap = document.querySelector<HTMLElement>('[data-testid="gap:0:2"]');
-    expect(gap).not.toBeNull();
-    expect(gap!.style.backgroundColor).toBe("rgb(59, 130, 246)");
-  });
+      const indicator = screen.getByTestId(`${gapId}:indicator`);
+      expect(indicator.style.backgroundColor).toBe("rgb(37, 99, 235)");
+      expect(indicator.style.height).toBe("3px");
+    },
+  );
 
   it("inside と gap で異なる背景色が使われる (UI 上区別できる)", () => {
     const onChange = vi.fn();
@@ -299,13 +320,33 @@ describe("AstTree DnD — visual feedback distinguishes inside vs between", () =
     act(() => {
       capturedHandlers.onDragOver?.(dragTo("1", "gap:0:2"));
     });
-    const gap = document.querySelector<HTMLElement>('[data-testid="gap:0:2"]');
-    const gapBg = gap?.style.backgroundColor;
+    const gapBg = screen.getByTestId("gap:0:2:indicator").style.backgroundColor;
 
     // Different colors used for the two feedback modes.
     expect(insideBg).toBeTruthy();
     expect(gapBg).toBeTruthy();
     expect(insideBg).not.toBe(gapBg);
+  });
+});
+
+describe("AstTree DnD — drag overlay and scrolling", () => {
+  it("drag 中の node label を DragOverlay に表示する", () => {
+    render(<AstTree ast={makeAst()} onChange={vi.fn()} />);
+
+    expect(screen.queryByTestId("ast-drag-overlay")).toBeNull();
+    act(() => {
+      capturedHandlers.onDragStart?.({ active: { id: "1" } });
+    });
+
+    expect(screen.getByTestId("ast-drag-overlay").textContent).toContain(
+      'Text: "A"',
+    );
+  });
+
+  it("scroll container の edge auto-scroll を有効にする", () => {
+    render(<AstTree ast={makeAst()} onChange={vi.fn()} />);
+
+    expect(capturedAutoScroll).toBe(true);
   });
 });
 

--- a/packages/pom-editor/src/AstTree.test.tsx
+++ b/packages/pom-editor/src/AstTree.test.tsx
@@ -269,7 +269,13 @@ describe("AstTree DnD — visual feedback distinguishes inside vs between", () =
       expect(gap.style.marginTop).toBe("-7px");
       expect(gap.style.marginBottom).toBe("-7px");
       expect(gap.dataset.dropPlacement).toBe("between");
+      expect(gap.style.pointerEvents).toBe("none");
     }
+
+    act(() => {
+      capturedHandlers.onDragStart?.({ active: { id: "1" } });
+    });
+    expect(screen.getByTestId("gap:0:0").style.pointerEvents).toBe("auto");
   });
 
   it("inside drop ターゲットに対して container 本体が青ハイライトされる", () => {

--- a/packages/pom-editor/src/AstTree.tsx
+++ b/packages/pom-editor/src/AstTree.tsx
@@ -119,6 +119,7 @@ function GapStrip({ parentId, index, depth }: GapStripProps) {
         marginLeft: `${depth * 16}px`,
         position: "relative",
         zIndex: isDragging ? 1 : undefined,
+        pointerEvents: isDragging ? "auto" : "none",
       }}
     >
       <div

--- a/packages/pom-editor/src/AstTree.tsx
+++ b/packages/pom-editor/src/AstTree.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState } from "react";
 import {
   DndContext,
+  DragOverlay,
   DragEndEvent,
   DragOverEvent,
   PointerSensor,
@@ -110,13 +111,33 @@ function GapStrip({ parentId, index, depth }: GapStripProps) {
     <div
       ref={setNodeRef}
       data-testid={id}
+      data-drop-placement="between"
       style={{
-        height: isOver ? "10px" : isDragging ? "8px" : "2px",
+        height: "16px",
+        marginTop: "-7px",
+        marginBottom: "-7px",
         marginLeft: `${depth * 16}px`,
-        backgroundColor: isOver ? "#3b82f6" : "transparent",
-        borderRadius: "2px",
+        position: "relative",
+        zIndex: isDragging ? 1 : undefined,
       }}
-    />
+    >
+      <div
+        data-testid={`${id}:indicator`}
+        style={{
+          position: "absolute",
+          top: "50%",
+          right: 0,
+          left: 0,
+          height: isOver ? "3px" : "1px",
+          transform: "translateY(-50%)",
+          backgroundColor: isOver ? "#2563eb" : "transparent",
+          borderRadius: "2px",
+          boxShadow: isOver ? "0 0 0 1px #ffffff" : undefined,
+          transition: "height 50ms, background-color 50ms",
+          pointerEvents: "none",
+        }}
+      />
+    </div>
   );
 }
 
@@ -149,6 +170,7 @@ function Row({ astNode, depth }: RowProps) {
     <div>
       <div
         ref={setBodyRef}
+        data-drop-placement={isContainer ? "inside" : undefined}
         style={{
           display: "flex",
           alignItems: "center",
@@ -173,8 +195,10 @@ function Row({ astNode, depth }: RowProps) {
             fontSize: "12px",
             lineHeight: 1,
             flexShrink: 0,
+            touchAction: "none",
           }}
           title="ドラッグして並び替え"
+          aria-label={`${nodeLabel(astNode.node)} をドラッグ`}
         >
           ⠿
         </span>
@@ -227,6 +251,17 @@ export interface AstTreeProps {
   onChange: (nodes: POMNode[]) => void;
 }
 
+function findAstNode(nodes: AstNode[], id: string): AstNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    if (node.children) {
+      const child = findAstNode(node.children, id);
+      if (child) return child;
+    }
+  }
+  return null;
+}
+
 export function AstTree({ ast, onChange }: AstTreeProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -235,6 +270,7 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
   );
   const [overId, setOverId] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const activeNode = activeId ? findAstNode(ast, activeId) : null;
 
   function onDragStart(event: { active: { id: string | number } }) {
     setActiveId(String(event.active.id));
@@ -275,6 +311,7 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
       <DndContext
         sensors={sensors}
         collisionDetection={pointerWithin}
+        autoScroll
         onDragStart={onDragStart}
         onDragOver={onDragOver}
         onDragEnd={onDragEnd}
@@ -310,6 +347,42 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
                 <GapStrip parentId="root" index={i + 1} depth={0} />
               </React.Fragment>
             ))}
+            <DragOverlay>
+              {activeNode ? (
+                <div
+                  data-testid="ast-drag-overlay"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "6px",
+                    maxWidth: "320px",
+                    padding: "7px 10px",
+                    border: "1px solid #93c5fd",
+                    borderRadius: "6px",
+                    background: "rgba(255, 255, 255, 0.96)",
+                    boxShadow: "0 8px 20px rgba(15, 23, 42, 0.18)",
+                    color: "#1e3a8a",
+                    fontFamily: "monospace",
+                    fontSize: "13px",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  <span aria-hidden="true" style={{ color: "#60a5fa" }}>
+                    ⠿
+                  </span>
+                  <span
+                    style={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {nodeLabel(activeNode.node)}
+                  </span>
+                </div>
+              ) : null}
+            </DragOverlay>
           </OverIdContext.Provider>
         </ActiveIdContext.Provider>
       </DndContext>


### PR DESCRIPTION
close #970

## 概要

AST ツリーの DnD で、before / after の drop hit area と視覚 feedback を改善しました。inside drop は container 行全体の面ハイライトとして区別し、drag 中のノード名を表示する DragOverlay と scroll container 端での auto-scroll を追加しています。

既存の AST mutation operation は変更せず、同一親内の並び替え、cross-parent move、nest / un-nest、および不正な drop の拒否 semantics を維持しています。

## 影響範囲

- `packages/pom-editor/src/AstTree.tsx`
- `packages/pom-editor/src/AstTree.test.tsx`
- `.changeset/tidy-trees-drag.md`

実装パッケージは `@hirokisakabe/pom-editor` のみです。同じ `PomEditor` を利用する website playground と pom-cli preview の AST モードへ反映されます。

## 検証

- `pnpm --filter @hirokisakabe/pom-editor run fmt:check`
- `pnpm --filter @hirokisakabe/pom-editor run lint`
- `pnpm --filter @hirokisakabe/pom-editor run typecheck`
- `pnpm --filter @hirokisakabe/pom-editor run knip`
- `pnpm --filter @hirokisakabe/pom-editor run test:run`（33 tests）
- `pnpm --filter @hirokisakabe/pom-editor run build`
- `pnpm --filter @hirokisakabe/pom-cli run test:run`（50 tests）
- `pnpm --filter @hirokisakabe/pom-cli run typecheck`
- `pnpm --filter @hirokisakabe/pom-cli run build`
- `pnpm --filter pom-docs run test:run`（46 tests）
- `pnpm --filter pom-docs run typecheck`
- website playground / pom-cli preview の短い・長い AST tree で、挿入線、inside highlight、DragOverlay、edge auto-scroll をブラウザ確認
