### PR TITLE
feat: preview UIからPPTX・画像を出力できるようにする

### DIFF
--- a/.changeset/brave-slides-export.md
+++ b/.changeset/brave-slides-export.md
@@ -1,0 +1,6 @@
+---
+"@hirokisakabe/pom-cli": minor
+"@hirokisakabe/pom-editor": minor
+---
+
+`pom preview` の編集中 XML から PPTX と PNG / SVG をダウンロードできるようにし、`PomEditor` に現在または全スライドの画像出力 callback を追加します。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Existing PPTX reading and structural round-trip work should treat `@pptx-glimpse
 
 ### Public API (`@hirokisakabe/pom-editor`)
 
-- `PomEditor` — XML / AST editing、preview、diagnostics、共通toolbarを持つReactコンポーネント。preview生成とoptionalなDownload / Save処理はhost callbackへ委譲する。
+- `PomEditor` — XML / AST editing、preview、diagnostics、共通toolbarを持つReactコンポーネント。preview生成とoptionalなDownload / Save / PNG・SVG画像出力処理はhost callbackへ委譲する。画像出力は `PomEditorImageExportOptions` で形式、現在/全スライド、現在のスライド番号を受け取る。
 - `PomAstEditor` — React コンポーネント。`xml` と `onChange` props を受け取り、AST ツリーを表示して DnD でノードを並び替えると更新後の XML を返す。
 
 ### Key Internal Types

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -49,7 +49,7 @@ pom preview slides.pom.xml
 pom preview slides.pom.md
 ```
 
-The browser opens http://localhost:3000 automatically. For `.pom.xml` files, XML and AST edits are kept in the browser and immediately reflected in the preview. Use **Download** to generate a PPTX from the current browser contents, or choose PNG / SVG and the current / all slides before selecting **Export Images**. These exports include unsaved edits and are also available for `.pom.md` inputs. Progress, success, and build diagnostics are shown in the editor.
+The browser opens http://localhost:3000 automatically. For `.pom.xml` files, XML and AST edits are kept in the browser and immediately reflected in the preview. Use **Download** to generate a PPTX from the current browser contents, or choose PNG / SVG and the current / all slides before selecting **Export Images**. All-slide image exports are downloaded as a ZIP. These exports include unsaved edits and are also available for `.pom.md` inputs. Progress, success, and build diagnostics are shown in the editor.
 
 Use **Save** to write the current XML back to a `.pom.xml` input file. If another editor changed the file after it was loaded, Save is rejected instead of overwriting that change. Successful saves replace the file atomically.
 

--- a/packages/pom-cli/README.md
+++ b/packages/pom-cli/README.md
@@ -49,7 +49,9 @@ pom preview slides.pom.xml
 pom preview slides.pom.md
 ```
 
-The browser opens http://localhost:3000 automatically. For `.pom.xml` files, XML and AST edits are kept in the browser and immediately reflected in the preview. Use **Save** to write the current XML back to the input file. If another editor changed the file after it was loaded, Save is rejected instead of overwriting that change. Successful saves replace the file atomically.
+The browser opens http://localhost:3000 automatically. For `.pom.xml` files, XML and AST edits are kept in the browser and immediately reflected in the preview. Use **Download** to generate a PPTX from the current browser contents, or choose PNG / SVG and the current / all slides before selecting **Export Images**. These exports include unsaved edits and are also available for `.pom.md` inputs. Progress, success, and build diagnostics are shown in the editor.
+
+Use **Save** to write the current XML back to a `.pom.xml` input file. If another editor changed the file after it was loaded, Save is rejected instead of overwriting that change. Successful saves replace the file atomically.
 
 External file changes continue to update the browser when there are no unsaved browser edits. When unsaved edits exist, they are preserved and the toolbar reports the external change. `.pom.md` input remains preview-only because writing generated XML back to Markdown is outside the editor's scope.
 

--- a/packages/pom-cli/client/App.test.tsx
+++ b/packages/pom-cli/client/App.test.tsx
@@ -11,6 +11,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PomEditorProps } from "@hirokisakabe/pom-editor";
 
 const api = vi.hoisted(() => ({
+  downloadPptx: vi.fn(),
+  exportImages: vi.fn(),
   generatePreview: vi.fn(),
   loadDocument: vi.fn(),
   saveDocument: vi.fn(),
@@ -43,6 +45,42 @@ vi.mock("@hirokisakabe/pom-editor", () => ({
         >
           Preview
         </button>
+        {props.onDownload && (
+          <button
+            type="button"
+            onClick={() => void props.onDownload?.(props.xml)}
+          >
+            Download PPTX
+          </button>
+        )}
+        {props.onExportImages && (
+          <>
+            <button
+              type="button"
+              onClick={() =>
+                void props.onExportImages?.(props.xml, {
+                  format: "png",
+                  scope: "current",
+                  currentSlide: 2,
+                })
+              }
+            >
+              Export current PNG
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void props.onExportImages?.(props.xml, {
+                  format: "svg",
+                  scope: "all",
+                  currentSlide: 2,
+                })
+              }
+            >
+              Export all SVG
+            </button>
+          </>
+        )}
         {props.onSave && (
           <button
             type="button"
@@ -114,6 +152,8 @@ function arrangeDocument() {
     editable: true,
   });
   api.generatePreview.mockResolvedValue({ svgs: [] });
+  api.downloadPptx.mockResolvedValue(undefined);
+  api.exportImages.mockResolvedValue(undefined);
   api.saveDocument.mockResolvedValue("revision-2");
 }
 
@@ -139,6 +179,34 @@ describe("CLI preview App", () => {
       expect.any(AbortSignal),
     );
     expect(screen.getByRole("status").textContent).toBe("Unsaved changes");
+  });
+
+  it("未保存XMLをPPTXと現在 / 全スライド画像の出力APIへ渡す", async () => {
+    arrangeDocument();
+    render(<App />);
+    const editor = await screen.findByRole("textbox", { name: "XML editor" });
+    fireEvent.change(editor, {
+      target: { value: "<Text>unsaved export</Text>" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PPTX" }));
+    fireEvent.click(screen.getByRole("button", { name: "Export current PNG" }));
+    fireEvent.click(screen.getByRole("button", { name: "Export all SVG" }));
+
+    expect(api.downloadPptx).toHaveBeenCalledWith(
+      "<Text>unsaved export</Text>",
+      "slides.pom.xml",
+    );
+    expect(api.exportImages).toHaveBeenNthCalledWith(
+      1,
+      "<Text>unsaved export</Text>",
+      { format: "png", slides: [2] },
+    );
+    expect(api.exportImages).toHaveBeenNthCalledWith(
+      2,
+      "<Text>unsaved export</Text>",
+      { format: "svg" },
+    );
   });
 
   it("Saveへ編集中XMLと読込時revisionを渡し、成功後にSaved表示へ戻す", async () => {

--- a/packages/pom-cli/client/App.tsx
+++ b/packages/pom-cli/client/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { PomEditor } from "@hirokisakabe/pom-editor";
 import {
+  downloadPptx,
+  exportImages,
   generatePreview,
   loadDocument,
   saveDocument,
@@ -109,6 +111,15 @@ export function App() {
         setXml(value);
       }}
       onPreview={(value, { signal }) => generatePreview(value, signal)}
+      onDownload={(value) => downloadPptx(value, document.filename)}
+      onExportImages={(value, options) =>
+        exportImages(value, {
+          format: options.format,
+          ...(options.scope === "current"
+            ? { slides: [options.currentSlide] }
+            : {}),
+        })
+      }
       onSave={
         document.editable
           ? async (value) => {

--- a/packages/pom-cli/client/api.test.ts
+++ b/packages/pom-cli/client/api.test.ts
@@ -1,7 +1,16 @@
+// @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { generatePreview, loadDocument, saveDocument } from "./api.ts";
+import {
+  downloadPptx,
+  exportImages,
+  generatePreview,
+  loadDocument,
+  PreviewExportError,
+  saveDocument,
+} from "./api.ts";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -74,5 +83,90 @@ describe("preview client API", () => {
     await expect(saveDocument("<Text />", "revision-1")).rejects.toThrow(
       "External change conflict",
     );
+  });
+
+  it("未保存XMLをPPTX APIへ渡してdownloadする", async () => {
+    const response = new Response(new Uint8Array([80, 75]), {
+      status: 200,
+      headers: {
+        "Content-Type":
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:pptx"),
+      revokeObjectURL: vi.fn(),
+    });
+
+    await downloadPptx("<Text>unsaved</Text>", "slides.pom.xml");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/_api/export/pptx",
+      expect.objectContaining({
+        body: JSON.stringify({ xml: "<Text>unsaved</Text>" }),
+      }),
+    );
+    expect(click).toHaveBeenCalled();
+  });
+
+  it("画像形式とslide指定をAPIへ渡して全responseをdownloadする", async () => {
+    const fetchMock = mockResponse(200, {
+      files: [
+        {
+          filename: "slides-slide-01.svg",
+          mediaType: "image/svg+xml",
+          data: "PHN2ZyAvPg==",
+        },
+        {
+          filename: "slides-slide-02.svg",
+          mediaType: "image/svg+xml",
+          data: "PHN2ZyAvPg==",
+        },
+      ],
+    });
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:image"),
+      revokeObjectURL: vi.fn(),
+    });
+
+    await exportImages("<Text>unsaved</Text>", {
+      format: "svg",
+      slides: [2],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/_api/export/images",
+      expect.objectContaining({
+        body: JSON.stringify({
+          xml: "<Text>unsaved</Text>",
+          format: "svg",
+          slides: [2],
+        }),
+      }),
+    );
+    expect(click).toHaveBeenCalledTimes(2);
+  });
+
+  it("export APIのdiagnosticsを保持したerrorを投げる", async () => {
+    mockResponse(422, {
+      errors: [{ type: "NODE_OVERLAP", message: "overlap" }],
+    });
+
+    const error = await downloadPptx("<Text />", "slides.pom.xml").catch(
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(PreviewExportError);
+    expect((error as PreviewExportError).diagnostics).toEqual([
+      { type: "NODE_OVERLAP", message: "overlap" },
+    ]);
   });
 });

--- a/packages/pom-cli/client/api.test.ts
+++ b/packages/pom-cli/client/api.test.ts
@@ -172,8 +172,12 @@ describe("preview client API", () => {
   it("不正なdiagnostics responseは型付きerrorとして扱わない", async () => {
     mockResponse(422, { errors: [null] });
 
-    await expect(downloadPptx("<Text />", "slides.pom.xml")).rejects.toThrow(
-      "PPTX generation failed",
+    const error = await downloadPptx("<Text />", "slides.pom.xml").catch(
+      (reason: unknown) => reason,
     );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(PreviewExportError);
+    expect((error as Error).message).toBe("PPTX generation failed");
   });
 });

--- a/packages/pom-cli/client/api.test.ts
+++ b/packages/pom-cli/client/api.test.ts
@@ -114,21 +114,17 @@ describe("preview client API", () => {
     expect(click).toHaveBeenCalled();
   });
 
-  it("画像形式とslide指定をAPIへ渡して全responseをdownloadする", async () => {
-    const fetchMock = mockResponse(200, {
-      files: [
-        {
-          filename: "slides-slide-01.svg",
-          mediaType: "image/svg+xml",
-          data: "PHN2ZyAvPg==",
+  it("画像形式とslide指定をAPIへ渡してresponseを1回downloadする", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([80, 75]), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/zip",
+          "X-Pom-Filename": "slides-svg-images.zip",
         },
-        {
-          filename: "slides-slide-02.svg",
-          mediaType: "image/svg+xml",
-          data: "PHN2ZyAvPg==",
-        },
-      ],
-    });
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
     const click = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(() => {});
@@ -152,7 +148,7 @@ describe("preview client API", () => {
         }),
       }),
     );
-    expect(click).toHaveBeenCalledTimes(2);
+    expect(click).toHaveBeenCalledTimes(1);
   });
 
   it("export APIのdiagnosticsを保持したerrorを投げる", async () => {
@@ -168,5 +164,13 @@ describe("preview client API", () => {
     expect((error as PreviewExportError).diagnostics).toEqual([
       { type: "NODE_OVERLAP", message: "overlap" },
     ]);
+  });
+
+  it("不正なdiagnostics responseは型付きerrorとして扱わない", async () => {
+    mockResponse(422, { errors: [null] });
+
+    await expect(downloadPptx("<Text />", "slides.pom.xml")).rejects.toThrow(
+      "PPTX generation failed",
+    );
   });
 });

--- a/packages/pom-cli/client/api.test.ts
+++ b/packages/pom-cli/client/api.test.ts
@@ -120,14 +120,16 @@ describe("preview client API", () => {
         status: 200,
         headers: {
           "Content-Type": "application/zip",
-          "X-Pom-Filename": "slides-svg-images.zip",
         },
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
+    let downloadedFilename = "";
     const click = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => {});
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadedFilename = this.download;
+      });
     vi.stubGlobal("URL", {
       createObjectURL: vi.fn(() => "blob:image"),
       revokeObjectURL: vi.fn(),
@@ -149,6 +151,7 @@ describe("preview client API", () => {
       }),
     );
     expect(click).toHaveBeenCalledTimes(1);
+    expect(downloadedFilename).toBe("slides-images.zip");
   });
 
   it("export APIのdiagnosticsを保持したerrorを投げる", async () => {

--- a/packages/pom-cli/client/api.ts
+++ b/packages/pom-cli/client/api.ts
@@ -191,8 +191,14 @@ export async function exportImages(
   if (!response.ok) {
     await throwExportError(response, "Image rendering failed");
   }
+  const fallbackFilename = response.headers
+    .get("content-type")
+    ?.toLowerCase()
+    .startsWith("application/zip")
+    ? "slides-images.zip"
+    : `slides.${options.format}`;
   downloadBlob(
     await response.blob(),
-    attachmentFilename(response, `slides.${options.format}`),
+    attachmentFilename(response, fallbackFilename),
   );
 }

--- a/packages/pom-cli/client/api.ts
+++ b/packages/pom-cli/client/api.ts
@@ -10,6 +10,22 @@ export interface PreviewDocument {
   editable: boolean;
 }
 
+interface ExportedImage {
+  filename: string;
+  mediaType: string;
+  data: string;
+}
+
+export class PreviewExportError extends Error {
+  constructor(
+    message: string,
+    public readonly diagnostics: PomEditorDiagnostic[],
+  ) {
+    super(message);
+    this.name = "PreviewExportError";
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -26,6 +42,35 @@ function errorMessage(value: unknown, fallback: string): string {
   return isRecord(value) && typeof value.message === "string"
     ? value.message
     : fallback;
+}
+
+async function throwExportError(
+  response: Response,
+  fallback: string,
+): Promise<never> {
+  const result = await readJson(response);
+  if (isRecord(result) && Array.isArray(result.errors)) {
+    const diagnostics = result.errors as PomEditorDiagnostic[];
+    throw new PreviewExportError(
+      diagnostics.map((diagnostic) => diagnostic.message).join("\n") ||
+        fallback,
+      diagnostics,
+    );
+  }
+  throw new Error(errorMessage(result, fallback));
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function outputBaseName(filename: string): string {
+  return filename.replace(/\.pom\.(?:xml|md)$/u, "");
 }
 
 export async function loadDocument(signal?: AbortSignal) {
@@ -88,4 +133,56 @@ export async function saveDocument(xml: string, revision: string) {
     throw new Error(errorMessage(result, "Save failed"));
   }
   return result.revision;
+}
+
+export async function downloadPptx(
+  xml: string,
+  sourceFilename: string,
+): Promise<void> {
+  const response = await fetch("/_api/export/pptx", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ xml }),
+  });
+  if (!response.ok) {
+    await throwExportError(response, "PPTX generation failed");
+  }
+  downloadBlob(await response.blob(), `${outputBaseName(sourceFilename)}.pptx`);
+}
+
+export async function exportImages(
+  xml: string,
+  options: {
+    format: "png" | "svg";
+    slides?: number[];
+  },
+): Promise<void> {
+  const response = await fetch("/_api/export/images", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ xml, ...options }),
+  });
+  if (!response.ok) {
+    await throwExportError(response, "Image rendering failed");
+  }
+  const result = await readJson(response);
+  if (
+    !isRecord(result) ||
+    !Array.isArray(result.files) ||
+    !result.files.every(
+      (file) =>
+        isRecord(file) &&
+        typeof file.filename === "string" &&
+        typeof file.mediaType === "string" &&
+        typeof file.data === "string",
+    )
+  ) {
+    throw new Error("Invalid image export response from the preview server");
+  }
+  for (const file of result.files as ExportedImage[]) {
+    const bytes = Uint8Array.from(atob(file.data), (character) =>
+      character.charCodeAt(0),
+    );
+    downloadBlob(new Blob([bytes], { type: file.mediaType }), file.filename);
+  }
 }

--- a/packages/pom-cli/client/api.ts
+++ b/packages/pom-cli/client/api.ts
@@ -71,11 +71,12 @@ async function throwExportError(
 
 function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
+  const revokeObjectURL = URL.revokeObjectURL.bind(URL);
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = filename;
   anchor.click();
-  setTimeout(() => URL.revokeObjectURL(url), 0);
+  setTimeout(() => revokeObjectURL(url), 0);
 }
 
 function outputBaseName(filename: string): string {

--- a/packages/pom-cli/client/api.ts
+++ b/packages/pom-cli/client/api.ts
@@ -10,12 +10,6 @@ export interface PreviewDocument {
   editable: boolean;
 }
 
-interface ExportedImage {
-  filename: string;
-  mediaType: string;
-  data: string;
-}
-
 export class PreviewExportError extends Error {
   constructor(
     message: string,
@@ -28,6 +22,17 @@ export class PreviewExportError extends Error {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isDiagnostic(value: unknown): value is PomEditorDiagnostic {
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    typeof value.message === "string" &&
+    (value.line === undefined || typeof value.line === "number") &&
+    (value.column === undefined || typeof value.column === "number") &&
+    (value.tagName === undefined || typeof value.tagName === "string")
+  );
 }
 
 async function readJson(response: Response): Promise<unknown> {
@@ -49,8 +54,12 @@ async function throwExportError(
   fallback: string,
 ): Promise<never> {
   const result = await readJson(response);
-  if (isRecord(result) && Array.isArray(result.errors)) {
-    const diagnostics = result.errors as PomEditorDiagnostic[];
+  if (
+    isRecord(result) &&
+    Array.isArray(result.errors) &&
+    result.errors.every(isDiagnostic)
+  ) {
+    const diagnostics = result.errors;
     throw new PreviewExportError(
       diagnostics.map((diagnostic) => diagnostic.message).join("\n") ||
         fallback,
@@ -71,6 +80,16 @@ function downloadBlob(blob: Blob, filename: string): void {
 
 function outputBaseName(filename: string): string {
   return filename.replace(/\.pom\.(?:xml|md)$/u, "");
+}
+
+function attachmentFilename(response: Response, fallback: string): string {
+  const encoded = response.headers.get("x-pom-filename");
+  if (!encoded) return fallback;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return fallback;
+  }
 }
 
 export async function loadDocument(signal?: AbortSignal) {
@@ -104,8 +123,12 @@ export async function generatePreview(
     signal,
   });
   const result = await readJson(response);
-  if (isRecord(result) && Array.isArray(result.errors)) {
-    return { errors: result.errors as PomEditorDiagnostic[] };
+  if (
+    isRecord(result) &&
+    Array.isArray(result.errors) &&
+    result.errors.every(isDiagnostic)
+  ) {
+    return { errors: result.errors };
   }
   if (!response.ok) throw new Error(errorMessage(result, "Preview failed"));
   if (
@@ -147,7 +170,10 @@ export async function downloadPptx(
   if (!response.ok) {
     await throwExportError(response, "PPTX generation failed");
   }
-  downloadBlob(await response.blob(), `${outputBaseName(sourceFilename)}.pptx`);
+  downloadBlob(
+    await response.blob(),
+    attachmentFilename(response, `${outputBaseName(sourceFilename)}.pptx`),
+  );
 }
 
 export async function exportImages(
@@ -165,24 +191,8 @@ export async function exportImages(
   if (!response.ok) {
     await throwExportError(response, "Image rendering failed");
   }
-  const result = await readJson(response);
-  if (
-    !isRecord(result) ||
-    !Array.isArray(result.files) ||
-    !result.files.every(
-      (file) =>
-        isRecord(file) &&
-        typeof file.filename === "string" &&
-        typeof file.mediaType === "string" &&
-        typeof file.data === "string",
-    )
-  ) {
-    throw new Error("Invalid image export response from the preview server");
-  }
-  for (const file of result.files as ExportedImage[]) {
-    const bytes = Uint8Array.from(atob(file.data), (character) =>
-      character.charCodeAt(0),
-    );
-    downloadBlob(new Blob([bytes], { type: file.mediaType }), file.filename);
-  }
+  downloadBlob(
+    await response.blob(),
+    attachmentFilename(response, `slides.${options.format}`),
+  );
 }

--- a/packages/pom-cli/package.json
+++ b/packages/pom-cli/package.json
@@ -44,6 +44,7 @@
     "@hirokisakabe/pom": "workspace:*",
     "@hirokisakabe/pom-md": "workspace:*",
     "commander": "^15.0.0",
+    "jszip": "^3.10.1",
     "pptx-glimpse": "^3.2.8"
   },
   "devDependencies": {

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { DiagnosticsError } from "@hirokisakabe/pom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const watchState = vi.hoisted(() => ({
@@ -49,11 +50,16 @@ afterEach(async () => {
 async function startServer(
   generatePreview = vi.fn().mockResolvedValue({ svgs: [] }),
   onDocumentEvent?: ReturnType<typeof vi.fn>,
+  exportOptions: {
+    generatePptx?: ReturnType<typeof vi.fn>;
+    renderImages?: ReturnType<typeof vi.fn>;
+  } = {},
 ) {
   server = createPreviewServer(inputFile, {
     clientScript: "globalThis.__POM_PREVIEW_CLIENT__ = true;",
     generatePreview,
     onDocumentEvent,
+    ...exportOptions,
   });
   await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
   const address = server.address();
@@ -156,6 +162,141 @@ describe("preview server", () => {
 
     expect(response.status).toBe(200);
     expect(generatePreview).toHaveBeenCalledWith(xml);
+  });
+
+  it("編集中の未保存XMLからPPTXを生成して返す", async () => {
+    const generatePptx = vi.fn().mockResolvedValue(new Uint8Array([80, 75]));
+    await startServer(undefined, undefined, { generatePptx });
+    const xml = "<Text>unsaved PPTX</Text>";
+    const response = await fetch(`${baseUrl}/_api/export/pptx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "presentationml.presentation",
+    );
+    expect(generatePptx).toHaveBeenCalledWith(xml);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([80, 75]),
+    );
+  });
+
+  it("PNG / SVGと現在 / 全スライド指定を画像render APIへ渡す", async () => {
+    const renderImages = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { slideNumber: 2, data: new Uint8Array([1, 2, 3]) },
+      ])
+      .mockResolvedValueOnce([
+        { slideNumber: 1, data: "<svg>one</svg>" },
+        { slideNumber: 2, data: "<svg>two</svg>" },
+      ]);
+    await startServer(undefined, undefined, { renderImages });
+    const xml = "<Text>unsaved images</Text>";
+
+    const currentResponse = await fetch(`${baseUrl}/_api/export/images`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml, format: "png", slides: [2] }),
+    });
+    const allResponse = await fetch(`${baseUrl}/_api/export/images`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml, format: "svg" }),
+    });
+
+    expect(renderImages).toHaveBeenNthCalledWith(1, xml, {
+      format: "png",
+      slides: [2],
+    });
+    expect(renderImages).toHaveBeenNthCalledWith(2, xml, { format: "svg" });
+    await expect(currentResponse.json()).resolves.toMatchObject({
+      files: [
+        {
+          filename: "slides-slide-02.png",
+          mediaType: "image/png",
+          data: "AQID",
+        },
+      ],
+    });
+    await expect(allResponse.json()).resolves.toMatchObject({
+      files: [
+        { filename: "slides-slide-01.svg", mediaType: "image/svg+xml" },
+        { filename: "slides-slide-02.svg", mediaType: "image/svg+xml" },
+      ],
+    });
+  });
+
+  it("PPTX / 画像生成失敗時はdiagnosticsを422で返す", async () => {
+    const failure = new DiagnosticsError([
+      { code: "NODE_OVERLAP", message: "overlap" },
+    ]);
+    const generatePptx = vi.fn().mockRejectedValue(failure);
+    const renderImages = vi.fn().mockRejectedValue(failure);
+    await startServer(undefined, undefined, {
+      generatePptx,
+      renderImages,
+    });
+    const request = (pathname: string, body: object) =>
+      fetch(`${baseUrl}${pathname}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    const pptxResponse = await request("/_api/export/pptx", {
+      xml: "<Text />",
+    });
+    const imageResponse = await request("/_api/export/images", {
+      xml: "<Text />",
+      format: "png",
+    });
+
+    expect(pptxResponse.status).toBe(422);
+    expect(imageResponse.status).toBe(422);
+    await expect(pptxResponse.json()).resolves.toMatchObject({
+      errors: [{ type: "NODE_OVERLAP", message: "overlap" }],
+    });
+    await expect(imageResponse.json()).resolves.toMatchObject({
+      errors: [{ type: "NODE_OVERLAP", message: "overlap" }],
+    });
+  });
+
+  it(".pom.md入力でも変換済みXMLからPPTX / 画像を出力できる", async () => {
+    inputFile = path.join(tempDir, "markdown.pom.md");
+    await fs.promises.writeFile(inputFile, "# Markdown slide");
+    const generatePptx = vi.fn().mockResolvedValue(new Uint8Array([80, 75]));
+    const renderImages = vi
+      .fn()
+      .mockResolvedValue([{ slideNumber: 1, data: "<svg />" }]);
+    await startServer(undefined, undefined, {
+      generatePptx,
+      renderImages,
+    });
+    const document = await fetch(`${baseUrl}/_api/document`).then(
+      (response) =>
+        response.json() as Promise<{ xml: string; editable: boolean }>,
+    );
+
+    const pptxResponse = await fetch(`${baseUrl}/_api/export/pptx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml: document.xml }),
+    });
+    const imageResponse = await fetch(`${baseUrl}/_api/export/images`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml: document.xml, format: "svg" }),
+    });
+
+    expect(document.editable).toBe(false);
+    expect(pptxResponse.status).toBe(200);
+    expect(imageResponse.status).toBe(200);
+    expect(generatePptx).toHaveBeenCalledWith(document.xml);
+    expect(renderImages).toHaveBeenCalledWith(document.xml, { format: "svg" });
   });
 
   it("request body上限超過を413で返す", async () => {

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { DiagnosticsError } from "@hirokisakabe/pom";
+import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const watchState = vi.hoisted(() => ({
@@ -213,21 +214,26 @@ describe("preview server", () => {
       slides: [2],
     });
     expect(renderImages).toHaveBeenNthCalledWith(2, xml, { format: "svg" });
-    await expect(currentResponse.json()).resolves.toMatchObject({
-      files: [
-        {
-          filename: "slides-slide-02.png",
-          mediaType: "image/png",
-          data: "AQID",
-        },
-      ],
-    });
-    await expect(allResponse.json()).resolves.toMatchObject({
-      files: [
-        { filename: "slides-slide-01.svg", mediaType: "image/svg+xml" },
-        { filename: "slides-slide-02.svg", mediaType: "image/svg+xml" },
-      ],
-    });
+    expect(currentResponse.headers.get("content-type")).toBe("image/png");
+    expect(
+      decodeURIComponent(currentResponse.headers.get("x-pom-filename") ?? ""),
+    ).toBe("slides-slide-02.png");
+    expect(new Uint8Array(await currentResponse.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+
+    expect(allResponse.headers.get("content-type")).toBe("application/zip");
+    expect(
+      decodeURIComponent(allResponse.headers.get("x-pom-filename") ?? ""),
+    ).toBe("slides-svg-images.zip");
+    const zip = await JSZip.loadAsync(await allResponse.arrayBuffer());
+    expect(Object.keys(zip.files).sort()).toEqual([
+      "slides-slide-01.svg",
+      "slides-slide-02.svg",
+    ]);
+    await expect(
+      zip.file("slides-slide-02.svg")?.async("string"),
+    ).resolves.toBe("<svg>two</svg>");
   });
 
   it("PPTX / 画像生成失敗時はdiagnosticsを422で返す", async () => {

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -316,6 +316,17 @@ describe("preview server", () => {
     expect(response.status).toBe(413);
   });
 
+  it("空のslides指定を400で拒否する", async () => {
+    await startServer();
+    const response = await fetch(`${baseUrl}/_api/export/images`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ xml: "<Text />", format: "png", slides: [] }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it("Save後のwatch通知を抑止し、後続のexternal changeだけを配信する", async () => {
     const onDocumentEvent = vi.fn();
     const generatePreview = await startServer(undefined, onDocumentEvent);

--- a/packages/pom-cli/src/preview.test.ts
+++ b/packages/pom-cli/src/preview.test.ts
@@ -327,6 +327,26 @@ describe("preview server", () => {
     expect(response.status).toBe(400);
   });
 
+  it.each([
+    ["xmlなし", { format: "png" }],
+    ["未知のformat", { xml: "<Text />", format: "gif" }],
+    ["0のslide", { xml: "<Text />", format: "png", slides: [0] }],
+    ["負数のslide", { xml: "<Text />", format: "png", slides: [-1] }],
+    ["小数のslide", { xml: "<Text />", format: "png", slides: [1.5] }],
+    ["文字列のslide", { xml: "<Text />", format: "png", slides: ["1"] }],
+  ])("不正な画像出力request (%s) を400で拒否する", async (_name, body) => {
+    const renderImages = vi.fn();
+    await startServer(undefined, undefined, { renderImages });
+    const response = await fetch(`${baseUrl}/_api/export/images`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(400);
+    expect(renderImages).not.toHaveBeenCalled();
+  });
+
   it("Save後のwatch通知を抑止し、後続のexternal changeだけを配信する", async () => {
     const onDocumentEvent = vi.fn();
     const generatePreview = await startServer(undefined, onDocumentEvent);

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -285,6 +285,7 @@ function readImageExportOptions(value: unknown): ImageExportOptions {
   if (
     request.slides !== undefined &&
     (!Array.isArray(request.slides) ||
+      request.slides.length === 0 ||
       !request.slides.every(
         (slide) => Number.isInteger(slide) && Number(slide) > 0,
       ))

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -5,6 +5,7 @@ import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildPptx, DiagnosticsError } from "@hirokisakabe/pom";
+import JSZip from "jszip";
 import { convertPptxToSvg } from "pptx-glimpse";
 import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
 import { loadInput, loadInputContent, type LoadedInput } from "./input.ts";
@@ -314,6 +315,32 @@ function outputBaseName(absInput: string): string {
   return path.basename(absInput).replace(/\.pom\.(?:xml|md)$/u, "");
 }
 
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*]/gu,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function sendAttachment(
+  res: http.ServerResponse,
+  data: string | Uint8Array,
+  mediaType: string,
+  filename: string,
+): void {
+  const buffer = Buffer.from(data);
+  res.writeHead(200, {
+    "Content-Type": mediaType,
+    "Content-Disposition": `attachment; filename="download"; filename*=UTF-8''${encodeRfc5987(
+      filename,
+    )}`,
+    "Content-Length": buffer.byteLength,
+    "Cache-Control": "no-store",
+    "X-Pom-Filename": encodeURIComponent(filename),
+  });
+  res.end(buffer);
+}
+
 export interface PreviewServerOptions {
   verbose?: boolean;
   clientScript?: string;
@@ -451,16 +478,12 @@ export function createPreviewServer(
           const buffer = options.generatePptx
             ? await options.generatePptx(xml)
             : await generatePptx(xml, loadInput(absInput));
-          res.writeHead(200, {
-            "Content-Type":
-              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            "Content-Disposition": `attachment; filename="presentation.pptx"; filename*=UTF-8''${encodeURIComponent(
-              `${outputBaseName(absInput)}.pptx`,
-            )}`,
-            "Content-Length": buffer.byteLength,
-            "Cache-Control": "no-store",
-          });
-          res.end(buffer);
+          sendAttachment(
+            res,
+            buffer,
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            `${outputBaseName(absInput)}.pptx`,
+          );
         } catch (error) {
           sendJson(res, 422, previewFailure(error));
         }
@@ -498,16 +521,32 @@ export function createPreviewServer(
             2,
             ...outputs.map((output) => String(output.slideNumber).length),
           );
-          sendJson(res, 200, {
-            files: outputs.map((output) => ({
-              filename: `${outputBaseName(absInput)}-slide-${String(
-                output.slideNumber,
-              ).padStart(padWidth, "0")}.${imageOptions.format}`,
-              mediaType:
-                imageOptions.format === "png" ? "image/png" : "image/svg+xml",
-              data: Buffer.from(output.data).toString("base64"),
-            })),
-          });
+          const files = outputs.map((output) => ({
+            filename: `${outputBaseName(absInput)}-slide-${String(
+              output.slideNumber,
+            ).padStart(padWidth, "0")}.${imageOptions.format}`,
+            data: output.data,
+          }));
+          if (imageOptions.slides !== undefined && files.length === 1) {
+            const file = files[0];
+            sendAttachment(
+              res,
+              file.data,
+              imageOptions.format === "png" ? "image/png" : "image/svg+xml",
+              file.filename,
+            );
+          } else {
+            const zip = new JSZip();
+            for (const file of files) {
+              zip.file(file.filename, file.data);
+            }
+            sendAttachment(
+              res,
+              await zip.generateAsync({ type: "uint8array" }),
+              "application/zip",
+              `${outputBaseName(absInput)}-${imageOptions.format}-images.zip`,
+            );
+          }
         } catch (error) {
           sendJson(res, 422, previewFailure(error));
         }

--- a/packages/pom-cli/src/preview.ts
+++ b/packages/pom-cli/src/preview.ts
@@ -8,6 +8,11 @@ import { buildPptx, DiagnosticsError } from "@hirokisakabe/pom";
 import { convertPptxToSvg } from "pptx-glimpse";
 import { EXTRA_FONT_MAPPING, resolveBundledFontsDir } from "./glimpse.ts";
 import { loadInput, loadInputContent, type LoadedInput } from "./input.ts";
+import {
+  renderPresentation,
+  type RenderedSlide,
+  type RenderFormat,
+} from "./render.ts";
 import { watchInputFile } from "./watch.ts";
 
 const DEFAULT_PORT = 3000;
@@ -34,6 +39,11 @@ interface PreviewFailure {
 }
 
 type PreviewResult = PreviewSuccess | PreviewFailure;
+
+interface ImageExportOptions {
+  format: RenderFormat;
+  slides?: number[];
+}
 
 class SaveConflictError extends Error {
   constructor() {
@@ -164,6 +174,25 @@ async function generateSvgs(
   return { svgs: slides.map((slide) => slide.svg) };
 }
 
+async function generatePptx(
+  xml: string,
+  context: Pick<LoadedInput, "slideWidth" | "slideHeight" | "masterPptxData">,
+): Promise<Uint8Array> {
+  const { pptx } = await buildPptx(
+    xml,
+    { w: context.slideWidth, h: context.slideHeight },
+    {
+      ...(context.masterPptxData ? { masterPptx: context.masterPptxData } : {}),
+      strict: true,
+    },
+  );
+  const buffer = await pptx.write({ outputType: "uint8array" });
+  if (!(buffer instanceof Uint8Array)) {
+    throw new Error("Unexpected output type from pptx.write");
+  }
+  return buffer;
+}
+
 function previewFailure(error: unknown): PreviewFailure {
   if (error instanceof DiagnosticsError) {
     return {
@@ -244,6 +273,31 @@ function readStringField(value: unknown, field: "xml" | "revision"): string {
   return (value as Record<string, string>)[field];
 }
 
+function readImageExportOptions(value: unknown): ImageExportOptions {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Expected an image export request");
+  }
+  const request = value as Record<string, unknown>;
+  if (request.format !== "png" && request.format !== "svg") {
+    throw new Error('Expected format to be "png" or "svg"');
+  }
+  if (
+    request.slides !== undefined &&
+    (!Array.isArray(request.slides) ||
+      !request.slides.every(
+        (slide) => Number.isInteger(slide) && Number(slide) > 0,
+      ))
+  ) {
+    throw new Error("Expected slides to contain positive integers");
+  }
+  return {
+    format: request.format,
+    ...(request.slides
+      ? { slides: request.slides.map((slide) => Number(slide)) }
+      : {}),
+  };
+}
+
 function sendJson(
   res: http.ServerResponse,
   status: number,
@@ -256,10 +310,19 @@ function sendJson(
   res.end(JSON.stringify(value));
 }
 
+function outputBaseName(absInput: string): string {
+  return path.basename(absInput).replace(/\.pom\.(?:xml|md)$/u, "");
+}
+
 export interface PreviewServerOptions {
   verbose?: boolean;
   clientScript?: string;
   generatePreview?: (xml: string) => Promise<PreviewResult>;
+  generatePptx?: (xml: string) => Promise<Uint8Array>;
+  renderImages?: (
+    xml: string,
+    options: ImageExportOptions,
+  ) => Promise<RenderedSlide[]>;
   onDocumentEvent?: (document: PreviewDocument) => void;
 }
 
@@ -376,6 +439,75 @@ export function createPreviewServer(
             ? await options.generatePreview(xml)
             : await generateSvgs(xml, loadInput(absInput), verbose);
           sendJson(res, 200, result);
+        } catch (error) {
+          sendJson(res, 422, previewFailure(error));
+        }
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/_api/export/pptx") {
+        const body = await readJsonBody(req);
+        const xml = readStringField(body, "xml");
+        try {
+          const buffer = options.generatePptx
+            ? await options.generatePptx(xml)
+            : await generatePptx(xml, loadInput(absInput));
+          res.writeHead(200, {
+            "Content-Type":
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "Content-Disposition": `attachment; filename="presentation.pptx"; filename*=UTF-8''${encodeURIComponent(
+              `${outputBaseName(absInput)}.pptx`,
+            )}`,
+            "Content-Length": buffer.byteLength,
+            "Cache-Control": "no-store",
+          });
+          res.end(buffer);
+        } catch (error) {
+          sendJson(res, 422, previewFailure(error));
+        }
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/_api/export/images") {
+        const body = await readJsonBody(req);
+        const xml = readStringField(body, "xml");
+        const imageOptions = readImageExportOptions(body);
+        try {
+          let outputs: RenderedSlide[];
+          if (options.renderImages) {
+            outputs = await options.renderImages(xml, imageOptions);
+          } else {
+            const context = loadInput(absInput);
+            outputs = await renderPresentation(
+              xml,
+              {
+                slideWidth: context.slideWidth,
+                slideHeight: context.slideHeight,
+                ...(context.masterPptxData
+                  ? { masterPptxData: context.masterPptxData }
+                  : {}),
+              },
+              {
+                ...imageOptions,
+                ...(imageOptions.format === "svg"
+                  ? { textOutput: "text" as const }
+                  : {}),
+                verbose,
+              },
+            );
+          }
+          const padWidth = Math.max(
+            2,
+            ...outputs.map((output) => String(output.slideNumber).length),
+          );
+          sendJson(res, 200, {
+            files: outputs.map((output) => ({
+              filename: `${outputBaseName(absInput)}-slide-${String(
+                output.slideNumber,
+              ).padStart(padWidth, "0")}.${imageOptions.format}`,
+              mediaType:
+                imageOptions.format === "png" ? "image/png" : "image/svg+xml",
+              data: Buffer.from(output.data).toString("base64"),
+            })),
+          });
         } catch (error) {
           sendJson(res, 422, previewFailure(error));
         }

--- a/packages/pom-cli/src/render.ts
+++ b/packages/pom-cli/src/render.ts
@@ -8,9 +8,84 @@ import { loadInput } from "./input.ts";
 export type RenderFormat = "png" | "svg";
 export type TextOutput = "path" | "text";
 
+export interface RenderContext {
+  slideWidth: number;
+  slideHeight: number;
+  masterPptxData?: Uint8Array;
+}
+
+export interface RenderedSlide {
+  slideNumber: number;
+  data: string | Uint8Array;
+}
+
 function makeLog(verbose: boolean) {
   if (!verbose) return (_msg: string) => {};
   return (msg: string) => process.stderr.write(`[pom] ${msg}\n`);
+}
+
+export async function renderPresentation(
+  xml: string,
+  context: RenderContext,
+  options: {
+    format: RenderFormat;
+    slides?: number[];
+    textOutput?: TextOutput;
+    verbose?: boolean;
+  },
+): Promise<RenderedSlide[]> {
+  const log = makeLog(options.verbose ?? false);
+  const t1 = Date.now();
+  const { pptx } = await buildPptx(
+    xml,
+    { w: context.slideWidth, h: context.slideHeight },
+    {
+      textMeasurement: "fallback",
+      ...(context.masterPptxData ? { masterPptx: context.masterPptxData } : {}),
+      strict: true,
+    },
+  );
+  log(`Building PPTX... done (${Date.now() - t1}ms)`);
+
+  const buffer = await pptx.write({ outputType: "uint8array" });
+  if (!(buffer instanceof Uint8Array)) {
+    throw new Error("Unexpected output type from pptx.write");
+  }
+
+  const convertOptions = {
+    width: context.slideWidth,
+    fontDirs: [resolveBundledFontsDir()],
+    fontMapping: EXTRA_FONT_MAPPING,
+    skipSystemFonts: true,
+    ...(options.slides ? { slides: options.slides } : {}),
+  };
+
+  const t2 = Date.now();
+  let outputs: RenderedSlide[];
+  if (options.format === "svg") {
+    const { slides } = await convertPptxToSvg(buffer, {
+      ...convertOptions,
+      ...(options.textOutput ? { textOutput: options.textOutput } : {}),
+    });
+    outputs = slides.map((slide) => ({
+      slideNumber: slide.slideNumber,
+      data: slide.svg,
+    }));
+  } else {
+    const { slides } = await convertPptxToPng(buffer, convertOptions);
+    outputs = slides.map((slide) => ({
+      slideNumber: slide.slideNumber,
+      data: slide.png,
+    }));
+  }
+  log(
+    `Rendering ${options.format.toUpperCase()}... done (${Date.now() - t2}ms)`,
+  );
+
+  if (outputs.length === 0) {
+    throw new Error("No slides were rendered");
+  }
+  return outputs;
 }
 
 export async function runRender(
@@ -41,44 +116,20 @@ export async function runRender(
     log,
   );
 
-  const t1 = Date.now();
-  const { pptx } = await buildPptx(
+  const outputs = await renderPresentation(
     xml,
-    { w: slideWidth, h: slideHeight },
     {
-      textMeasurement: "fallback",
-      ...(masterPptxData ? { masterPptx: masterPptxData } : {}),
-      strict: true,
+      slideWidth,
+      slideHeight,
+      ...(masterPptxData ? { masterPptxData } : {}),
+    },
+    {
+      format,
+      ...(options.slides ? { slides: options.slides } : {}),
+      ...(options.textOutput ? { textOutput: options.textOutput } : {}),
+      verbose,
     },
   );
-  log(`Building PPTX... done (${Date.now() - t1}ms)`);
-
-  const buffer = await pptx.write({ outputType: "uint8array" });
-  if (!(buffer instanceof Uint8Array)) {
-    throw new Error("Unexpected output type from pptx.write");
-  }
-
-  const convertOptions = {
-    width: slideWidth,
-    fontDirs: [resolveBundledFontsDir()],
-    fontMapping: EXTRA_FONT_MAPPING,
-    skipSystemFonts: true,
-    ...(options.slides ? { slides: options.slides } : {}),
-  };
-
-  const t2 = Date.now();
-  let outputs: { slideNumber: number; data: string | Uint8Array }[];
-  if (format === "svg") {
-    const { slides } = await convertPptxToSvg(buffer, {
-      ...convertOptions,
-      ...(options.textOutput ? { textOutput: options.textOutput } : {}),
-    });
-    outputs = slides.map((s) => ({ slideNumber: s.slideNumber, data: s.svg }));
-  } else {
-    const { slides } = await convertPptxToPng(buffer, convertOptions);
-    outputs = slides.map((s) => ({ slideNumber: s.slideNumber, data: s.png }));
-  }
-  log(`Rendering ${format.toUpperCase()}... done (${Date.now() - t2}ms)`);
 
   if (options.slides) {
     const rendered = new Set(outputs.map((o) => o.slideNumber));
@@ -88,10 +139,6 @@ export async function runRender(
         `Warning: slide ${missing.join(", ")} not found in the presentation`,
       );
     }
-  }
-
-  if (outputs.length === 0) {
-    throw new Error("No slides were rendered");
   }
 
   fs.mkdirSync(absOutputDir, { recursive: true });

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -48,10 +48,16 @@ import { PomEditor } from "@hirokisakabe/pom-editor";
     return response.json();
   }}
   onDownload={(nextXml) => downloadPptx(nextXml)}
+  onExportImages={(nextXml, { format, scope, currentSlide }) =>
+    exportImages(nextXml, {
+      format,
+      slides: scope === "current" ? [currentSlide] : undefined,
+    })
+  }
 />;
 ```
 
-Preview generation and file operations stay in the host application. `onDownload`, `onSave`, and `onCopyPreview` are optional, and their actions only appear when the corresponding callback is provided.
+Preview generation and file operations stay in the host application. `onDownload`, `onExportImages`, `onSave`, and `onCopyPreview` are optional, and their actions only appear when the corresponding callback is provided. Image export adds PNG / SVG and current / all slide controls to the toolbar.
 SVG preview results are sanitized before they are inserted into the document.
 
 ### Standalone AST editor
@@ -89,19 +95,20 @@ function App() {
 
 ### `<PomEditor />`
 
-| Prop            | Type                                                   | Description                                      |
-| --------------- | ------------------------------------------------------ | ------------------------------------------------ |
-| `xml`           | `string`                                               | Controlled pom XML source                        |
-| `onChange`      | `(xml: string) => void`                                | Receives XML and AST edits                       |
-| `onPreview`     | `(xml, { signal }) => Promise<{ svgs } \| { errors }>` | Host-provided preview adapter                    |
-| `onDownload`    | `(xml: string) => void \| Promise<void>`               | Optional Download action                         |
-| `onSave`        | `(xml: string) => void \| Promise<void>`               | Optional Save action                             |
-| `onCopyPreview` | `(svg: string) => void \| Promise<void>`               | Optional preview image copy action               |
-| `toolbarStart`  | `ReactNode`                                            | Host content before the standard toolbar actions |
-| `toolbarEnd`    | `ReactNode`                                            | Host content after the standard toolbar actions  |
-| `debounceMs`    | `number`                                               | Preview debounce delay (default: `500`)          |
-| `className`     | `string`                                               | Optional class name for the editor root          |
-| `style`         | `CSSProperties`                                        | Optional inline style for the editor root        |
+| Prop             | Type                                                                   | Description                                      |
+| ---------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| `xml`            | `string`                                                               | Controlled pom XML source                        |
+| `onChange`       | `(xml: string) => void`                                                | Receives XML and AST edits                       |
+| `onPreview`      | `(xml, { signal }) => Promise<{ svgs } \| { errors }>`                 | Host-provided preview adapter                    |
+| `onDownload`     | `(xml: string) => void \| Promise<void>`                               | Optional Download action                         |
+| `onExportImages` | `(xml, options: PomEditorImageExportOptions) => void \| Promise<void>` | Optional PNG / SVG image export action           |
+| `onSave`         | `(xml: string) => void \| Promise<void>`                               | Optional Save action                             |
+| `onCopyPreview`  | `(svg: string) => void \| Promise<void>`                               | Optional preview image copy action               |
+| `toolbarStart`   | `ReactNode`                                                            | Host content before the standard toolbar actions |
+| `toolbarEnd`     | `ReactNode`                                                            | Host content after the standard toolbar actions  |
+| `debounceMs`     | `number`                                                               | Preview debounce delay (default: `500`)          |
+| `className`      | `string`                                                               | Optional class name for the editor root          |
+| `style`          | `CSSProperties`                                                        | Optional inline style for the editor root        |
 
 ### `<PomAstEditor xml onChange />`
 

--- a/packages/pom-editor/docs/embedding-editor.md
+++ b/packages/pom-editor/docs/embedding-editor.md
@@ -28,20 +28,21 @@ import { PomEditor } from "@hirokisakabe/pom-editor";
     return response.json();
   }}
   onDownload={(nextXml) => downloadPptx(nextXml)}
+  onExportImages={(nextXml, options) => exportImages(nextXml, options)}
   onSave={(nextXml) => saveXml(nextXml)}
 />;
 ```
 
-`PomEditor` is controlled through `xml` and `onChange`. It includes XML / AST modes, debounced preview, diagnostics, Refresh, and slide pagination. `onDownload` and `onSave` add toolbar actions, while `onCopyPreview` adds a Copy button to the preview; each appears only when its callback is supplied. SVG previews are sanitized before insertion.
+`PomEditor` is controlled through `xml` and `onChange`. It includes XML / AST modes, debounced preview, diagnostics, Refresh, and slide pagination. `onDownload`, `onExportImages`, and `onSave` add toolbar actions, while `onCopyPreview` adds a Copy button to the preview; each appears only when its callback is supplied. `onExportImages` receives the selected PNG / SVG format, current / all scope, and current 1-based slide number. SVG previews are sanitized before insertion.
 
-| Prop                                    | Purpose                                                                     |
-| --------------------------------------- | --------------------------------------------------------------------------- |
-| `xml`, `onChange`                       | Controlled pom XML source and updates                                       |
-| `onPreview`                             | Host adapter returning `{ svgs }` or `{ errors }`; receives an abort signal |
-| `onDownload`, `onSave`, `onCopyPreview` | Optional host actions                                                       |
-| `toolbarStart`, `toolbarEnd`            | Host content around standard toolbar actions                                |
-| `debounceMs`                            | Preview delay; defaults to 500 ms                                           |
-| `className`, `style`                    | Root element styling                                                        |
+| Prop                                                      | Purpose                                                                     |
+| --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `xml`, `onChange`                                         | Controlled pom XML source and updates                                       |
+| `onPreview`                                               | Host adapter returning `{ svgs }` or `{ errors }`; receives an abort signal |
+| `onDownload`, `onExportImages`, `onSave`, `onCopyPreview` | Optional host actions                                                       |
+| `toolbarStart`, `toolbarEnd`                              | Host content around standard toolbar actions                                |
+| `debounceMs`                                              | Preview delay; defaults to 500 ms                                           |
+| `className`, `style`                                      | Root element styling                                                        |
 
 ## Embed only the AST editor
 

--- a/packages/pom-editor/src/PomEditor.test.tsx
+++ b/packages/pom-editor/src/PomEditor.test.tsx
@@ -187,6 +187,80 @@ describe("PomEditor", () => {
     expect(await screen.findByText("SVG exported")).toBeTruthy();
   });
 
+  it("現在表示しているページ番号をcurrent画像出力へ渡す", async () => {
+    const onExportImages = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PomEditor
+        xml="<Text />"
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          svgs: [
+            '<svg xmlns="http://www.w3.org/2000/svg"><text>First</text></svg>',
+            '<svg xmlns="http://www.w3.org/2000/svg"><text>Second</text></svg>',
+          ],
+        })}
+        onExportImages={onExportImages}
+        debounceMs={0}
+      />,
+    );
+    await screen.findByText("First");
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await screen.findByText("Second");
+
+    fireEvent.click(screen.getByRole("button", { name: "Export Images" }));
+
+    await waitFor(() =>
+      expect(onExportImages).toHaveBeenCalledWith("<Text />", {
+        format: "png",
+        scope: "current",
+        currentSlide: 2,
+      }),
+    );
+  });
+
+  it("XML変更後は新しいpreviewが成功するまで画像出力を無効化する", async () => {
+    const never = new Promise<never>(() => {});
+    const onPreview = vi
+      .fn()
+      .mockResolvedValueOnce({
+        svgs: [
+          '<svg xmlns="http://www.w3.org/2000/svg"><text>Old</text></svg>',
+        ],
+      })
+      .mockReturnValueOnce(never);
+    const { rerender } = render(
+      <PomEditor
+        xml="<Text>old</Text>"
+        onChange={vi.fn()}
+        onPreview={onPreview}
+        onExportImages={vi.fn()}
+        debounceMs={0}
+      />,
+    );
+    await screen.findByText("Old");
+    expect(
+      screen
+        .getByRole("button", { name: "Export Images" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+
+    rerender(
+      <PomEditor
+        xml="<Text>new</Text>"
+        onChange={vi.fn()}
+        onPreview={onPreview}
+        onExportImages={vi.fn()}
+        debounceMs={0}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Export Images" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
   it("出力処理中は多重実行を防ぎ、処理中表示とdiagnosticsを表示する", async () => {
     let rejectExport: ((reason: unknown) => void) | undefined;
     const onExportImages = vi.fn(

--- a/packages/pom-editor/src/PomEditor.test.tsx
+++ b/packages/pom-editor/src/PomEditor.test.tsx
@@ -261,6 +261,52 @@ describe("PomEditor", () => {
     ).toBe(true);
   });
 
+  it("出力中にXMLが変わった場合は古いaction結果を表示しない", async () => {
+    let resolveExport: (() => void) | undefined;
+    const onExportImages = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+    const onPreview = vi.fn().mockResolvedValue({
+      svgs: [
+        '<svg xmlns="http://www.w3.org/2000/svg"><text>Ready</text></svg>',
+      ],
+    });
+    const { rerender } = render(
+      <PomEditor
+        xml="<Text>old</Text>"
+        onChange={vi.fn()}
+        onPreview={onPreview}
+        onExportImages={onExportImages}
+        debounceMs={0}
+      />,
+    );
+    await screen.findByText("Ready");
+    fireEvent.click(screen.getByRole("button", { name: "Export Images" }));
+
+    rerender(
+      <PomEditor
+        xml="<Text>new</Text>"
+        onChange={vi.fn()}
+        onPreview={onPreview}
+        onExportImages={onExportImages}
+        debounceMs={0}
+      />,
+    );
+    resolveExport?.();
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Export Images" })
+          .hasAttribute("disabled"),
+      ).toBe(false),
+    );
+    expect(screen.queryByText("PNG exported")).toBeNull();
+  });
+
   it("出力処理中は多重実行を防ぎ、処理中表示とdiagnosticsを表示する", async () => {
     let rejectExport: ((reason: unknown) => void) | undefined;
     const onExportImages = vi.fn(

--- a/packages/pom-editor/src/PomEditor.test.tsx
+++ b/packages/pom-editor/src/PomEditor.test.tsx
@@ -151,6 +151,90 @@ describe("PomEditor", () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledWith("<Text />"));
   });
 
+  it("PNG / SVGと現在 / 全スライドを選んで画像出力callbackへ渡す", async () => {
+    const onExportImages = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PomEditor
+        xml="<Text />"
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          svgs: [
+            '<svg xmlns="http://www.w3.org/2000/svg"><text>Ready</text></svg>',
+          ],
+        })}
+        onExportImages={onExportImages}
+        debounceMs={0}
+      />,
+    );
+    await screen.findByText("Ready");
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Image format" }), {
+      target: { value: "svg" },
+    });
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Slides to export" }),
+      { target: { value: "all" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Export Images" }));
+
+    await waitFor(() =>
+      expect(onExportImages).toHaveBeenCalledWith("<Text />", {
+        format: "svg",
+        scope: "all",
+        currentSlide: 1,
+      }),
+    );
+    expect(await screen.findByText("SVG exported")).toBeTruthy();
+  });
+
+  it("出力処理中は多重実行を防ぎ、処理中表示とdiagnosticsを表示する", async () => {
+    let rejectExport: ((reason: unknown) => void) | undefined;
+    const onExportImages = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectExport = reject;
+        }),
+    );
+    const onDownload = vi.fn();
+    render(
+      <PomEditor
+        xml="<Text />"
+        onChange={vi.fn()}
+        onPreview={vi.fn().mockResolvedValue({
+          svgs: ['<svg xmlns="http://www.w3.org/2000/svg" />'],
+        })}
+        onDownload={onDownload}
+        onExportImages={onExportImages}
+        debounceMs={0}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Export Images" })
+          .hasAttribute("disabled"),
+      ).toBe(false),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Export Images" }));
+    expect(
+      screen
+        .getByRole("button", { name: "Rendering PNG..." })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Download" }).hasAttribute("disabled"),
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    expect(onDownload).not.toHaveBeenCalled();
+
+    rejectExport?.({
+      diagnostics: [{ type: "NODE_OVERLAP", message: "overlap" }],
+    });
+
+    expect(await screen.findByRole("button", { name: /overlap/ })).toBeTruthy();
+  });
+
   it("AST modeの行付きdiagnosticからXML modeへ切り替えて該当位置へ移動する", async () => {
     render(
       <PomEditor

--- a/packages/pom-editor/src/PomEditor.tsx
+++ b/packages/pom-editor/src/PomEditor.tsx
@@ -93,6 +93,8 @@ export function PomEditor({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const onPreviewRef = useRef(onPreview);
+  const currentXmlRef = useRef(xml);
+  currentXmlRef.current = xml;
 
   useEffect(() => {
     onPreviewRef.current = onPreview;
@@ -170,6 +172,7 @@ export function PomEditor({
     successMessage: string,
   ) {
     if (runningAction !== null) return;
+    const actionXml = xml;
     setRunningAction(action);
     setActionNotice(
       action === "download"
@@ -181,9 +184,12 @@ export function PomEditor({
     setDiagnostics(null);
     setDiagnosticNotice(null);
     try {
-      await callback(xml);
-      setActionNotice(successMessage);
+      await callback(actionXml);
+      if (currentXmlRef.current === actionXml) {
+        setActionNotice(successMessage);
+      }
     } catch (error) {
+      if (currentXmlRef.current !== actionXml) return;
       setActionNotice(null);
       const actionDiagnostics =
         typeof error === "object" &&

--- a/packages/pom-editor/src/PomEditor.tsx
+++ b/packages/pom-editor/src/PomEditor.tsx
@@ -75,6 +75,7 @@ export function PomEditor({
 }: PomEditorProps) {
   const [mode, setMode] = useState<PomEditorMode>("xml");
   const [svgs, setSvgs] = useState<string[]>([]);
+  const [previewedXml, setPreviewedXml] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [imageFormat, setImageFormat] = useState<"png" | "svg">("png");
@@ -97,11 +98,16 @@ export function PomEditor({
     onPreviewRef.current = onPreview;
   }, [onPreview]);
 
+  useEffect(() => {
+    setActionNotice(null);
+  }, [xml]);
+
   const executePreview = useCallback(async () => {
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
     setIsLoading(true);
+    setPreviewedXml(null);
     setDiagnostics(null);
     setDiagnosticNotice(null);
 
@@ -115,6 +121,7 @@ export function PomEditor({
         return;
       }
       setSvgs(result.svgs);
+      setPreviewedXml(xml);
       setCurrentPage(1);
     } catch (error) {
       if (controller.signal.aborted) return;
@@ -334,9 +341,10 @@ export function PomEditor({
               <select
                 aria-label="Image format"
                 value={imageFormat}
-                onChange={(event) =>
-                  setImageFormat(event.target.value as "png" | "svg")
-                }
+                onChange={(event) => {
+                  setImageFormat(event.target.value as "png" | "svg");
+                  setActionNotice(null);
+                }}
                 disabled={runningAction !== null}
               >
                 <option value="png">PNG</option>
@@ -348,9 +356,10 @@ export function PomEditor({
               <select
                 aria-label="Slides to export"
                 value={imageScope}
-                onChange={(event) =>
-                  setImageScope(event.target.value as "current" | "all")
-                }
+                onChange={(event) => {
+                  setImageScope(event.target.value as "current" | "all");
+                  setActionNotice(null);
+                }}
                 disabled={runningAction !== null}
               >
                 <option value="current">Current</option>
@@ -372,7 +381,12 @@ export function PomEditor({
                   `${imageFormat.toUpperCase()} exported`,
                 )
               }
-              disabled={runningAction !== null || svgs.length === 0}
+              disabled={
+                runningAction !== null ||
+                isLoading ||
+                svgs.length === 0 ||
+                previewedXml !== xml
+              }
             >
               {runningAction === "images"
                 ? `Rendering ${imageFormat.toUpperCase()}...`

--- a/packages/pom-editor/src/PomEditor.tsx
+++ b/packages/pom-editor/src/PomEditor.tsx
@@ -22,6 +22,12 @@ export type PomEditorPreviewResult =
   | { svgs: string[]; errors?: never }
   | { errors: PomEditorDiagnostic[]; svgs?: never };
 
+export interface PomEditorImageExportOptions {
+  format: "png" | "svg";
+  scope: "current" | "all";
+  currentSlide: number;
+}
+
 export interface PomEditorProps {
   xml: string;
   onChange: (xml: string) => void;
@@ -30,6 +36,10 @@ export interface PomEditorProps {
     options: { signal: AbortSignal },
   ) => Promise<PomEditorPreviewResult>;
   onDownload?: (xml: string) => void | Promise<void>;
+  onExportImages?: (
+    xml: string,
+    options: PomEditorImageExportOptions,
+  ) => void | Promise<void>;
   onSave?: (xml: string) => void | Promise<void>;
   onCopyPreview?: (svg: string) => void | Promise<void>;
   toolbarStart?: ReactNode;
@@ -54,6 +64,7 @@ export function PomEditor({
   onChange,
   onPreview,
   onDownload,
+  onExportImages,
   onSave,
   onCopyPreview,
   toolbarStart,
@@ -66,9 +77,12 @@ export function PomEditor({
   const [svgs, setSvgs] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
+  const [imageFormat, setImageFormat] = useState<"png" | "svg">("png");
+  const [imageScope, setImageScope] = useState<"current" | "all">("current");
   const [runningAction, setRunningAction] = useState<
-    "download" | "save" | null
+    "download" | "images" | "save" | null
   >(null);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
   const [diagnostics, setDiagnostics] = useState<PomEditorDiagnostic[] | null>(
     null,
   );
@@ -144,22 +158,42 @@ export function PomEditor({
   }
 
   async function runAction(
-    action: "download" | "save",
+    action: "download" | "images" | "save",
     callback: (xml: string) => void | Promise<void>,
+    successMessage: string,
   ) {
     if (runningAction !== null) return;
     setRunningAction(action);
+    setActionNotice(
+      action === "download"
+        ? "Generating PPTX..."
+        : action === "images"
+          ? `Rendering ${imageFormat.toUpperCase()}...`
+          : "Saving...",
+    );
     setDiagnostics(null);
     setDiagnosticNotice(null);
     try {
       await callback(xml);
+      setActionNotice(successMessage);
     } catch (error) {
-      setDiagnostics([
-        {
-          type: "unknown",
-          message: error instanceof Error ? error.message : `${action} failed`,
-        },
-      ]);
+      setActionNotice(null);
+      const actionDiagnostics =
+        typeof error === "object" &&
+        error !== null &&
+        "diagnostics" in error &&
+        Array.isArray(error.diagnostics)
+          ? (error.diagnostics as PomEditorDiagnostic[])
+          : null;
+      setDiagnostics(
+        actionDiagnostics ?? [
+          {
+            type: "unknown",
+            message:
+              error instanceof Error ? error.message : `${action} failed`,
+          },
+        ],
+      );
     } finally {
       setRunningAction(null);
     }
@@ -234,6 +268,7 @@ export function PomEditor({
           gap: 8,
           padding: "6px 16px",
           borderBottom: "1px solid #e5e7eb",
+          flexWrap: "wrap",
         }}
       >
         {toolbarStart}
@@ -284,21 +319,87 @@ export function PomEditor({
           <button
             type="button"
             style={toolbarButtonStyle}
-            onClick={() => void runAction("download", onDownload)}
+            onClick={() =>
+              void runAction("download", onDownload, "PPTX downloaded")
+            }
             disabled={runningAction !== null}
           >
-            Download
+            {runningAction === "download" ? "Generating PPTX..." : "Download"}
           </button>
+        )}
+        {onExportImages && (
+          <>
+            <label style={{ color: "#4b5563", fontSize: 12 }}>
+              <span style={{ marginRight: 4 }}>Format</span>
+              <select
+                aria-label="Image format"
+                value={imageFormat}
+                onChange={(event) =>
+                  setImageFormat(event.target.value as "png" | "svg")
+                }
+                disabled={runningAction !== null}
+              >
+                <option value="png">PNG</option>
+                <option value="svg">SVG</option>
+              </select>
+            </label>
+            <label style={{ color: "#4b5563", fontSize: 12 }}>
+              <span style={{ marginRight: 4 }}>Slides</span>
+              <select
+                aria-label="Slides to export"
+                value={imageScope}
+                onChange={(event) =>
+                  setImageScope(event.target.value as "current" | "all")
+                }
+                disabled={runningAction !== null}
+              >
+                <option value="current">Current</option>
+                <option value="all">All</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              style={toolbarButtonStyle}
+              onClick={() =>
+                void runAction(
+                  "images",
+                  (value) =>
+                    onExportImages(value, {
+                      format: imageFormat,
+                      scope: imageScope,
+                      currentSlide: currentPage,
+                    }),
+                  `${imageFormat.toUpperCase()} exported`,
+                )
+              }
+              disabled={runningAction !== null || svgs.length === 0}
+            >
+              {runningAction === "images"
+                ? `Rendering ${imageFormat.toUpperCase()}...`
+                : "Export Images"}
+            </button>
+          </>
         )}
         {onSave && (
           <button
             type="button"
             style={toolbarButtonStyle}
-            onClick={() => void runAction("save", onSave)}
+            onClick={() => void runAction("save", onSave, "Saved")}
             disabled={runningAction !== null}
           >
-            Save
+            {runningAction === "save" ? "Saving..." : "Save"}
           </button>
+        )}
+        {actionNotice && (
+          <span
+            role="status"
+            style={{
+              color: runningAction === null ? "#047857" : "#4b5563",
+              fontSize: 12,
+            }}
+          >
+            {actionNotice}
+          </span>
         )}
         {toolbarEnd && (
           <div

--- a/packages/pom-editor/src/PomEditor.tsx
+++ b/packages/pom-editor/src/PomEditor.tsx
@@ -2,7 +2,13 @@
 
 import { EditorView } from "@codemirror/view";
 import type { CSSProperties, ReactNode } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { PomAstEditor } from "./PomAstEditor.tsx";
 import { SlidePreview } from "./SlidePreview.tsx";
@@ -94,7 +100,10 @@ export function PomEditor({
   const abortControllerRef = useRef<AbortController | null>(null);
   const onPreviewRef = useRef(onPreview);
   const currentXmlRef = useRef(xml);
-  currentXmlRef.current = xml;
+
+  useLayoutEffect(() => {
+    currentXmlRef.current = xml;
+  }, [xml]);
 
   useEffect(() => {
     onPreviewRef.current = onPreview;

--- a/packages/pom-editor/src/index.ts
+++ b/packages/pom-editor/src/index.ts
@@ -3,6 +3,7 @@ export type { PomAstEditorProps } from "./PomAstEditor.tsx";
 export { PomEditor } from "./PomEditor.tsx";
 export type {
   PomEditorDiagnostic,
+  PomEditorImageExportOptions,
   PomEditorMode,
   PomEditorPreviewResult,
   PomEditorProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       pptx-glimpse:
         specifier: ^3.2.8
         version: 3.2.8


### PR DESCRIPTION
close #979

## 概要

- `pom preview` の編集中XMLからPPTXを生成してダウンロードできるようにしました
- PNG / SVGと現在 / 全スライドを選べる画像出力操作を追加し、全スライドはZIPでまとめてダウンロードします
- build / renderの処理中・成功・失敗・diagnosticsを`PomEditor`内に表示し、多重実行と古いXMLへの結果反映を防ぎます
- `.pom.xml` / `.pom.md`の両入力で、保存前の編集内容を出力APIへ渡します

## 影響範囲

- `packages/pom-cli`: preview server API、browser client、CLI render共通処理、README
- `packages/pom-editor`: 画像出力callback・toolbar UI・状態/diagnostics表示
- `.changeset`: `@hirokisakabe/pom-cli` / `@hirokisakabe/pom-editor` minor

## 検証

- `pnpm --filter @hirokisakabe/pom-editor run fmt:check`
- `pnpm --filter @hirokisakabe/pom-editor run lint`
- `pnpm --filter @hirokisakabe/pom-editor run typecheck`
- `pnpm --filter @hirokisakabe/pom-editor run test:run` (38 tests)
- `pnpm --filter @hirokisakabe/pom-editor run knip`
- `pnpm --filter @hirokisakabe/pom-editor run build`
- `pnpm --filter @hirokisakabe/pom-cli run fmt:check`
- `pnpm --filter @hirokisakabe/pom-cli run lint`
- `pnpm --filter @hirokisakabe/pom-cli run typecheck`
- `pnpm --filter @hirokisakabe/pom-cli run test:run` (66 tests)
- `pnpm --filter @hirokisakabe/pom-cli run knip`
- `pnpm --filter @hirokisakabe/pom-cli run build`
- 実ブラウザで未保存XMLからPPTXをダウンロードし、生成物内の未保存テキストとSVG全スライド出力を確認
