### PR TITLE
PomAstEditor の standalone 公開 API を廃止して PomEditor に一本化する

### DIFF
--- a/.changeset/quiet-cats-edit.md
+++ b/.changeset/quiet-cats-edit.md
@@ -1,0 +1,7 @@
+---
+"@hirokisakabe/pom-editor": major
+---
+
+公開コンポーネントを `PomEditor` に一本化し、package root から `PomAstEditor` と `PomAstEditorProps` の export を削除します。
+
+AST 編集を利用する場合は、XML / AST モード切り替え、preview、diagnostics、host actions をまとめた `PomEditor` へ移行してください。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Root: `pnpm --filter @hirokisakabe/pom run <script>`
 packages/
 ├── pom/              # Core library — src/ (parseXml/ → calcYogaLayout/ → toPositioned/ → renderPptx/), vrt/, preview/, docs/, main.ts
 ├── pom-cli/          # CLI tool — preview and build presentations
-├── pom-editor/       # React component for visual DnD AST editing — PomAstEditor
+├── pom-editor/       # React component for XML / AST editing — PomEditor
 ├── pom-jsx/          # JSX/TSX authoring package
 ├── pom-md/           # Markdown → pom XML converter
 ├── pom-vscode/       # VS Code extension for live preview
@@ -76,7 +76,6 @@ Existing PPTX reading and structural round-trip work should treat `@pptx-glimpse
 ### Public API (`@hirokisakabe/pom-editor`)
 
 - `PomEditor` — XML / AST editing、preview、diagnostics、共通toolbarを持つReactコンポーネント。preview生成とoptionalなDownload / Save / PNG・SVG画像出力処理はhost callbackへ委譲する。画像出力は `PomEditorImageExportOptions` で形式、現在/全スライド、現在のスライド番号を受け取る。
-- `PomAstEditor` — React コンポーネント。`xml` と `onChange` props を受け取り、AST ツリーを表示して DnD でノードを並び替えると更新後の XML を返す。
 
 ### Key Internal Types
 

--- a/packages/pom-editor/AGENTS.md
+++ b/packages/pom-editor/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — packages/pom-editor
 
-Reusable browser editor components for pom. Exports `PomEditor` for XML / AST editing, preview, diagnostics, and host-provided actions, plus the standalone `PomAstEditor` DnD tree component. リポジトリ共通ルールはルート `AGENTS.md` を参照。
+Reusable browser editor components for pom. Exports `PomEditor` for XML / AST editing, preview, diagnostics, and host-provided actions. The AST tree remains an internal component. リポジトリ共通ルールはルート `AGENTS.md` を参照。
 
 ```bash
 pnpm --filter @hirokisakabe/pom-editor run build       # TypeScript compilation

--- a/packages/pom-editor/README.md
+++ b/packages/pom-editor/README.md
@@ -60,37 +60,6 @@ import { PomEditor } from "@hirokisakabe/pom-editor";
 Preview generation and file operations stay in the host application. `onDownload`, `onExportImages`, `onSave`, and `onCopyPreview` are optional, and their actions only appear when the corresponding callback is provided. Image export adds PNG / SVG and current / all slide controls to the toolbar.
 SVG preview results are sanitized before they are inserted into the document.
 
-### Standalone AST editor
-
-```tsx
-import { PomAstEditor } from "@hirokisakabe/pom-editor";
-import { useState } from "react";
-
-const initialXml = `
-<Slide>
-  <VStack gap="16" padding="24">
-    <Text fontSize="32" bold="true">Title</Text>
-    <Text>Body text</Text>
-  </VStack>
-</Slide>
-`;
-
-function App() {
-  const [xml, setXml] = useState(initialXml);
-
-  return (
-    <div style={{ display: "flex", height: "100vh" }}>
-      <div style={{ width: 300, borderRight: "1px solid #e5e7eb" }}>
-        <PomAstEditor xml={xml} onChange={setXml} />
-      </div>
-      <div style={{ flex: 1, padding: 24 }}>
-        <pre>{xml}</pre>
-      </div>
-    </div>
-  );
-}
-```
-
 ## API
 
 ### `<PomEditor />`
@@ -109,21 +78,6 @@ function App() {
 | `debounceMs`     | `number`                                                               | Preview debounce delay (default: `500`)          |
 | `className`      | `string`                                                               | Optional class name for the editor root          |
 | `style`          | `CSSProperties`                                                        | Optional inline style for the editor root        |
-
-### `<PomAstEditor xml onChange />`
-
-| Prop               | Type                    | Description                                                        |
-| ------------------ | ----------------------- | ------------------------------------------------------------------ |
-| `xml`              | `string`                | pom XML string (one or more `<Slide>` elements)                    |
-| `onChange`         | `(xml: string) => void` | Called with updated XML after each drag-and-drop reorder           |
-| `onRequestXmlMode` | `() => void`            | Optional callback shown after parse errors to return to XML source |
-
-Renders a tree of nodes from the parsed XML. Each row supports two drop targets:
-
-- A thin gap between rows — drop here to insert as a **sibling** at that position (works across parents, so a node can be moved to any container or pulled up to the root).
-- The container row body itself — drop here to nest the dragged node as the **last child of that container** (`VStack` / `HStack` / `Layer` only). Drops on non-container bodies are ignored.
-
-Top-level slides can be reordered via the root-level gaps. Cycle-forming drops (e.g. moving a container into its own descendant) are silently rejected.
 
 ## License
 

--- a/packages/pom-editor/docs/embedding-editor.md
+++ b/packages/pom-editor/docs/embedding-editor.md
@@ -1,6 +1,6 @@
 # Embedding the Editor
 
-`@hirokisakabe/pom-editor` provides React components for embedding pom XML / AST editing, preview, diagnostics, and host actions in an application. It edits the same pom XML model used by the other authoring surfaces; preview generation and persistence remain under host control.
+`@hirokisakabe/pom-editor` provides a React component for embedding pom XML / AST editing, preview, diagnostics, and host actions in an application. It edits the same pom XML model used by the other authoring surfaces; preview generation and persistence remain under host control.
 
 ## Install
 
@@ -43,19 +43,5 @@ import { PomEditor } from "@hirokisakabe/pom-editor";
 | `toolbarStart`, `toolbarEnd`                              | Host content around standard toolbar actions                                |
 | `debounceMs`                                              | Preview delay; defaults to 500 ms                                           |
 | `className`, `style`                                      | Root element styling                                                        |
-
-## Embed only the AST editor
-
-```tsx
-import { PomAstEditor } from "@hirokisakabe/pom-editor";
-import { useState } from "react";
-
-function App() {
-  const [xml, setXml] = useState(`<Slide><Text>Hello</Text></Slide>`);
-  return <PomAstEditor xml={xml} onChange={setXml} />;
-}
-```
-
-`PomAstEditor` shows the parsed tree and supports drag-and-drop reordering and nesting for `VStack`, `HStack`, and `Layer`. It returns serialized pom XML after every accepted move.
 
 For server-side preview generation, pass the XML to [`buildPptx()`](/pom-library) and convert the result to SVG, or expose an application-specific endpoint like the example above. See [pom XML](/pom-xml) for the shared model.

--- a/packages/pom-editor/src/index.ts
+++ b/packages/pom-editor/src/index.ts
@@ -1,5 +1,3 @@
-export { PomAstEditor } from "./PomAstEditor.tsx";
-export type { PomAstEditorProps } from "./PomAstEditor.tsx";
 export { PomEditor } from "./PomEditor.tsx";
 export type {
   PomEditorDiagnostic,


### PR DESCRIPTION
close #995

## 概要

`@hirokisakabe/pom-editor` の package root から `PomAstEditor` と `PomAstEditorProps` の export を削除し、公開コンポーネントを `PomEditor` に一本化します。

AST tree の内部コンポーネント分割と既存の DnD 実装は維持しています。

## 変更内容

- package root の standalone AST editor export を削除
- README、埋め込みガイド、ルートおよび package の AGENTS.md を `PomEditor` のみの公開 API 説明へ更新
- 破壊的変更と移行先を記載した major changeset を追加

## 影響範囲

- `packages/pom-editor`
- ルート `AGENTS.md` の package / public API 説明
- `.changeset`

他パッケージの実装 API と AST editor の UI / DnD 挙動には変更ありません。

## ローカル検証

- `pnpm --filter @hirokisakabe/pom run build`
- `pnpm --filter @hirokisakabe/pom-editor run fmt`
- `pnpm --filter @hirokisakabe/pom-editor run build`
- `pnpm --filter @hirokisakabe/pom-editor run lint`
- `pnpm --filter @hirokisakabe/pom-editor run typecheck`
- `pnpm --filter @hirokisakabe/pom-editor run test:run`（5 files / 38 tests passed）
- `pnpm exec changeset status`