### PR TITLE
feat: AST editor を内容・レイアウト中心の編集体験へ刷新する

### DIFF
--- a/.changeset/fresh-apes-edit.md
+++ b/.changeset/fresh-apes-edit.md
@@ -1,0 +1,5 @@
+---
+"@hirokisakabe/pom-editor": minor
+---
+
+AST editor の Text を本文中心のインライン編集表示へ変更し、VStack、HStack、Layer を方向と構造属性が分かるレイアウトコンテナとして表示します。

--- a/packages/pom-editor/src/AstTree.test.tsx
+++ b/packages/pom-editor/src/AstTree.test.tsx
@@ -460,6 +460,31 @@ describe("AstTree content editing", () => {
     expect(screen.getByRole("button", { name: "Text: A" })).toBeTruthy();
   });
 
+  it("編集中に外部から本文が変わった場合は stale draft を破棄する", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <AstTree ast={makeAst()} onChange={onChange} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Text: A" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Text を編集" }), {
+      target: { value: "Stale draft" },
+    });
+
+    const updatedAst = makeAst();
+    updatedAst[0].children![0] = {
+      ...updatedAst[0].children![0],
+      node: { type: "text", text: "External update" },
+    };
+    rerender(<AstTree ast={updatedAst} onChange={onChange} />);
+
+    expect(screen.queryByRole("textbox", { name: "Text を編集" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Text: External update" }),
+    ).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("空 Text にクリック可能な placeholder を表示する", () => {
     const emptyText = {
       id: "empty",

--- a/packages/pom-editor/src/AstTree.test.tsx
+++ b/packages/pom-editor/src/AstTree.test.tsx
@@ -1,4 +1,10 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 interface DragSubject {
@@ -18,6 +24,7 @@ let capturedHandlers: {
   onDragCancel?: () => void;
 } = {};
 let capturedAutoScroll: boolean | undefined;
+const dragPointerDown = vi.fn();
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({
@@ -47,7 +54,7 @@ vi.mock("@dnd-kit/core", () => ({
   pointerWithin: () => [],
   useDraggable: () => ({
     attributes: {},
-    listeners: {},
+    listeners: { onPointerDown: dragPointerDown },
     setNodeRef: () => {},
     transform: null,
     isDragging: false,
@@ -66,6 +73,7 @@ afterEach(() => {
   cleanup();
   capturedHandlers = {};
   capturedAutoScroll = undefined;
+  dragPointerDown.mockClear();
 });
 
 // Two slides, each is a VStack with text children.
@@ -286,13 +294,9 @@ describe("AstTree DnD — visual feedback distinguishes inside vs between", () =
       capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
     });
 
-    // Both VStack rows are present; the one we dropped onto gets the inside highlight.
-    const insideHighlighted = screen
-      .getAllByText("VStack")
-      .map((el) => el.parentElement)
-      .find((el) => el?.style.backgroundColor === "rgb(219, 234, 254)");
-    expect(insideHighlighted).toBeTruthy();
-    expect(insideHighlighted!.style.outline).toBe("1px solid #2563eb");
+    const insideHighlighted = screen.getByTestId("layout-container:3");
+    expect(insideHighlighted.style.backgroundColor).toBe("rgb(219, 234, 254)");
+    expect(insideHighlighted.style.border).toBe("1px solid rgb(37, 99, 235)");
   });
 
   it.each(["gap:0:0", "gap:0:2"])(
@@ -318,10 +322,8 @@ describe("AstTree DnD — visual feedback distinguishes inside vs between", () =
     act(() => {
       capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
     });
-    const insideBg = screen
-      .getAllByText("VStack")
-      .map((el) => el.parentElement)
-      .find((el) => el?.style.backgroundColor)?.style.backgroundColor;
+    const insideBg =
+      screen.getByTestId("layout-container:3").style.backgroundColor;
 
     act(() => {
       capturedHandlers.onDragOver?.(dragTo("1", "gap:0:2"));
@@ -344,8 +346,9 @@ describe("AstTree DnD — drag overlay and scrolling", () => {
       capturedHandlers.onDragStart?.({ active: { id: "1" } });
     });
 
-    expect(screen.getByTestId("ast-drag-overlay").textContent).toContain(
-      'Text: "A"',
+    expect(screen.getByTestId("ast-drag-overlay").textContent).toContain("A");
+    expect(screen.getByTestId("ast-drag-overlay").textContent).not.toContain(
+      "Text:",
     );
   });
 
@@ -364,21 +367,17 @@ describe("AstTree DnD — drag lifecycle clears state", () => {
     act(() => {
       capturedHandlers.onDragOver?.(dragTo("1", "inside:3"));
     });
-    expect(
-      screen
-        .getAllByText("VStack")
-        .some((el) => el.parentElement?.style.backgroundColor),
-    ).toBe(true);
+    expect(screen.getByTestId("layout-container:3").style.backgroundColor).toBe(
+      "rgb(219, 234, 254)",
+    );
 
     act(() => {
       capturedHandlers.onDragCancel?.();
     });
 
-    expect(
-      screen
-        .getAllByText("VStack")
-        .every((el) => !el.parentElement?.style.backgroundColor),
-    ).toBe(true);
+    expect(screen.getByTestId("layout-container:3").style.backgroundColor).toBe(
+      "rgb(248, 250, 252)",
+    );
   });
 
   it("drag end 後にハイライトがクリアされる", () => {
@@ -392,11 +391,9 @@ describe("AstTree DnD — drag lifecycle clears state", () => {
       capturedHandlers.onDragEnd?.(dragTo("1", "inside:3"));
     });
 
-    expect(
-      screen
-        .getAllByText("VStack")
-        .every((el) => !el.parentElement?.style.backgroundColor),
-    ).toBe(true);
+    expect(screen.getByTestId("layout-container:3").style.backgroundColor).toBe(
+      "rgb(248, 250, 252)",
+    );
   });
 
   it("over が null の drag end では onChange が呼ばれない", () => {
@@ -406,5 +403,155 @@ describe("AstTree DnD — drag lifecycle clears state", () => {
     capturedHandlers.onDragEnd?.(dragTo("1", null));
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("AstTree content editing", () => {
+  it("Text prefix や引用符を付けず本文を主表示にする", () => {
+    render(<AstTree ast={makeAst()} onChange={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Text: A" }).textContent).toBe(
+      "A",
+    );
+    expect(screen.queryByText('Text: "A"')).toBeNull();
+  });
+
+  it("本文クリック後、Enter で編集内容を確定する", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Text: A" }));
+    const input = screen.getByRole("textbox", { name: "Text を編集" });
+    fireEvent.change(input, { target: { value: "Edited title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const nodes = onChange.mock.calls[0][0] as Array<
+      POMNode & { children: Array<POMNode & { text?: string }> }
+    >;
+    expect(nodes[0].children[0].text).toBe("Edited title");
+  });
+
+  it("フォーカスアウトで編集内容を確定する", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Text: B" }));
+    const input = screen.getByRole("textbox", { name: "Text を編集" });
+    fireEvent.change(input, { target: { value: "Edited body" } });
+    fireEvent.blur(input);
+
+    const nodes = onChange.mock.calls[0][0] as Array<
+      POMNode & { children: Array<POMNode & { text?: string }> }
+    >;
+    expect(nodes[0].children[1].text).toBe("Edited body");
+  });
+
+  it("Escape で編集前の本文へ戻し、変更を通知しない", () => {
+    const onChange = vi.fn();
+    render(<AstTree ast={makeAst()} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Text: A" }));
+    const input = screen.getByRole("textbox", { name: "Text を編集" });
+    fireEvent.change(input, { target: { value: "Discard me" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Text: A" })).toBeTruthy();
+  });
+
+  it("空 Text にクリック可能な placeholder を表示する", () => {
+    const emptyText = {
+      id: "empty",
+      node: { type: "text", text: "" } as POMNode,
+      parentId: "root",
+    };
+    render(<AstTree ast={[emptyText]} onChange={vi.fn()} />);
+
+    const placeholder = screen.getByRole("button", { name: "Empty Text" });
+    expect(placeholder.textContent).toBe("クリックしてテキストを入力");
+    fireEvent.click(placeholder);
+    expect(screen.getByRole("textbox", { name: "Text を編集" })).toBeTruthy();
+  });
+
+  it("本文の操作では drag listener が動かず、専用 handle から開始できる", () => {
+    render(<AstTree ast={makeAst()} onChange={vi.fn()} />);
+
+    const text = screen.getByRole("button", { name: "Text: A" });
+    fireEvent.pointerDown(text);
+    expect(dragPointerDown).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(screen.getByTestId("drag-handle:1"));
+    expect(dragPointerDown).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AstTree layout containers", () => {
+  function makeLayoutAst(): AstNode[] {
+    const text = {
+      id: "text",
+      node: { type: "text", text: "Nested content" } as POMNode,
+      parentId: "layer",
+    };
+    const layer = {
+      id: "layer",
+      node: { type: "layer", children: [text.node] } as POMNode,
+      parentId: "hstack",
+      children: [text],
+    };
+    const hstack = {
+      id: "hstack",
+      node: {
+        type: "hstack",
+        gap: 12,
+        children: [layer.node],
+      } as POMNode,
+      parentId: "vstack",
+      children: [layer],
+    };
+    return [
+      {
+        id: "vstack",
+        node: {
+          type: "vstack",
+          padding: { top: 8, right: 16, bottom: 8, left: 16 },
+          children: [hstack.node],
+        },
+        parentId: "root",
+        children: [hstack],
+      },
+    ];
+  }
+
+  it("VStack / HStack / Layer が子要素を内包する frame として表示される", () => {
+    render(<AstTree ast={makeLayoutAst()} onChange={vi.fn()} />);
+
+    expect(
+      screen
+        .getByTestId("layout-container:vstack")
+        .contains(screen.getByTestId("layout-container:hstack")),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("layout-container:hstack")
+        .contains(screen.getByTestId("layout-container:layer")),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("layout-container:layer")
+        .contains(screen.getByRole("button", { name: "Text: Nested content" })),
+    ).toBe(true);
+  });
+
+  it("layout ごとに異なる方向表現と secondary information を表示する", () => {
+    render(<AstTree ast={makeLayoutAst()} onChange={vi.fn()} />);
+
+    expect(screen.getByLabelText("Vertical layout").textContent).toBe("↓");
+    expect(screen.getByLabelText("Horizontal layout").textContent).toBe("→");
+    expect(screen.getByLabelText("Overlapping layout").textContent).toBe("▱");
+    expect(screen.getByText("gap 12")).toBeTruthy();
+    expect(
+      screen.getByText('padding {"top":8,"right":16,"bottom":8,"left":16}'),
+    ).toBeTruthy();
   });
 });

--- a/packages/pom-editor/src/AstTree.tsx
+++ b/packages/pom-editor/src/AstTree.tsx
@@ -421,7 +421,11 @@ function Row({ astNode, onTextChange }: RowProps) {
         isDragging={isDragging}
       />
       {astNode.node.type === "text" ? (
-        <TextContent astNode={astNode} onTextChange={onTextChange} />
+        <TextContent
+          key={`${astNode.id}:${astNode.node.text}`}
+          astNode={astNode}
+          onTextChange={onTextChange}
+        />
       ) : (
         <span
           style={{
@@ -478,9 +482,14 @@ function findAstNode(nodes: AstNode[], id: string): AstNode | null {
 function replaceText(nodes: AstNode[], id: string, text: string): AstNode[] {
   return nodes.map((node) => {
     if (node.id === id) {
+      const updatedNode = {
+        ...node.node,
+        text,
+      } as POMNode & { runs?: unknown };
+      delete updatedNode.runs;
       return {
         ...node,
-        node: { ...node.node, text } as POMNode,
+        node: updatedNode,
       };
     }
     if (node.children) {

--- a/packages/pom-editor/src/AstTree.tsx
+++ b/packages/pom-editor/src/AstTree.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useRef, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -46,10 +46,8 @@ const NODE_LABELS: Record<string, string> = {
 function nodeLabel(node: POMNode): string {
   const base = NODE_LABELS[node.type] ?? node.type;
   const record = node as Record<string, unknown>;
-  if (node.type === "text" && typeof record.text === "string") {
-    const preview = record.text.slice(0, 20);
-    return `${base}: "${preview}${record.text.length > 20 ? "…" : ""}"`;
-  }
+  if (node.type === "text" && typeof record.text === "string")
+    return record.text || "Empty text";
   if (node.type === "image" && typeof record.src === "string") {
     return `${base}: ${record.src.split("/").pop() ?? record.src}`;
   }
@@ -96,10 +94,9 @@ function parseInsideId(id: string): string | null {
 interface GapStripProps {
   parentId: string;
   index: number;
-  depth: number;
 }
 
-function GapStrip({ parentId, index, depth }: GapStripProps) {
+function GapStrip({ parentId, index }: GapStripProps) {
   const id = gapId(parentId, index);
   const { setNodeRef } = useDroppable({ id });
   const overId = useContext(OverIdContext);
@@ -116,7 +113,6 @@ function GapStrip({ parentId, index, depth }: GapStripProps) {
         height: "16px",
         marginTop: "-7px",
         marginBottom: "-7px",
-        marginLeft: `${depth * 16}px`,
         position: "relative",
         zIndex: isDragging ? 1 : undefined,
         pointerEvents: isDragging ? "auto" : "none",
@@ -144,10 +140,155 @@ function GapStrip({ parentId, index, depth }: GapStripProps) {
 
 interface RowProps {
   astNode: AstNode;
-  depth: number;
+  onTextChange: (id: string, text: string) => void;
 }
 
-function Row({ astNode, depth }: RowProps) {
+const LAYOUT_PRESENTATION = {
+  vstack: { icon: "↓", label: "VStack", description: "Vertical layout" },
+  hstack: { icon: "→", label: "HStack", description: "Horizontal layout" },
+  layer: { icon: "▱", label: "Layer", description: "Overlapping layout" },
+} as const;
+
+function DragHandle({
+  drag,
+  id,
+  label,
+  isDragging,
+}: {
+  drag: ReturnType<typeof useDraggable>;
+  id: string;
+  label: string;
+  isDragging: boolean;
+}) {
+  return (
+    <span
+      {...drag.listeners}
+      {...drag.attributes}
+      data-testid={`drag-handle:${id}`}
+      style={{
+        cursor: isDragging ? "grabbing" : "grab",
+        color: "#9ca3af",
+        fontSize: "12px",
+        lineHeight: 1,
+        flexShrink: 0,
+        touchAction: "none",
+        userSelect: "none",
+      }}
+      title="ドラッグして並び替え"
+      aria-label={`${label} をドラッグ`}
+    >
+      ⠿
+    </span>
+  );
+}
+
+function TextContent({
+  astNode,
+  onTextChange,
+}: {
+  astNode: AstNode;
+  onTextChange: (id: string, text: string) => void;
+}) {
+  const record = astNode.node as Record<string, unknown>;
+  const text = typeof record.text === "string" ? record.text : "";
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(text);
+  const cancelBlurRef = useRef(false);
+
+  function startEditing() {
+    setDraft(text);
+    cancelBlurRef.current = false;
+    setIsEditing(true);
+  }
+
+  function commit() {
+    if (cancelBlurRef.current) {
+      cancelBlurRef.current = false;
+      return;
+    }
+    setIsEditing(false);
+    if (draft !== text) onTextChange(astNode.id, draft);
+  }
+
+  if (isEditing) {
+    return (
+      <input
+        autoFocus
+        aria-label="Text を編集"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            cancelBlurRef.current = true;
+            setDraft(text);
+            setIsEditing(false);
+          }
+        }}
+        style={{
+          minWidth: 0,
+          width: "100%",
+          border: "1px solid #60a5fa",
+          borderRadius: "4px",
+          padding: "3px 6px",
+          background: "#ffffff",
+          color: "#111827",
+          font: "inherit",
+          outline: "2px solid #dbeafe",
+        }}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      aria-label={text ? `Text: ${text}` : "Empty Text"}
+      title="Text — クリックして編集"
+      style={{
+        minWidth: 0,
+        flex: 1,
+        border: 0,
+        padding: "3px 0",
+        background: "transparent",
+        color: text ? "#1f2937" : "#9ca3af",
+        cursor: "text",
+        font: "inherit",
+        fontStyle: text ? "normal" : "italic",
+        textAlign: "left",
+        whiteSpace: "pre-wrap",
+        overflowWrap: "anywhere",
+        userSelect: "text",
+      }}
+    >
+      {text || "クリックしてテキストを入力"}
+    </button>
+  );
+}
+
+function secondaryInformation(node: POMNode): string[] {
+  const record = node as Record<string, unknown>;
+  const information: string[] = [];
+  if (typeof record.gap === "number")
+    information.push(`gap ${record.gap.toString()}`);
+  if (record.padding !== undefined) {
+    const padding =
+      record.padding !== null && typeof record.padding === "object"
+        ? JSON.stringify(record.padding)
+        : typeof record.padding === "number"
+          ? record.padding.toString()
+          : "";
+    information.push(`padding ${padding}`);
+  }
+  return information;
+}
+
+function Row({ astNode, onTextChange }: RowProps) {
   const isContainer = isContainerType(astNode.node.type);
   const overId = useContext(OverIdContext);
   const activeId = useContext(ActiveIdContext);
@@ -160,54 +301,132 @@ function Row({ astNode, depth }: RowProps) {
     disabled: !isContainer || isDragging,
   });
 
-  const setBodyRef = (el: HTMLElement | null) => {
+  const setBodyRef = (el: HTMLDivElement | null) => {
     inside.setNodeRef(el);
     drag.setNodeRef(el);
   };
 
   const isInsideOver = isContainer && overId === insideId(astNode.id);
+  const presentation = isContainer
+    ? LAYOUT_PRESENTATION[astNode.node.type as keyof typeof LAYOUT_PRESENTATION]
+    : null;
 
-  return (
-    <div>
+  if (presentation) {
+    const information = secondaryInformation(astNode.node);
+    return (
       <div
         ref={setBodyRef}
-        data-drop-placement={isContainer ? "inside" : undefined}
+        data-testid={`layout-container:${astNode.id}`}
+        data-layout-type={astNode.node.type}
+        data-drop-placement="inside"
         style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "6px",
-          paddingLeft: `${depth * 16}px`,
-          paddingTop: "3px",
-          paddingBottom: "3px",
-          borderRadius: "4px",
-          userSelect: "none",
+          margin: "2px 0",
+          padding: "6px",
+          border: `1px solid ${isInsideOver ? "#2563eb" : "#cbd5e1"}`,
+          borderRadius: "7px",
           opacity: isDragging ? 0.4 : 1,
-          backgroundColor: isInsideOver ? "#dbeafe" : undefined,
-          outline: isInsideOver ? "1px solid #2563eb" : undefined,
-          transition: "background-color 50ms",
+          backgroundColor: isInsideOver ? "#dbeafe" : "#f8fafc",
+          transition: "background-color 50ms, border-color 50ms",
         }}
       >
-        <span
-          {...drag.listeners}
-          {...drag.attributes}
+        <div
           style={{
-            cursor: isDragging ? "grabbing" : "grab",
-            color: "#9ca3af",
+            display: "flex",
+            alignItems: "center",
+            flexWrap: "wrap",
+            gap: "6px",
+            minWidth: 0,
+            color: "#475569",
             fontSize: "12px",
-            lineHeight: 1,
-            flexShrink: 0,
-            touchAction: "none",
+            fontFamily: "sans-serif",
           }}
-          title="ドラッグして並び替え"
-          aria-label={`${nodeLabel(astNode.node)} をドラッグ`}
         >
-          ⠿
-        </span>
+          <DragHandle
+            drag={drag}
+            id={astNode.id}
+            label={presentation.label}
+            isDragging={isDragging}
+          />
+          <span
+            aria-label={presentation.description}
+            title={presentation.description}
+            style={{
+              display: "inline-grid",
+              placeItems: "center",
+              width: "18px",
+              height: "18px",
+              borderRadius: "4px",
+              background: "#e2e8f0",
+              color: "#334155",
+              fontWeight: 700,
+            }}
+          >
+            {presentation.icon}
+          </span>
+          <span style={{ fontWeight: 600 }}>{presentation.label}</span>
+          {information.map((item) => (
+            <span
+              key={item}
+              style={{
+                borderRadius: "999px",
+                padding: "1px 5px",
+                background: "#e2e8f0",
+                color: "#64748b",
+                fontSize: "10px",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+        <div
+          data-testid={`layout-children:${astNode.id}`}
+          style={{
+            minWidth: 0,
+            marginTop: "5px",
+            paddingLeft: "14px",
+            borderLeft: "2px solid #e2e8f0",
+          }}
+        >
+          <ChildList
+            parentId={astNode.id}
+            nodes={astNode.children ?? []}
+            onTextChange={onTextChange}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setBodyRef}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "6px",
+        minWidth: 0,
+        padding: "3px 4px",
+        borderRadius: "4px",
+        opacity: isDragging ? 0.4 : 1,
+        fontSize: "13px",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <DragHandle
+        drag={drag}
+        id={astNode.id}
+        label={nodeLabel(astNode.node)}
+        isDragging={isDragging}
+      />
+      {astNode.node.type === "text" ? (
+        <TextContent astNode={astNode} onTextChange={onTextChange} />
+      ) : (
         <span
           style={{
-            fontSize: "13px",
-            fontFamily: "monospace",
-            color: astNode.children ? "#1d4ed8" : "#374151",
+            minWidth: 0,
+            color: "#374151",
             whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -215,13 +434,6 @@ function Row({ astNode, depth }: RowProps) {
         >
           {nodeLabel(astNode.node)}
         </span>
-      </div>
-      {astNode.children && (
-        <ChildList
-          parentId={astNode.id}
-          nodes={astNode.children}
-          depth={depth + 1}
-        />
       )}
     </div>
   );
@@ -230,17 +442,17 @@ function Row({ astNode, depth }: RowProps) {
 interface ChildListProps {
   parentId: string;
   nodes: AstNode[];
-  depth: number;
+  onTextChange: (id: string, text: string) => void;
 }
 
-function ChildList({ parentId, nodes, depth }: ChildListProps) {
+function ChildList({ parentId, nodes, onTextChange }: ChildListProps) {
   return (
     <>
-      <GapStrip parentId={parentId} index={0} depth={depth} />
+      <GapStrip parentId={parentId} index={0} />
       {nodes.map((child, i) => (
         <React.Fragment key={child.id}>
-          <Row astNode={child} depth={depth} />
-          <GapStrip parentId={parentId} index={i + 1} depth={depth} />
+          <Row astNode={child} onTextChange={onTextChange} />
+          <GapStrip parentId={parentId} index={i + 1} />
         </React.Fragment>
       ))}
     </>
@@ -261,6 +473,21 @@ function findAstNode(nodes: AstNode[], id: string): AstNode | null {
     }
   }
   return null;
+}
+
+function replaceText(nodes: AstNode[], id: string, text: string): AstNode[] {
+  return nodes.map((node) => {
+    if (node.id === id) {
+      return {
+        ...node,
+        node: { ...node.node, text } as POMNode,
+      };
+    }
+    if (node.children) {
+      return { ...node, children: replaceText(node.children, id, text) };
+    }
+    return node;
+  });
 }
 
 export function AstTree({ ast, onChange }: AstTreeProps) {
@@ -307,6 +534,10 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
     setActiveId(null);
   }
 
+  function onTextChange(id: string, text: string) {
+    onChange(rebuildNodes(replaceText(ast, id, text)));
+  }
+
   return (
     <div>
       <DndContext
@@ -320,7 +551,7 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
       >
         <ActiveIdContext.Provider value={activeId}>
           <OverIdContext.Provider value={overId}>
-            <GapStrip parentId="root" index={0} depth={0} />
+            <GapStrip parentId="root" index={0} />
             {ast.map((astNode, i) => (
               <React.Fragment key={astNode.id}>
                 {i > 0 && (
@@ -344,8 +575,8 @@ export function AstTree({ ast, onChange }: AstTreeProps) {
                 >
                   Slide {i + 1}
                 </div>
-                <Row astNode={astNode} depth={0} />
-                <GapStrip parentId="root" index={i + 1} depth={0} />
+                <Row astNode={astNode} onTextChange={onTextChange} />
+                <GapStrip parentId="root" index={i + 1} />
               </React.Fragment>
             ))}
             <DragOverlay>

--- a/packages/pom-editor/src/PomAstEditor.test.tsx
+++ b/packages/pom-editor/src/PomAstEditor.test.tsx
@@ -6,6 +6,26 @@ import { PomAstEditor } from "./PomAstEditor.tsx";
 afterEach(cleanup);
 
 describe("PomAstEditor", () => {
+  it("Text の inline edit を XML に反映する", () => {
+    const onChange = vi.fn();
+    render(
+      <PomAstEditor
+        xml="<Slide><Text>Original</Text></Slide>"
+        onChange={onChange}
+        onRequestXmlMode={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Text: Original" }));
+    const input = screen.getByRole("textbox", { name: "Text を編集" });
+    fireEvent.change(input, { target: { value: "Edited" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith(
+      '<Slide>\n  <Text text="Edited" />\n</Slide>',
+    );
+  });
+
   it("parse不能時にerrorとXML modeへ戻る導線を表示する", () => {
     const onRequestXmlMode = vi.fn();
     render(

--- a/packages/pom-editor/src/PomAstEditor.test.tsx
+++ b/packages/pom-editor/src/PomAstEditor.test.tsx
@@ -26,6 +26,25 @@ describe("PomAstEditor", () => {
     );
   });
 
+  it("装飾付き Text の inline edit は本文全体を plain text に置換する", () => {
+    const onChange = vi.fn();
+    render(
+      <PomAstEditor
+        xml="<Slide><Text>Before <B>bold</B></Text></Slide>"
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Text: Before bold" }));
+    const input = screen.getByRole("textbox", { name: "Text を編集" });
+    fireEvent.change(input, { target: { value: "Edited" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith(
+      '<Slide>\n  <Text text="Edited" />\n</Slide>',
+    );
+  });
+
   it("parse不能時にerrorとXML modeへ戻る導線を表示する", () => {
     const onRequestXmlMode = vi.fn();
     render(


### PR DESCRIPTION
close #996

## 目的

AST editor を型名中心のツリーから、スライド本文とレイアウト構造を直接理解・編集できる表示へ刷新します。

## 変更内容

- Text の本文を主表示にし、クリックから inline edit を開始できるようにしました
- Enter / フォーカスアウトで確定し、Escape で編集前の値へ戻す操作を追加しました
- Text の drag 操作を専用ハンドルへ分離しました
- VStack / HStack / Layer を子要素を囲む container frame として表示し、方向・重なりのアイコンと gap / padding を表示しました
- rich text 編集時は装飾 runs を除去して本文全体を plain text に置換し、外部更新時の stale draft を破棄します
- inline edit、container 表示、既存 DnD 回帰、XML 反映をカバーするテストを追加しました
- 利用者向け changeset を追加しました

## 影響範囲

- `packages/pom-editor/src/AstTree.tsx`
- `packages/pom-editor/src/AstTree.test.tsx`
- `packages/pom-editor/src/PomAstEditor.test.tsx`
- `.changeset/fresh-apes-edit.md`

`@hirokisakabe/pom-editor` の内部 AST editor 表示・操作に限定した変更で、他 package の公開 API 変更はありません。

## ローカル検証

- `pnpm --filter @hirokisakabe/pom-editor run build`
- `pnpm --filter @hirokisakabe/pom-editor run lint`
- `pnpm --filter @hirokisakabe/pom-editor run typecheck`
- `pnpm --filter @hirokisakabe/pom-editor run test:run`（49 tests passed）
- `pnpm --filter @hirokisakabe/pom-editor run knip`
- pom-cli preview を実ブラウザで開き、container frame、Enter 確定、Escape 取消、console error なしを確認
